### PR TITLE
README PR Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/methylDragon/rosidl_typesupport_zenoh
 git clone https://github.com/methylDragon/zenoh_ros_examples
 git clone ssh://git@github.com/methylDragon/rmw_zenoh.git -b develop
 mkdir rmw_zenoh/zenoh_ament/lib
-ln -s LOCATION_OF_ZENOH_LIBRARY.so ~/zenoh_ws/src/rmw_zenoh/zenoh_ament/lib/libzenoh_ffi.so
+ln -s LOCATION_OF_ZENOH_LIBRARY.so rmw_zenoh/zenoh_ament/lib/libzenoh_ffi.so
 cd ~/zenoh_ws
 source ~/ros2_foxy/install/setup.bash
 colcon build


### PR DESCRIPTION
https://github.com/methylDragon/rmw_zenoh/pull/1 was targeting the wrong branch. This just targets the right branch.