### PR TITLE
Implement instanced message queues with varying depth (and rework rmw_wait for subscriptions)

### DIFF
--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -46,12 +46,13 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
 
       if ((*it)->zn_message_queue_.size() >= (*it)->queue_depth_) {
         // Log warning if message is discarded due to hitting the queue depth
-        RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
-                               "Message queue depth of %ld reached, discarding oldest message "
-                               "for subscription for %s (ID: %ld)",
-                               (*it)->queue_depth_,
-                               key.c_str(),
-                               (*it)->subscription_id_);
+        RCUTILS_LOG_WARN_NAMED(
+          "rmw_zenoh_cpp",
+          "Message queue depth of %ld reached, discarding oldest message "
+          "for subscription for %s (ID: %ld)",
+          (*it)->queue_depth_,
+          key.c_str(),
+          (*it)->subscription_id_);
 
         (*it)->zn_message_queue_.pop_back();
       }

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -16,38 +16,45 @@ extern "C"
 
 std::mutex sub_callback_mutex;
 
+
+/// STATIC SUBSCRIPTION DATA MEMBERS ===========================================
 size_t rmw_subscription_data_t::sub_id_counter = 0;
 
-// Zenoh topic to subscription data
+// Map of Zenoh topic key expression to subscription data
 std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
-  rmw_subscription_data_t::zn_topic_to_sub_data_map;
+  rmw_subscription_data_t::zn_topic_to_sub_data;
 
-// Static message map
-std::unordered_map<std::string, std::vector<unsigned char> >
-  rmw_subscription_data_t::zn_messages_;
 
+/// ZENOH MESSAGE SUBSCRIPTION CALLBACK ========================================
 void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
-  // Prevent race conditions...
   std::lock_guard<std::mutex> guard(sub_callback_mutex);
 
   // NOTE(CH3): We unfortunately have to do this copy construction since we shouldn't be using
   // char * as keys to the unordered_map
   std::string key(sample->key.val, sample->key.len);
 
-  // Vector to store the byte array (so we have a copyable type instead of a pointer)
+  // Vector to store the byte array (so we have a copyable container instead of a pointer)
   std::vector<unsigned char> byte_vec(sample->value.val, sample->value.val + sample->value.len);
 
-  // Fill the static message map with the latest received message
-  //
-  // NOTE(CH3): This means that the queue size for each topic is ONE for now!!
-  // So this might break if a topic is being spammed.
-  // TODO(CH3): Implement queuing logic
-  if (rmw_subscription_data_t::zn_messages_.find(key)
-      != rmw_subscription_data_t::zn_messages_.end()) {
-    // Log warning if message is clobbered
-    RCUTILS_LOG_WARN_NAMED(
-        "rmw_zenoh_cpp", "overwriting existing untaken zenoh message: %s", key.c_str());
-  }
+  // Get shared pointer to byte array vector
+  // NOTE(CH3): We use a shared pointer to avoid copies and to leverage on the smart pointer's
+  // reference counting
+  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char> >(byte_vec);
 
-  rmw_subscription_data_t::zn_messages_[key] = std::vector<unsigned char>(byte_vec);
+  auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
+
+  if (map_iter != rmw_subscription_data_t::zn_topic_to_sub_data.end()) {
+    // Push shared pointer to message bytes to all associated subscription message queues
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      if ((*it)->zn_message_queue_.size() == (*it)->queue_depth_) {
+        // Log warning if message is discarded due to hitting the queue depth
+        RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
+                               "Message queue depth reached, discarding oldest message: %s",
+                               key.c_str());
+        (*it)->zn_message_queue_.pop_front();
+      }
+
+      (*it)->zn_message_queue_.push_back(byte_vec_ptr);
+    }
+  }
 }

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -18,7 +18,7 @@ std::mutex sub_callback_mutex;
 
 
 /// STATIC SUBSCRIPTION DATA MEMBERS ===========================================
