### PR TITLE
Add copyright notices

### DIFF
--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/MessageTypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/MessageTypeSupport.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__MESSAGETYPESUPPORT_HPP_
 #define RMW_ZENOH_CPP__MESSAGETYPESUPPORT_HPP_
 

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/MessageTypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/MessageTypeSupport.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// This file is originally from:
+// https://github.com/ros2/rmw_fastrtps/blob/9c45384ebce80c51aca5ad01c6392d02bd9e27ea/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/MessageTypeSupport.hpp
 
 #ifndef RMW_ZENOH_CPP__MESSAGETYPESUPPORT_HPP_
 #define RMW_ZENOH_CPP__MESSAGETYPESUPPORT_HPP_

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/ServiceTypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/ServiceTypeSupport.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__SERVICETYPESUPPORT_HPP_
 #define RMW_ZENOH_CPP__SERVICETYPESUPPORT_HPP_
 

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/ServiceTypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/ServiceTypeSupport.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// This file is originally from:
+// https://github.com/ros2/rmw_fastrtps/blob/9c45384ebce80c51aca5ad01c6392d02bd9e27ea/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/ServiceTypeSupport.hpp
 
 #ifndef RMW_ZENOH_CPP__SERVICETYPESUPPORT_HPP_
 #define RMW_ZENOH_CPP__SERVICETYPESUPPORT_HPP_

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/TypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/TypeSupport.hpp
@@ -1,4 +1,5 @@
 // Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/TypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/TypeSupport.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__TYPESUPPORT_HPP_
 #define RMW_ZENOH_CPP__TYPESUPPORT_HPP_
 

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/TypeSupport.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/TypeSupport.hpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// This file is originally from:
+// https://github.com/ros2/rmw_fastrtps/blob/b13e134cea2852aba210299bef6f4df172d9a0e3/rmw_fastrtps_cpp/include/rmw_fastrtps_cpp/TypeSupport.hpp
 
 #ifndef RMW_ZENOH_CPP__TYPESUPPORT_HPP_
 #define RMW_ZENOH_CPP__TYPESUPPORT_HPP_

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/identifier.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/identifier.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__IDENTIFIER_HPP_
 #define RMW_ZENOH_CPP__IDENTIFIER_HPP_
 

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/rmw_context_impl.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/rmw_context_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__RMW_CONTEXT_IMPL_HPP_
 #define RMW_ZENOH_CPP__RMW_CONTEXT_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/rmw_init_options_impl.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/rmw_init_options_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__RMW_INIT_OPTIONS_IMPL_HPP_
 #define RMW_ZENOH_CPP__RMW_INIT_OPTIONS_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/rmw_node_impl.hpp
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/rmw_node_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef RMW_ZENOH_CPP__RMW_NODE_IMPL_HPP_
 #define RMW_ZENOH_CPP__RMW_NODE_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/client_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "client_impl.hpp"
 
 #include <iostream>

--- a/rmw_zenoh_cpp/src/impl/client_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__CLIENT_IMPL_HPP_
 #define IMPL__CLIENT_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/identifier.cpp
+++ b/rmw_zenoh_cpp/src/impl/identifier.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rmw_zenoh_cpp/identifier.hpp"
 
 const char * const eclipse_zenoh_identifier = "rmw_zenoh_cpp";

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "pubsub_impl.hpp"
 
 #include <iostream>

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__PUBSUB_IMPL_HPP_
 #define IMPL__PUBSUB_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "service_impl.hpp"
 
 #include <iostream>

--- a/rmw_zenoh_cpp/src/impl/service_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__SERVICE_IMPL_HPP_
 #define IMPL__SERVICE_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/type_support_common.cpp
+++ b/rmw_zenoh_cpp/src/impl/type_support_common.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Open Source Robotics Foundation, Inc.
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,6 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// This file is originally from:
+// https://github.com/ros2/rmw_fastrtps/blob/0134bcf52244cbbb6e7e8ac631de391beaa85f17/rmw_fastrtps_cpp/src/type_support_common.cpp
 
 #include <string>
 

--- a/rmw_zenoh_cpp/src/impl/type_support_common.cpp
+++ b/rmw_zenoh_cpp/src/impl/type_support_common.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <string>
 
 #include "rmw/error_handling.h"

--- a/rmw_zenoh_cpp/src/impl/type_support_common.hpp
+++ b/rmw_zenoh_cpp/src/impl/type_support_common.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__TYPE_SUPPORT_COMMON_HPP_
 #define IMPL__TYPE_SUPPORT_COMMON_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/type_support_common.hpp