-size_t rmw_subscription_data_t::sub_id_counter = 0;
+std::atomic<size_t> rmw_subscription_data_t::sub_id_counter(0);
 
 // Map of Zenoh topic key expression to subscription data
 std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -46,7 +46,7 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
   if (map_iter != rmw_subscription_data_t::zn_topic_to_sub_data.end()) {
     // Push shared pointer to message bytes to all associated subscription message queues
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
-      if ((*it)->zn_message_queue_.size() == (*it)->queue_depth_) {
+      if ((*it)->zn_message_queue_.size() >= (*it)->queue_depth_) {
         // Log warning if message is discarded due to hitting the queue depth
         RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
                                "Message queue depth reached, discarding oldest message: %s",

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -21,7 +21,7 @@ std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
   rmw_subscription_data_t::zn_topic_to_sub_data;
 
 
-/// ZENOH MESSAGE SUBSCRIPTION CALLBACK ========================================
+/// ZENOH MESSAGE SUBSCRIPTION CALLBACK (static method) ========================
 void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
   std::lock_guard<std::mutex> guard(sub_callback_mutex);
 

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -16,6 +16,12 @@ extern "C"
 
 std::mutex sub_callback_mutex;
 
+size_t rmw_subscription_data_t::sub_id_counter = 0;
+
+// Zenoh topic to subscription data
+std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
+  rmw_subscription_data_t::zn_topic_to_sub_data_map;
+
 // Static message map
 std::unordered_map<std::string, std::vector<unsigned char> >
   rmw_subscription_data_t::zn_messages_;

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -17,7 +17,7 @@ std::mutex sub_callback_mutex;
 std::atomic<size_t> rmw_subscription_data_t::subscription_id_counter(0);
 
 // Map of Zenoh topic key expression to subscription data
-std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
+std::unordered_map<std::string, std::vector<rmw_subscription_data_t *>>
   rmw_subscription_data_t::zn_topic_to_sub_data;
 
 
@@ -35,7 +35,7 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
   // Get shared pointer to byte array vector
   // NOTE(CH3): We use a shared pointer to avoid copies and to leverage on the smart pointer's
   // reference counting
-  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char> >(std::move(byte_vec));
+  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char>>(std::move(byte_vec));
 
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -49,7 +49,8 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
       if ((*it)->zn_message_queue_.size() >= (*it)->queue_depth_) {
         // Log warning if message is discarded due to hitting the queue depth
         RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
-                               "Message queue depth reached, discarding oldest message: %s",
+                               "Message queue depth of %ld reached, discarding oldest message: %s",
+                               (*it)->queue_depth_,
                                key.c_str());
         (*it)->zn_message_queue_.pop_front();
       }

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -14,7 +14,7 @@ std::mutex sub_callback_mutex;
 
 
 /// STATIC SUBSCRIPTION DATA MEMBERS ===========================================
-std::atomic<size_t> rmw_subscription_data_t::sub_id_counter(0);
+std::atomic<size_t> rmw_subscription_data_t::subscription_id_counter(0);
 
 // Map of Zenoh topic key expression to subscription data
 std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
@@ -47,9 +47,11 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
       if ((*it)->zn_message_queue_.size() >= (*it)->queue_depth_) {
         // Log warning if message is discarded due to hitting the queue depth
         RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
-                               "Message queue depth of %ld reached, discarding oldest message: %s",
+                               "Message queue depth of %ld reached, discarding oldest message "
+                               "for subscription for %s (ID: %ld)",
                                (*it)->queue_depth_,
-                               key.c_str());
+                               key.c_str(),
+                               (*it)->subscription_id_);
 
         (*it)->zn_message_queue_.pop_back();
       }

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -35,7 +35,7 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
   // Get shared pointer to byte array vector
   // NOTE(CH3): We use a shared pointer to avoid copies and to leverage on the smart pointer's
   // reference counting
-  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char> >(byte_vec);
+  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char> >(std::move(byte_vec));
 
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -42,7 +42,7 @@ struct rmw_subscription_data_t
   static void zn_sub_callback(const zn_sample * sample);
 
   // Counter to give subscriptions unique IDs
-  static std::atomic<size_t> sub_id_counter;
+  static std::atomic<size_t> subscription_id_counter;
 
   // Map of Zenoh topic key expression to subscription data struct instances
   static std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <memory>
 #include <deque>
+#include <atomic>
 
 #include "rmw/rmw.h"
 #include "rmw_zenoh_cpp/TypeSupport.hpp"
@@ -40,7 +41,7 @@ struct rmw_subscription_data_t
   static void zn_sub_callback(const zn_sample * sample);
 
   // Counter to give subscriptions unique IDs
-  static size_t sub_id_counter;
+  static std::atomic<size_t> sub_id_counter;
 
   // Map of Zenoh topic key expression to subscription data struct instances
   static std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <memory>
 #include <deque>
+#include <mutex>
 #include <atomic>
 
 #include "rmw/rmw.h"
@@ -59,6 +60,7 @@ struct rmw_subscription_data_t
 
   // Instanced message queue
   std::deque<std::shared_ptr<std::vector<unsigned char> > > zn_message_queue_;
+  std::mutex message_queue_mutex_;
 
   size_t subscription_id_;
   size_t queue_depth_;

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <deque>
 
 #include "rmw/rmw.h"
 #include "rmw_zenoh_cpp/TypeSupport.hpp"
@@ -34,10 +35,21 @@ struct rmw_publisher_data_t
 // Functionally a struct. But with a method for handling incoming Zenoh messages
 struct rmw_subscription_data_t
 {
+  /// STATIC MEMBERS ===============================================================================
   static void zn_sub_callback(const zn_sample * sample);
+
+  // Counter to give subscriptions unique IDs
+  static size_t sub_id_counter;
 
   // Map of Zenoh topic key expression to latest serialized ROS messages
   static std::unordered_map<std::string, std::vector<unsigned char> > zn_messages_;
+
+  // Map of Zenoh topic key expression to subscription data struct instances
+  static std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
+    zn_topic_to_sub_data_map;
+
+  /// INSTANCE MEMBERS =============================================================================
+  std::deque<std::vector<unsigned char> > zn_message_queue_;
 
   const void * type_support_impl_;
   const char * typesupport_identifier_;
@@ -47,6 +59,8 @@ struct rmw_subscription_data_t
 
   ZNSession * zn_session_;
   ZNSubscriber * zn_subscriber_;
+
+  size_t sub_id_;
 };
 
 #endif  // IMPL__PUBSUB_IMPL_HPP_

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -59,7 +59,7 @@ struct rmw_subscription_data_t
   // Instanced message queue
   std::deque<std::shared_ptr<std::vector<unsigned char> > > zn_message_queue_;
 
-  size_t sub_id_;
+  size_t subscription_id_;
   size_t queue_depth_;
 };
 

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <memory>
 #include <deque>
 
 #include "rmw/rmw.h"
@@ -41,16 +42,11 @@ struct rmw_subscription_data_t
   // Counter to give subscriptions unique IDs
   static size_t sub_id_counter;
 
-  // Map of Zenoh topic key expression to latest serialized ROS messages
-  static std::unordered_map<std::string, std::vector<unsigned char> > zn_messages_;
-
   // Map of Zenoh topic key expression to subscription data struct instances
   static std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
-    zn_topic_to_sub_data_map;
+    zn_topic_to_sub_data;
 
   /// INSTANCE MEMBERS =============================================================================
-  std::deque<std::vector<unsigned char> > zn_message_queue_;
-
   const void * type_support_impl_;
   const char * typesupport_identifier_;
 
@@ -60,7 +56,11 @@ struct rmw_subscription_data_t
   ZNSession * zn_session_;
   ZNSubscriber * zn_subscriber_;
 
+  // Instanced message queue
+  std::deque<std::shared_ptr<std::vector<unsigned char> > > zn_message_queue_;
+
   size_t sub_id_;
+  size_t queue_depth_;
 };
 
 #endif  // IMPL__PUBSUB_IMPL_HPP_

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.hpp
@@ -45,7 +45,7 @@ struct rmw_subscription_data_t
   static std::atomic<size_t> subscription_id_counter;
 
   // Map of Zenoh topic key expression to subscription data struct instances
-  static std::unordered_map<std::string, std::vector<rmw_subscription_data_t *> >
+  static std::unordered_map<std::string, std::vector<rmw_subscription_data_t *>>
     zn_topic_to_sub_data;
 
   /// INSTANCE MEMBERS =============================================================================
@@ -59,7 +59,7 @@ struct rmw_subscription_data_t
   ZNSubscriber * zn_subscriber_;
 
   // Instanced message queue