+++ b/rmw_zenoh_cpp/src/impl/type_support_common.hpp
@@ -1,3 +1,4 @@
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 // Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,6 +12,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
+// This file is originally from:
+// https://github.com/ros2/rmw_fastrtps/blob/469624e3d483290d6f88fe4b89ee5feaa7694e61/rmw_fastrtps_cpp/src/type_support_common.hpp
 
 #ifndef IMPL__TYPE_SUPPORT_COMMON_HPP_
 #define IMPL__TYPE_SUPPORT_COMMON_HPP_

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "wait_impl.hpp"
 
 #include "rcutils/logging_macros.h"

--- a/rmw_zenoh_cpp/src/impl/wait_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__WAIT_IMPL_HPP_
 #define IMPL__WAIT_IMPL_HPP_
 

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <unistd.h>
 #include <string>
 

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Docs: http://docs.ros2.org/latest/api/rmw/event_8h.html
 
 #include "rcutils/logging_macros.h"

--- a/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/get_node_info_and_types.h"

--- a/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/get_service_names_and_types.h"

--- a/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/get_topic_endpoint_info.h"

--- a/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/get_topic_names_and_types.h"

--- a/rmw_zenoh_cpp/src/rmw_gids.cpp
+++ b/rmw_zenoh_cpp/src/rmw_gids.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 
 #include "rmw/topic_endpoint_info_array.h"

--- a/rmw_zenoh_cpp/src/rmw_graph_info.cpp
+++ b/rmw_zenoh_cpp/src/rmw_graph_info.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rmw_zenoh_cpp/src/rmw_guard_conditions.cpp
+++ b/rmw_zenoh_cpp/src/rmw_guard_conditions.cpp
@@ -1,3 +1,4 @@
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 // Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Edited from: https://github.com/ros2/rmw_fastrtps/blob/master/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp
-
-// Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
+// This file is significantly modified from:
+// https://github.com/ros2/rmw_fastrtps/blob/112c6e14c30dc53e5f9112e03db242c6360b14ff/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp
 
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/error_handling.h"

--- a/rmw_zenoh_cpp/src/rmw_guard_conditions.cpp
+++ b/rmw_zenoh_cpp/src/rmw_guard_conditions.cpp
@@ -1,6 +1,20 @@
-// Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Edited from: https://github.com/ros2/rmw_fastrtps/blob/master/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp
-// Under the Apache 2.0 license
+
+// Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
 
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/error_handling.h"

--- a/rmw_zenoh_cpp/src/rmw_implementation_info.cpp
+++ b/rmw_zenoh_cpp/src/rmw_implementation_info.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Doc: http://docs.ros2.org/latest/api/rmw/init_8h.html
 
 #include <cstring>

--- a/rmw_zenoh_cpp/src/rmw_init_options.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init_options.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Doc: http://docs.ros2.org/latest/api/rmw/init__options_8h.html
 
 #include "rmw/impl/cpp/macros.hpp"

--- a/rmw_zenoh_cpp/src/rmw_logging.cpp
+++ b/rmw_zenoh_cpp/src/rmw_logging.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rmw_zenoh_cpp/src/rmw_node.cpp
+++ b/rmw_zenoh_cpp/src/rmw_node.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
 
 #include "rmw/impl/cpp/macros.hpp"

--- a/rmw_zenoh_cpp/src/rmw_publish.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publish.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <fastcdr/FastBuffer.h>
 #include <fastcdr/Cdr.h>
 

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
 

--- a/rmw_zenoh_cpp/src/rmw_serialization.cpp
+++ b/rmw_zenoh_cpp/src/rmw_serialization.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <string>
 
 #include "rcutils/logging_macros.h"

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <functional>
 #include <string>
 

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -1,3 +1,4 @@
+// Copyright 2016-2018 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 // Copyright 2020 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Edited from: https://github.com/ros2/rmw_fastrtps/blob/master/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
-
-// Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
+// This file was significantly modified from:
+// https://github.com/ros2/rmw_fastrtps/blob/47a369ea9a4b042d4ffea5e614ed84e766fdb049/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
 
 #include "rcutils/logging_macros.h"
 

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -1,6 +1,20 @@
-// Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Edited from: https://github.com/ros2/rmw_fastrtps/blob/master/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp
-// Under the Apache 2.0 license
+
+// Doc: http://docs.ros2.org/latest/api/rmw/rmw_8h.html
 
 #include "rcutils/logging_macros.h"
 


### PR DESCRIPTION
Fixes the CI test for copyright information.

We need to confirm the copyright status of those files that were copied or edited from `rmw_fastrtps_cpp` files.