-  std::deque<std::shared_ptr<std::vector<unsigned char> > > zn_message_queue_;
+  std::deque<std::shared_ptr<std::vector<unsigned char>>> zn_message_queue_;
   std::mutex message_queue_mutex_;
 
   size_t subscription_id_;

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -28,7 +28,6 @@ bool check_wait_conditions(
             subscriptions->subscribers[i] = nullptr;
           }
         } else {
-          RCUTILS_LOG_INFO("QUEUE SIZE %ld", subscription_data->zn_message_queue_.size());
           subscriptions_ready++;
           stop_wait = true;
         }

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -14,6 +14,14 @@ bool check_wait_conditions(
   const rmw_events_t * events,
   bool finalize)
 {
+  // NOTE(CH3): On the finalize parameter
+  // This check function is used as a predicate to wait on a condition variable. But rcl expects
+  // rmw to set any passed in pointers to NULL if the condition is not ready.
+  //
+  // The finalize parameter is used to make sure that this setting to NULL only happens ONCE per
+  // rmw_wait call. Otherwise on repeat calls to check the predicate, things will break since
+  // it'll try to compare or dereference a nullptr.
+
   bool stop_wait = false;
 
   // Subscriptions

--- a/rmw_zenoh_cpp/src/impl/wait_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.hpp
@@ -21,7 +21,8 @@ bool check_wait_conditions(
   const rmw_guard_conditions_t * guard_conditions,
   const rmw_services_t * services,
   const rmw_clients_t * clients,
-  const rmw_events_t * events
+  const rmw_events_t * events,
+  bool finalize
 );
 
 #endif  // IMPL__WAIT_IMPL_HPP_

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -127,9 +127,9 @@ rmw_create_publisher(
   ZNSession * s = node->context->impl->session;
 
   // The topic ID must be unique within a single process, but separate processes can reuse IDs,
-  // even in the same Zenoh network, because the ID is never transmitted over the wire. Conversely,
-  // the ID used in two communicating processes cannot be used to determine if they are using the
-  // same topic or not.
+  // even in the same Zenoh network, because the ID is never transmitted over the wire.
+  // Conversely, the ID used in two communicating processes cannot be used to determine if they are
+  // using the same topic or not.
   publisher_data->zn_topic_id_ = zn_declare_resource(s, publisher->topic_name);
 
   // Assign publisher data members

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -250,7 +250,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   } else {
     // Delete the subscription data pointer in the Zenoh topic to subscription data map
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
-      if ((*it)->subscription_id_ == subscription_data->subscription_id_){
+      if ((*it)->subscription_id_ == subscription_data->subscription_id_) {
         map_iter->second.erase(it);
         break;
       }
@@ -320,7 +320,7 @@ rmw_take(
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription->topic_name, RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN SUBSCRIPTION MEMBERS ===============================================
-  auto subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
+  auto * subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
 
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &subscription_data->node_->context->options.allocator;
@@ -418,7 +418,7 @@ rmw_take_with_info(
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription->data, RMW_RET_ERROR);
 
   // OBTAIN SUBSCRIPTION MEMBERS ===============================================
-  auto subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
+  auto * subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
 
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &subscription_data->node_->context->options.allocator;

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -257,23 +257,26 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
     // Delete the map element if no other subscription data pointers exist
     // (That is, when no other subscriptions are listening to the Zenoh topic)
     if (map_iter->second.empty()) {
-      RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                              "[rmw_destroy_subscription] No more subscriptions listening to %s",
-                              subscription->topic_name);
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "[rmw_destroy_subscription] No more subscriptions listening to %s",
+        subscription->topic_name);
 
       // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
       zn_undeclare_subscriber(subscription_data->zn_subscriber_);
-      RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                              "[rmw_destroy_subscription] Zenoh subcriber undeclared for %s",
-                              subscription->topic_name);
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "[rmw_destroy_subscription] Zenoh subcriber undeclared for %s",
+        subscription->topic_name);
 
       rmw_subscription_data_t::zn_topic_to_sub_data.erase(map_iter);
     }
 
-    RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                            "[rmw_destroy_subscription] Subscription for %s (ID: %ld) removed from topic map",
-                            subscription->topic_name,
-                            subscription_data->subscription_id_);
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_destroy_subscription] Subscription for %s (ID: %ld) removed from topic map",
+      subscription->topic_name,
+      subscription_data->subscription_id_);
   }
 
   // CLEANUP ===================================================================
@@ -350,7 +353,7 @@ rmw_take(
   //
   // But that will mean tracking the serialisation state of the message (perhaps with a pair?)
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-      allocator->allocate(msg_bytes_ptr->size(), allocator->state));
+    allocator->allocate(msg_bytes_ptr->size(), allocator->state));
   memcpy(cdr_buffer, &msg_bytes_ptr->front(), msg_bytes_ptr->size());
 
   // Object that manages the raw buffer

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -153,7 +153,7 @@ rmw_create_subscription(
 
   // Assign and increment unique subscription ID atomically
   subscription_data->subscription_id_ =
-    rmw_subscription_data_t::sub_id_counter.fetch_add(1, std::memory_order_relaxed);
+    rmw_subscription_data_t::subscription_id_counter.fetch_add(1, std::memory_order_relaxed);
 
   // Configure message queue
   std::deque<std::shared_ptr<std::vector<unsigned char> > > empty_deque;

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -151,8 +151,9 @@ rmw_create_subscription(
   // Assign node pointer
   subscription_data->node_ = node;
 
-  // Assign unique subscription ID
-  subscription_data->subscription_id_ = ++rmw_subscription_data_t::sub_id_counter;
+  // Assign and increment unique subscription ID atomically
+  subscription_data->subscription_id_ =
+    rmw_subscription_data_t::sub_id_counter.fetch_add(1, std::memory_order_relaxed);
 
   // Configure message queue
   std::deque<std::shared_ptr<std::vector<unsigned char> > > empty_deque;

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -30,10 +30,11 @@ rmw_create_subscription(
   const rmw_qos_profile_t * qos_profile,
   const rmw_subscription_options_t * subscription_options)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_create_subscription] %s with queue of depth %ld",
-                          topic_name,
-                          qos_profile->depth);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_subscription] %s with queue of depth %ld",
+    topic_name,
+    qos_profile->depth);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
@@ -164,9 +165,10 @@ rmw_create_subscription(
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 
   if (map_iter == rmw_subscription_data_t::zn_topic_to_sub_data.end()) {
-    RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                            "[rmw_create_subscription] New topic detected: %s",
-                            topic_name);
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_subscription] New topic detected: %s",
+      topic_name);
 
     // If no elements for this Zenoh topic key expression exists, add it in
     std::vector<rmw_subscription_data_t *> sub_data_vec{subscription_data};
@@ -175,23 +177,25 @@ rmw_create_subscription(
     // We initialise subscribers ONCE (otherwise we'll get duplicate messages)
     // The topic name will be the same for any duplicate subscribers, so it is ok
     subscription_data->zn_subscriber_ = zn_declare_subscriber(
-        subscription_data->zn_session_,
-        subscription->topic_name,
-        zn_subinfo_default(),  // NOTE(CH3): Default for now
-        subscription_data->zn_sub_callback);
+      subscription_data->zn_session_,
+      subscription->topic_name,
+      zn_subinfo_default(),  // NOTE(CH3): Default for now
+      subscription_data->zn_sub_callback);
 
-    RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                            "[rmw_create_subscription] Zenoh subscription declared for %s",
-                            topic_name);
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_subscription] Zenoh subscription declared for %s",
+      topic_name);
   } else {
     // Otherwise, append to the vector
     map_iter->second.push_back(subscription_data);
   }
 
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_create_subscription] Subscription for %s (ID: %ld) added to topic map",
-                          topic_name,
-                          subscription_data->subscription_id_);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_subscription] Subscription for %s (ID: %ld) added to topic map",
+    topic_name,
+    subscription_data->subscription_id_);
 
   // TODO(CH3): Put the subscription name/pointer into its corresponding node for tracking?
 
@@ -223,10 +227,11 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   // OBTAIN SUBSCRIPTION MEMBERS ===============================================
   auto subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
 
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_destroy_subscription] %s (ID: %ld)",
-                          subscription->topic_name,
-                          subscription_data->subscription_id_);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_destroy_subscription] %s (ID: %ld)",
+    subscription->topic_name,
+    subscription_data->subscription_id_);
 
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &node->context->options.allocator;
@@ -236,9 +241,10 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 
   if (map_iter == rmw_subscription_data_t::zn_topic_to_sub_data.end()) {
-    RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
-                           "subscription not found in Zenoh topic to subscription data map! %s",
-                           subscription->topic_name);
+    RCUTILS_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp",
+      "subscription not found in Zenoh topic to subscription data map! %s",
+      subscription->topic_name);
   } else {
     // Delete the subscription data pointer in the Zenoh topic to subscription data map
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
@@ -271,8 +277,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   }
 
   // CLEANUP ===================================================================
-  allocator->deallocate(subscription_data->type_support_,
-                        allocator->state);
+  allocator->deallocate(subscription_data->type_support_, allocator->state);
   allocator->deallocate(subscription->data, allocator->state);
 
   allocator->deallocate(const_cast<char *>(subscription->topic_name), allocator->state);
@@ -331,9 +336,10 @@ rmw_take(
 
   subscription_data->message_queue_mutex_.unlock();
 
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_take] Message found: %s",
-                          subscription->topic_name);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_take] Message found: %s",
+    subscription->topic_name);
 
   // DESERIALIZE MESSAGE =======================================================
   //
@@ -426,9 +432,10 @@ rmw_take_with_info(
 
   subscription_data->message_queue_mutex_.unlock();
 
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_take] Message found: %s",
-                          subscription->topic_name);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_take] Message found: %s",
+    subscription->topic_name);
 
   // DESERIALIZE MESSAGE =======================================================
   //

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -39,10 +39,11 @@ rmw_create_subscription(
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node,
-                                   node->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return nullptr);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, nullptr);
   if (strlen(topic_name) == 0) {
@@ -80,11 +81,10 @@ rmw_create_subscription(
 
   // OBTAIN TYPESUPPORT ========================================================
   const rosidl_message_type_support_t * type_support = get_message_typesupport_handle(
-      type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
+    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
 
   if (!type_support) {
-    type_support = get_message_typesupport_handle(
-      type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);
+    type_support = get_message_typesupport_handle(type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);
     if (!type_support) {
       RCUTILS_LOG_INFO("%s", topic_name);
       RMW_SET_ERROR_MSG("type support not from this implementation");
@@ -92,9 +92,9 @@ rmw_create_subscription(
     }
   }
 
-  // CREATE SUBSCRIPTION ==========================================================
+  // CREATE SUBSCRIPTION =======================================================
   rmw_subscription_t * subscription = static_cast<rmw_subscription_t *>(
-      allocator->allocate(sizeof(rmw_subscription_t), allocator->state));
+    allocator->allocate(sizeof(rmw_subscription_t), allocator->state));
   if (!subscription) {
     RMW_SET_ERROR_MSG("failed to allocate rmw_subscription_t");
     return nullptr;
@@ -113,7 +113,7 @@ rmw_create_subscription(
   }
 
   subscription->data = static_cast<rmw_subscription_data_t *>(
-      allocator->allocate(sizeof(rmw_subscription_data_t), allocator->state));
+    allocator->allocate(sizeof(rmw_subscription_data_t), allocator->state));
   new(subscription->data) rmw_subscription_data_t();
   if (!subscription->data) {
     RMW_SET_ERROR_MSG("failed to allocate subscription data");
@@ -124,7 +124,7 @@ rmw_create_subscription(
 
   // CREATE SUBSCRIPTION MEMBERS ===============================================
   // Init type support callbacks
-  auto callbacks = static_cast<const message_type_support_callbacks_t *>(type_support->data);
+  auto * callbacks = static_cast<const message_type_support_callbacks_t *>(type_support->data);
 
   // Obtain Zenoh session
   ZNSession * s = node->context->impl->session;
@@ -138,7 +138,7 @@ rmw_create_subscription(
 
   // Allocate and in-place assign new message typesupport instance
   subscription_data->type_support_ = static_cast<rmw_zenoh_cpp::MessageTypeSupport *>(
-      allocator->allocate(sizeof(rmw_zenoh_cpp::MessageTypeSupport), allocator->state));
+    allocator->allocate(sizeof(rmw_zenoh_cpp::MessageTypeSupport), allocator->state));
   new(subscription_data->type_support_) rmw_zenoh_cpp::MessageTypeSupport(callbacks);
   if (!subscription_data->type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate MessageTypeSupport");
@@ -159,7 +159,7 @@ rmw_create_subscription(
   // Configure message queue
   subscription_data->queue_depth_ = qos_profile->depth;
 
-  // ADD SUBSCRIPTION DATA TO TOPIC MAP ============================================================
+  // ADD SUBSCRIPTION DATA TO TOPIC MAP ========================================
   // This will allow us to access the subscription data structs for this Zenoh topic key expression
   std::string key(subscription->topic_name);
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
@@ -215,14 +215,16 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node,
-                                   node->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(subscription,
-                                   subscription->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription,
+    subscription->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   // OBTAIN SUBSCRIPTION MEMBERS ===============================================
   auto subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
@@ -236,7 +238,7 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
-  // DELETE SUBSCRIPTION DATA IN TOPIC MAP =========================================================
+  // DELETE SUBSCRIPTION DATA IN TOPIC MAP =====================================
   std::string key(subscription->topic_name);
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 
@@ -308,10 +310,11 @@ rmw_take(
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_message, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(subscription,
-                                   subscription->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription,
+    subscription->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription->data, RMW_RET_ERROR);
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription->topic_name, RMW_RET_INVALID_ARGUMENT);
@@ -360,9 +363,10 @@ rmw_take(
   eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), msg_bytes_ptr->size());
 
   // Object that serializes the data
-  eprosima::fastcdr::Cdr deser(fastbuffer,
-                               eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-                               eprosima::fastcdr::Cdr::DDS_CDR);
+  eprosima::fastcdr::Cdr deser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
   if (!subscription_data->type_support_->deserializeROSmessage(
       deser, ros_message, subscription_data->type_support_impl_)) {
     RMW_SET_ERROR_MSG("could not deserialize ROS message");
@@ -404,10 +408,11 @@ rmw_take_with_info(
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(message_info, RMW_RET_INVALID_ARGUMENT);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(subscription,
-                                   subscription->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    subscription,
+    subscription->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription->topic_name, RMW_RET_ERROR);
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription->data, RMW_RET_ERROR);
@@ -456,9 +461,10 @@ rmw_take_with_info(
   eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), msg_bytes_ptr->size());
 
   // Object that serializes the data
-  eprosima::fastcdr::Cdr deser(fastbuffer,
-                               eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-                               eprosima::fastcdr::Cdr::DDS_CDR);
+  eprosima::fastcdr::Cdr deser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
   if (!subscription_data->type_support_->deserializeROSmessage(
       deser, ros_message, subscription_data->type_support_impl_)) {
     RMW_SET_ERROR_MSG("could not deserialize ROS message");

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -344,11 +344,11 @@ rmw_take(
   //
   // But that will mean tracking the serialisation state of the message (perhaps with a pair?)
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-      allocator->allocate((*msg_bytes_ptr).size(), allocator->state));
-  memcpy(cdr_buffer, &(*msg_bytes_ptr).front(), (*msg_bytes_ptr).size());
+      allocator->allocate(msg_bytes_ptr->size(), allocator->state));
+  memcpy(cdr_buffer, &msg_bytes_ptr->front(), msg_bytes_ptr->size());
 
   // Object that manages the raw buffer
-  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), (*msg_bytes_ptr).size());
+  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), msg_bytes_ptr->size());
 
   // Object that serializes the data
   eprosima::fastcdr::Cdr deser(fastbuffer,
@@ -439,11 +439,11 @@ rmw_take_with_info(
   //
   // But that will mean tracking the serialisation state of the message (perhaps with a pair?)
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-      allocator->allocate((*msg_bytes_ptr).size(), allocator->state));
-  memcpy(cdr_buffer, &(*msg_bytes_ptr).front(), (*msg_bytes_ptr).size());
+    allocator->allocate(msg_bytes_ptr->size(), allocator->state));
+  memcpy(cdr_buffer, &msg_bytes_ptr->front(), msg_bytes_ptr->size());
 
   // Object that manages the raw buffer
-  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), (*msg_bytes_ptr).size());
+  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), msg_bytes_ptr->size());
 
   // Object that serializes the data
   eprosima::fastcdr::Cdr deser(fastbuffer,

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -156,9 +156,6 @@ rmw_create_subscription(
     rmw_subscription_data_t::subscription_id_counter.fetch_add(1, std::memory_order_relaxed);
 
   // Configure message queue
-  std::deque<std::shared_ptr<std::vector<unsigned char> > > empty_deque;
-
-  subscription_data->zn_message_queue_ = empty_deque;
   subscription_data->queue_depth_ = qos_profile->depth;
 
   // ADD SUBSCRIPTION DATA TO TOPIC MAP ============================================================

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -410,6 +410,8 @@ rmw_take_with_info(
   rcutils_allocator_t * allocator = &subscription_data->node_->context->options.allocator;
 
   // RETRIEVE SERIALIZED MESSAGE ===============================================
+  std::unique_lock<std::mutex> lock(subscription_data->message_queue_mutex_);
+
   if (subscription_data->zn_message_queue_.empty()) {
     // NOTE(CH3): It is correct to be returning RMW_RET_OK. The information that the message
     // was not found is encoded in the fact that the taken-out parameter is still False.
@@ -419,8 +421,10 @@ rmw_take_with_info(
   }
 
   // NOTE(CH3): Potential place to handle "QoS" (e.g. could pop from back so it is LIFO)
-  auto msg_bytes = *subscription_data->zn_message_queue_.back();
+  auto msg_bytes_ptr = subscription_data->zn_message_queue_.back();
   subscription_data->zn_message_queue_.pop_back();
+
+  subscription_data->message_queue_mutex_.unlock();
 
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
                           "[rmw_take] Message found: %s",
@@ -435,11 +439,11 @@ rmw_take_with_info(
   //
   // But that will mean tracking the serialisation state of the message (perhaps with a pair?)
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-      allocator->allocate(msg_bytes.size(), allocator->state));
-  memcpy(cdr_buffer, &msg_bytes.front(), msg_bytes.size());
+      allocator->allocate((*msg_bytes_ptr).size(), allocator->state));
+  memcpy(cdr_buffer, &(*msg_bytes_ptr).front(), (*msg_bytes_ptr).size());
 
   // Object that manages the raw buffer
-  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), msg_bytes.size());
+  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), (*msg_bytes_ptr).size());
 
   // Object that serializes the data
   eprosima::fastcdr::Cdr deser(fastbuffer,

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -239,36 +239,36 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
     RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp",
                            "subscription not found in Zenoh topic to subscription data map! %s",
                            subscription->topic_name);
-  }
-
-  // Delete the subscription data pointer in the Zenoh topic to subscription data map
-  for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
-    if ((*it)->subscription_id_ == subscription_data->subscription_id_){
-      map_iter->second.erase(it);
-      break;
+  } else {
+    // Delete the subscription data pointer in the Zenoh topic to subscription data map
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      if ((*it)->subscription_id_ == subscription_data->subscription_id_){
+        map_iter->second.erase(it);
+        break;
+      }
     }
-  }
 
-  // Delete the map element if no other subscription data pointers exist
-  // (That is, when no other subscriptions are listening to the Zenoh topic)
-  if (map_iter->second.empty()) {
+    // Delete the map element if no other subscription data pointers exist
+    // (That is, when no other subscriptions are listening to the Zenoh topic)
+    if (map_iter->second.empty()) {
+      RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
+                              "[rmw_destroy_subscription] No more subscriptions listening to %s",
+                              subscription->topic_name);
+
+      // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
+      zn_undeclare_subscriber(subscription_data->zn_subscriber_);
+      RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
+                              "[rmw_destroy_subscription] Zenoh subcriber undeclared for %s",
+                              subscription->topic_name);
+
+      rmw_subscription_data_t::zn_topic_to_sub_data.erase(map_iter);
+    }
+
     RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                            "[rmw_destroy_subscription] No more subscriptions listening to %s",
-                            subscription->topic_name);
-
-    // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
-    zn_undeclare_subscriber(subscription_data->zn_subscriber_);
-    RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                            "[rmw_destroy_subscription] Zenoh subcriber undeclared for %s",
-                            subscription->topic_name);
-
-    rmw_subscription_data_t::zn_topic_to_sub_data.erase(map_iter);
+                            "[rmw_destroy_subscription] Subscription for %s (ID: %ld) removed from topic map",
+                            subscription->topic_name,
+                            subscription_data->subscription_id_);
   }
-
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_destroy_subscription] Subscription for %s (ID: %ld) removed from topic map",
-                          subscription->topic_name,
-                          subscription_data->subscription_id_);
 
   // CLEANUP ===================================================================
   allocator->deallocate(subscription_data->type_support_,

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -117,13 +117,13 @@ rmw_wait(  // All parameters are in parameters
   RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_INVALID_ARGUMENT);
 
   RCUTILS_LOG_DEBUG_NAMED(
-      "rmw_zenoh_cpp",
-      "[rmw_wait] %ld subscriptions, %ld srv_servers, %ld srv_clients, %ld events, %ld guard conditions",
-      subscriptions->subscriber_count,
-      services->service_count,
-      clients->client_count,
-      events->event_count,
-      guard_conditions->guard_condition_count);
+    "rmw_zenoh_cpp",
+    "[rmw_wait] %ld subscriptions, %ld srv_servers, %ld srv_clients, %ld events, %ld guard conditions",
+    subscriptions->subscriber_count,
+    services->service_count,
+    clients->client_count,
+    events->event_count,
+    guard_conditions->guard_condition_count);
 
   if (wait_timeout) {
     RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_wait] TIMEOUT: %ld s %ld ns",

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -159,9 +159,9 @@ rmw_wait(  // All parameters are in parameters
   // CHECK WAIT CONDITIONS =====================================================
   std::unique_lock<std::mutex> lock(*condition_mutex);
 
-  bool ready = check_wait_conditions(subscriptions, guard_conditions, services, clients, events);
+  bool ready = check_wait_conditions(subscriptions, guard_conditions, services, clients, events, false);
   auto predicate = [subscriptions, guard_conditions, services, clients, events]() {
-    return check_wait_conditions(subscriptions, guard_conditions, services, clients, events);
+    return check_wait_conditions(subscriptions, guard_conditions, services, clients, events, false);
   };
 
   bool timed_out = false;
@@ -182,6 +182,7 @@ rmw_wait(  // All parameters are in parameters
     }
   }
 
+  check_wait_conditions(subscriptions, guard_conditions, services, clients, events, true);
   lock.unlock();
 
   if (timed_out) {

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -182,6 +182,12 @@ rmw_wait(  // All parameters are in parameters
     }
   }
 
+  // The finalize parameter passed in here enables debug and setting of non-ready conditions
+  // to NULL (as expected by rcl)
+  //
+  // (In other words, it ensures that this happens once per rmw_wait call)
+  //
+  // Debug logs and NULL assignments do not happen in the predicate above, and only on this call
   check_wait_conditions(subscriptions, guard_conditions, services, clients, events, true);
   lock.unlock();
 

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -117,12 +117,13 @@ rmw_wait(  // All parameters are in parameters
   RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_INVALID_ARGUMENT);
 
   RCUTILS_LOG_DEBUG_NAMED(
-    "rmw_zenoh_cpp",
-    "[rmw_wait] %ld subscriptions, %ld srv_servers, %ld srv_clients, %ld events",
-    subscriptions->subscriber_count,
-    services->service_count,
-    clients->client_count,
-    events->event_count);
+      "rmw_zenoh_cpp",
+      "[rmw_wait] %ld subscriptions, %ld srv_servers, %ld srv_clients, %ld events, %ld guard conditions",
+      subscriptions->subscriber_count,
+      services->service_count,
+      clients->client_count,
+      events->event_count,
+      guard_conditions->guard_condition_count);
 
   if (wait_timeout) {
     RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_wait] TIMEOUT: %ld s %ld ns",


### PR DESCRIPTION
This PR implements instanced message queues for subscriptions (so we no longer need to rely on a static message map.)

This also means that we can now maintain message queues of varying depth!

Additionally, the issue of subscriptions fighting over messages is now resolved, since each subscription controls their own message queue.

Also, all messages are passed around the queues as shared_ptrs, which means deallocation is resolved neatly via the reference counting mechanism, and we reduce instances of data copying when duplicate subscriptions are attached to a topic.

And finally, this means that we can track which specific subscriptions are ready in rmw_wait, which saves extra cycles because subscriptions that are not ready will not run their `rmw_take_message_with_info`!

## To test
Use https://github.com/methylDragon/zenoh_ros_examples/ and try:

Terminal 1: (Runs two subscriptions attached to /topic)
```
RMW_IMPLEMENTATION=rmw_zenoh_cpp ros2 run zenoh_ros_sub double_sub
```

Terminal 2 (or more): (Run a publisher to /topic)
```
RMW_IMPLEMENTATION=rmw_zenoh_cpp ros2 run zenoh_ros_pub publisher_member_function
```

You may run more than one publisher to overload the message queue (the subscriptions are set to max queue depth 10.) You should see a warning get printed out if messages are discarded due to the queue reaching max size.

Remember that you may use `--ros-args --log-level debug` to see the debug logs.