### PR TITLE
Implement instanced message queues with varying depth (and rework rmw_wait) for SERVICES!

### DIFF
--- a/rmw_zenoh_cpp/src/impl/client_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.cpp
@@ -38,6 +38,8 @@ void rmw_client_data_t::zn_response_sub_callback(const zn_sample * sample) {
 
   auto map_iter = rmw_client_data_t::zn_topic_to_client_data.find(key);
 
+  // If the key was not found in the map, it means that there are no RMW clients listening on this
+  // topic, so this message can be dropped without issue
   if (map_iter != rmw_client_data_t::zn_topic_to_client_data.end()) {
     // Push shared pointer to message bytes to all associated client response message queues
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {

--- a/rmw_zenoh_cpp/src/impl/client_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.cpp
@@ -1,69 +1,85 @@
 #include "client_impl.hpp"
 
 #include <iostream>
-#include <mutex>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
 
 #include "rcutils/logging_macros.h"
 
 std::mutex response_callback_mutex;
 std::mutex query_callback_mutex;
 
-// Static sequence ID
+/// STATIC CLIENT DATA MEMBERS ================================================
 std::atomic<std::int64_t> rmw_client_data_t::sequence_id_counter(0);
+std::atomic<size_t> rmw_client_data_t::client_id_counter(0);
 
-// Static response ROS message map
-std::unordered_map<std::string, std::vector<unsigned char>>
-  rmw_client_data_t::zn_response_messages_;
+// Map of Zenoh topic key expression to client data
+std::unordered_map<std::string, std::vector<rmw_client_data_t *>>
+  rmw_client_data_t::zn_topic_to_client_data;
 
-// Static availability query Zenoh response set
-std::unordered_set<std::string> rmw_client_data_t::zn_availability_query_responses_;
+// Map of Zenoh queryable key expression to client data
+std::unordered_map<std::string, std::vector<rmw_client_data_t *>>
+  rmw_client_data_t::zn_queryable_to_client_data;
 
-/// ZENOH RESPONSE SUBSCRIPTION CALLBACK =======================================
+
+/// ZENOH RESPONSE SUBSCRIPTION CALLBACK (static method) =======================
 void rmw_client_data_t::zn_response_sub_callback(const zn_sample * sample) {
-  // Prevent race conditions...
   std::lock_guard<std::mutex> guard(response_callback_mutex);
 
   // NOTE(CH3): We unfortunately have to do this copy construction since we shouldn't be using
   // char * as keys to the unordered_map
   std::string key(sample->key.val, sample->key.len);
 
-  // Vector to store the byte array (so we have a copyable type instead of a pointer)
+  // Vector to store the byte array (so we have a copyable container instead of a pointer)
   std::vector<unsigned char> byte_vec(sample->value.val, sample->value.val + sample->value.len);
 
-  // Fill the static response message map with the latest received message
-  //
-  // NOTE(CH3): This means that the queue size for each topic is ONE for now!!
-  // So this might break if a service is being spammed.
-  // TODO(CH3): Implement queuing logic
-  if (rmw_client_data_t::zn_response_messages_.find(key)
-      != rmw_client_data_t::zn_response_messages_.end()) {
-    // Log warning if message is clobbered
-    RCUTILS_LOG_WARN_NAMED(
-        "rmw_zenoh_cpp", "overwriting existing untaken zenoh response message: %s", key.c_str());
+  // Get shared pointer to byte array vector
+  // NOTE(CH3): We use a shared pointer to avoid copies and to leverage on the smart pointer's
+  // reference counting
+  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char>>(std::move(byte_vec));
+
+  auto map_iter = rmw_client_data_t::zn_topic_to_client_data.find(key);
+
+  if (map_iter != rmw_client_data_t::zn_topic_to_client_data.end()) {
+    // Push shared pointer to message bytes to all associated client response message queues
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      std::unique_lock<std::mutex> lock((*it)->response_queue_mutex_);
+
+      if ((*it)->zn_response_message_queue_.size() >= (*it)->queue_depth_) {
+        // Log warning if message is discarded due to hitting the queue depth
+        RCUTILS_LOG_WARN_NAMED(
+          "rmw_zenoh_cpp",
+          "Request queue depth of %ld reached, discarding oldest response message "
+          "for client for %s (ID: %ld)",
+          (*it)->queue_depth_,
+          key.c_str(),
+          (*it)->client_id_);
+
+        (*it)->zn_response_message_queue_.pop_back();
+      }
+      (*it)->zn_response_message_queue_.push_front(byte_vec_ptr);
+
+      (*it)->response_queue_mutex_.unlock();
+    }
   }
-
-  rmw_client_data_t::zn_response_messages_[key] = std::vector<unsigned char>(byte_vec);
 }
-
 /// ZENOH SERVICE AVAILABILITY QUERY CALLBACK ==================================
 void rmw_client_data_t::zn_service_availability_query_callback(const zn_source_info * info,
                                                                const zn_sample * sample) {
-  // Prevent race conditions...
   std::lock_guard<std::mutex> guard(query_callback_mutex);
 
   // NOTE(CH3): We unfortunately have to do this copy construction since we shouldn't be using
   // char * as keys to the unordered_map
   std::string key(sample->key.val, sample->key.len);
 
-  // Insert if key not found in query response set
-  if (rmw_client_data_t::zn_availability_query_responses_.find(key)
-      == rmw_client_data_t::zn_availability_query_responses_.end()) {
-    rmw_client_data_t::zn_availability_query_responses_.insert(key);
-  } else {
-    RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp", "zenoh availability for %s already set", key.c_str());
+  auto map_iter = rmw_client_data_t::zn_queryable_to_client_data.find(key);
+
+  if (map_iter != rmw_client_data_t::zn_queryable_to_client_data.end()) {
+    // Update all associated client availability query response sets
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      std::unique_lock<std::mutex> lock((*it)->availability_set_mutex_);
+
+      (*it)->zn_availability_query_responses_.insert(key);
+
+      (*it)->availability_set_mutex_.unlock();
+    }
   }
 }

--- a/rmw_zenoh_cpp/src/impl/client_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.cpp
@@ -13,7 +13,7 @@ std::mutex response_callback_mutex;
 std::mutex query_callback_mutex;
 
 // Static sequence ID
-int64_t rmw_client_data_t::sequence_id = -1;
+std::atomic<std::int64_t> rmw_client_data_t::sequence_id_counter(0);
 
 // Static response ROS message map
 std::unordered_map<std::string, std::vector<unsigned char>>

--- a/rmw_zenoh_cpp/src/impl/client_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.cpp
@@ -16,7 +16,7 @@ std::mutex query_callback_mutex;
 int64_t rmw_client_data_t::sequence_id = -1;
 
 // Static response ROS message map
-std::unordered_map<std::string, std::vector<unsigned char> >
+std::unordered_map<std::string, std::vector<unsigned char>>
   rmw_client_data_t::zn_response_messages_;
 
 // Static availability query Zenoh response set

--- a/rmw_zenoh_cpp/src/impl/client_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.hpp
@@ -27,7 +27,7 @@ struct rmw_client_data_t
   static int64_t sequence_id;
 
   // Serialized ROS response messages
-  static std::unordered_map<std::string, std::vector<unsigned char> > zn_response_messages_;
+  static std::unordered_map<std::string, std::vector<unsigned char>> zn_response_messages_;
 
   // Availability query Zenoh responses
   static std::unordered_set<std::string> zn_availability_query_responses_;

--- a/rmw_zenoh_cpp/src/impl/client_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.hpp
@@ -6,6 +6,10 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <memory>
+#include <deque>
+#include <mutex>
+#include <atomic>
 
 #include "rmw/rmw.h"
 #include "rmw_zenoh_cpp/TypeSupport.hpp"
@@ -24,7 +28,7 @@ struct rmw_client_data_t
   );
 
   // Sequence id
-  static int64_t sequence_id;
+  static std::atomic<std::int64_t> sequence_id_counter;
 
   // Serialized ROS response messages
   static std::unordered_map<std::string, std::vector<unsigned char>> zn_response_messages_;

--- a/rmw_zenoh_cpp/src/impl/client_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/client_impl.hpp
@@ -27,14 +27,19 @@ struct rmw_client_data_t
     const zn_source_info * info, const zn_sample * sample
   );
 
-  // Sequence id
+  // Counter to give client servers unique IDs
+  static std::atomic<size_t> client_id_counter;
+
+  // Request-response sequence id (To identify and match individual requests)
   static std::atomic<std::int64_t> sequence_id_counter;
 
-  // Serialized ROS response messages
-  static std::unordered_map<std::string, std::vector<unsigned char>> zn_response_messages_;
+  // Map of Zenoh topic key expression to client data struct instances
+  static std::unordered_map<std::string, std::vector<rmw_client_data_t *>>
+    zn_topic_to_client_data;
 
-  // Availability query Zenoh responses
-  static std::unordered_set<std::string> zn_availability_query_responses_;
+  // Map of Zenoh queryable key expression to client data struct instances
+  static std::unordered_map<std::string, std::vector<rmw_client_data_t *>>
+    zn_queryable_to_client_data;
 
   /// TYPE SUPPORT =============================================================
   const void * request_type_support_impl_;
@@ -57,6 +62,17 @@ struct rmw_client_data_t
 
   /// ROS ======================================================================
   const rmw_node_t * node_;
+
+  // Instanced response message queue
+  std::deque<std::shared_ptr<std::vector<unsigned char>>> zn_response_message_queue_;
+  std::mutex response_queue_mutex_;
+
+  // Instanced availability query Zenoh responses
+  std::unordered_set<std::string> zn_availability_query_responses_;
+  std::mutex availability_set_mutex_;
+
+  size_t client_id_;
+  size_t queue_depth_;
 };
 
 #endif  // IMPL__CLIENT_IMPL_HPP_

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -39,7 +39,8 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
 
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 
-  // If the key was not found in the map, the map_iter will return a pointer to the map's end
+  // If the key was not found in the map, it means that there are no RMW subscriptions listening
+  // on this topic, so this message can be dropped without issue
   if (map_iter != rmw_subscription_data_t::zn_topic_to_sub_data.end()) {
     // Push shared pointer to message bytes to all associated subscription message queues
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {

--- a/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/pubsub_impl.cpp
@@ -39,6 +39,7 @@ void rmw_subscription_data_t::zn_sub_callback(const zn_sample * sample) {
 
   auto map_iter = rmw_subscription_data_t::zn_topic_to_sub_data.find(key);
 
+  // If the key was not found in the map, the map_iter will return a pointer to the map's end
   if (map_iter != rmw_subscription_data_t::zn_topic_to_sub_data.end()) {
     // Push shared pointer to message bytes to all associated subscription message queues
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -61,3 +61,14 @@ void rmw_service_data_t::zn_request_sub_callback(const zn_sample * sample) {
     }
   }
 }
+
+/// ZENOH SERVICE AVAILABILITY QUERYABLE CALLBACK ==============================
+void rmw_service_data_t::zn_service_availability_queryable_callback(ZNQuery * query) {
+  const zn_string * resource = zn_query_res_name(query);
+  const zn_string * predicate = zn_query_predicate(query);
+
+  std::string res(resource->val, resource->len);
+  std::string response("available");  // NOTE(CH3): The contents actually don't matter...
+
+  zn_send_reply(query, res.c_str(), (const unsigned char *)response.c_str(), response.length());
+}

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -1,10 +1,6 @@
 #include "service_impl.hpp"
 
 #include <iostream>
-#include <mutex>
-#include <string>
-#include <unordered_map>
-#include <vector>
 
 #include "rcutils/logging_macros.h"
 #include "rmw_zenoh_cpp/TypeSupport.hpp"

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -38,7 +38,8 @@ void rmw_service_data_t::zn_request_sub_callback(const zn_sample * sample) {
 
   auto map_iter = rmw_service_data_t::zn_topic_to_service_data.find(key);
 
-  // If the key was not found in the map, the map_iter will return a pointer to the map's end
+  // If the key was not found in the map, it means that there are no RMW services listening on this
+  // topic, so this message can be dropped without issue
   if (map_iter != rmw_service_data_t::zn_topic_to_service_data.end()) {
     // Push shared pointer to message bytes to all associated service request message queues
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -16,32 +16,52 @@ extern "C"
 
 std::mutex request_callback_mutex;
 
-// Static request message map
-std::unordered_map<std::string, std::vector<unsigned char> >
-  rmw_service_data_t::zn_request_messages_;
+/// STATIC SERVICE DATA MEMBERS ================================================
+std::atomic<size_t> rmw_service_data_t::service_id_counter(0);
 
+// Map of Zenoh topic key expression to service data
+std::unordered_map<std::string, std::vector<rmw_service_data_t *> >
+  rmw_service_data_t::zn_topic_to_service_data;
+
+
+/// ZENOH REQUEST MESSAGE SUBSCRIPTION CALLBACK (static method) ================
 void rmw_service_data_t::zn_request_sub_callback(const zn_sample * sample) {
-  // Prevent race conditions...
   std::lock_guard<std::mutex> guard(request_callback_mutex);
 
   // NOTE(CH3): We unfortunately have to do this copy construction since we shouldn't be using
   // char * as keys to the unordered_map
   std::string key(sample->key.val, sample->key.len);
 
-  // Vector to store the byte array (so we have a copyable type instead of a pointer)
+  // Vector to store the byte array (so we have a copyable container instead of a pointer)
   std::vector<unsigned char> byte_vec(sample->value.val, sample->value.val + sample->value.len);
 
-  // Fill the static request message map with the latest received message
-  //
-  // NOTE(CH3): This means that the queue size for each topic is ONE for now!!
-  // So this might break if a service is being spammed.
-  // TODO(CH3): Implement queuing logic
-  if (rmw_service_data_t::zn_request_messages_.find(key)
-      != rmw_service_data_t::zn_request_messages_.end()) {
-    // Log warning if message is clobbered
-    RCUTILS_LOG_WARN_NAMED(
-        "rmw_zenoh_cpp", "overwriting existing untaken zenoh request message: %s", key.c_str());
-  }
+  // Get shared pointer to byte array vector
+  // NOTE(CH3): We use a shared pointer to avoid copies and to leverage on the smart pointer's
+  // reference counting
+  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char> >(std::move(byte_vec));
 
-  rmw_service_data_t::zn_request_messages_[key] = std::vector<unsigned char>(byte_vec);
+  auto map_iter = rmw_service_data_t::zn_topic_to_service_data.find(key);
+
+  if (map_iter != rmw_service_data_t::zn_topic_to_service_data.end()) {
+    // Push shared pointer to message bytes to all associated service request message queues
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      std::unique_lock<std::mutex> lock((*it)->request_queue_mutex_);
+
+      if ((*it)->zn_request_message_queue_.size() >= (*it)->queue_depth_) {
+        // Log warning if message is discarded due to hitting the queue depth
+        RCUTILS_LOG_WARN_NAMED(
+          "rmw_zenoh_cpp",
+          "Request queue depth of %ld reached, discarding oldest request message "
+          "for service for %s (ID: %ld)",
+          (*it)->queue_depth_,
+          key.c_str(),
+          (*it)->service_id_);
+
+        (*it)->zn_request_message_queue_.pop_back();
+      }
+      (*it)->zn_request_message_queue_.push_front(byte_vec_ptr);
+
+      (*it)->request_queue_mutex_.unlock();
+    }
+  }
 }

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -38,6 +38,7 @@ void rmw_service_data_t::zn_request_sub_callback(const zn_sample * sample) {
 
   auto map_iter = rmw_service_data_t::zn_topic_to_service_data.find(key);
 
+  // If the key was not found in the map, the map_iter will return a pointer to the map's end
   if (map_iter != rmw_service_data_t::zn_topic_to_service_data.end()) {
     // Push shared pointer to message bytes to all associated service request message queues
     for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {

--- a/rmw_zenoh_cpp/src/impl/service_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.cpp
@@ -20,7 +20,7 @@ std::mutex request_callback_mutex;
 std::atomic<size_t> rmw_service_data_t::service_id_counter(0);
 
 // Map of Zenoh topic key expression to service data
-std::unordered_map<std::string, std::vector<rmw_service_data_t *> >
+std::unordered_map<std::string, std::vector<rmw_service_data_t *>>
   rmw_service_data_t::zn_topic_to_service_data;
 
 
@@ -38,7 +38,7 @@ void rmw_service_data_t::zn_request_sub_callback(const zn_sample * sample) {
   // Get shared pointer to byte array vector
   // NOTE(CH3): We use a shared pointer to avoid copies and to leverage on the smart pointer's
   // reference counting
-  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char> >(std::move(byte_vec));
+  auto byte_vec_ptr = std::make_shared<std::vector<unsigned char>>(std::move(byte_vec));
 
   auto map_iter = rmw_service_data_t::zn_topic_to_service_data.find(key);
 

--- a/rmw_zenoh_cpp/src/impl/service_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.hpp
@@ -23,6 +23,8 @@ struct rmw_service_data_t
   /// STATIC MEMBERS ===========================================================
   static void zn_request_sub_callback(const zn_sample * sample);
 
+  static void zn_service_availability_queryable_callback(ZNQuery * query);
+
   // Counter to give service servers unique IDs
   static std::atomic<size_t> service_id_counter;
 

--- a/rmw_zenoh_cpp/src/impl/service_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.hpp
@@ -27,7 +27,7 @@ struct rmw_service_data_t
   static std::atomic<size_t> service_id_counter;
 
   // Map of Zenoh topic key expression to service data struct instances
-  static std::unordered_map<std::string, std::vector<rmw_service_data_t *> >
+  static std::unordered_map<std::string, std::vector<rmw_service_data_t *>>
     zn_topic_to_service_data;
 
   /// INSTANCE MEMBERS =========================================================
@@ -55,7 +55,7 @@ struct rmw_service_data_t
   const rmw_node_t * node_;
 
   // Instanced request message queue
-  std::deque<std::shared_ptr<std::vector<unsigned char> > > zn_request_message_queue_;
+  std::deque<std::shared_ptr<std::vector<unsigned char>>> zn_request_message_queue_;
   std::mutex request_queue_mutex_;
 
   size_t service_id_;

--- a/rmw_zenoh_cpp/src/impl/service_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.hpp
@@ -5,6 +5,10 @@
 #include <utility>
 #include <string>
 #include <vector>
+#include <memory>
+#include <deque>
+#include <mutex>
+#include <atomic>
 
 #include "rmw/rmw.h"
 #include "rmw_zenoh_cpp/TypeSupport.hpp"
@@ -19,10 +23,15 @@ struct rmw_service_data_t
   /// STATIC MEMBERS ===========================================================
   static void zn_request_sub_callback(const zn_sample * sample);
 
-  // Serialized ROS request messages
-  static std::unordered_map<std::string, std::vector<unsigned char> > zn_request_messages_;
+  // Counter to give service servers unique IDs
+  static std::atomic<size_t> service_id_counter;
 
-  /// TYPE SUPPORT =============================================================
+  // Map of Zenoh topic key expression to service data struct instances
+  static std::unordered_map<std::string, std::vector<rmw_service_data_t *> >
+    zn_topic_to_service_data;
+
+  /// INSTANCE MEMBERS =========================================================
+  // Type support
   const void * request_type_support_impl_;
   const void * response_type_support_impl_;
   const char * typesupport_identifier_;
@@ -30,7 +39,7 @@ struct rmw_service_data_t
   rmw_zenoh_cpp::TypeSupport * request_type_support_;
   rmw_zenoh_cpp::TypeSupport * response_type_support_;
 
-  /// ZENOH ====================================================================
+  /// Zenoh
   ZNSession * zn_session_;
   ZNQueryable * zn_queryable_;
 
@@ -44,6 +53,13 @@ struct rmw_service_data_t
 
   /// ROS ======================================================================
   const rmw_node_t * node_;
+
+  // Instanced request message queue
+  std::deque<std::shared_ptr<std::vector<unsigned char> > > zn_request_message_queue_;
+  std::mutex request_queue_mutex_;
+
+  size_t service_id_;
+  size_t queue_depth_;
 };
 
 #endif  // IMPL__SERVICE_IMPL_HPP_

--- a/rmw_zenoh_cpp/src/impl/service_impl.hpp
+++ b/rmw_zenoh_cpp/src/impl/service_impl.hpp
@@ -39,7 +39,7 @@ struct rmw_service_data_t
   rmw_zenoh_cpp::TypeSupport * request_type_support_;
   rmw_zenoh_cpp::TypeSupport * response_type_support_;
 
-  /// Zenoh
+  /// ZENOH ====================================================================
   ZNSession * zn_session_;
   ZNQueryable * zn_queryable_;
 

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -66,7 +66,7 @@ bool check_wait_conditions(
         }
     }
 
-    if (finalize && services_ready != 0) {
+    if (finalize && services_ready > 0) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp", "[rmw_wait] SERVICES READY: %ld",
         services_ready);
@@ -92,7 +92,7 @@ bool check_wait_conditions(
         }
     }
 
-    if (finalize && clients_ready != 0) {
+    if (finalize && clients_ready > 0) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp", "[rmw_wait] CLIENTS READY: %ld",
         clients_ready);

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -42,7 +42,7 @@ bool check_wait_conditions(
         }
     }
 
-    if (finalize) {
+    if (finalize && subscriptions_ready != 0) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp", "[rmw_wait] SUBSCRIPTIONS READY: %ld",
         subscriptions_ready);
@@ -66,7 +66,7 @@ bool check_wait_conditions(
         }
     }
 
-    if (finalize) {
+    if (finalize && services_ready != 0) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp", "[rmw_wait] SERVICES READY: %ld",
         services_ready);
@@ -81,7 +81,7 @@ bool check_wait_conditions(
     for (size_t i = 0; i < clients->client_count; ++i) {
         auto client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
         if (client_data->zn_response_message_queue_.empty()
-            || client_data->zn_availability_query_responses_.empty()) {
+            && client_data->zn_availability_query_responses_.empty()) {
           if (finalize) {
             // Setting to nullptr lets rcl know that this client is not ready
             clients->clients[i] = nullptr;
@@ -92,7 +92,7 @@ bool check_wait_conditions(
         }
     }
 
-    if (finalize) {
+    if (finalize && clients_ready != 0) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp", "[rmw_wait] CLIENTS READY: %ld",
         clients_ready);

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -123,5 +123,16 @@ bool check_wait_conditions(
   //   }
   // }
 
+  // STUB: NULLIFY/IGNORE ALL GUARD CONDITIONS AND EVENTS FOR NOW
+  // Notably, this causes the QoS warning to be suppressed..
+  // Since that arises from the taking of QoS events, which aren't supported by Zenoh at the moment
+  for (size_t i = 0; i < events->event_count; ++i) {
+    events->events[i] = nullptr;
+  }
+
+  for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
+    guard_conditions->guard_conditions[i] = nullptr;
+  }
+
   return stop_wait;
 }

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -99,6 +99,47 @@ bool check_wait_conditions(
     }
   }
 
+  // GUARD CONDITIONS ==========================================================
+  // STUB: NULLIFY/IGNORE ALL GUARD CONDITIONS FOR NOW
+  for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
+    guard_conditions->guard_conditions[i] = nullptr;
+  }
+
+  // NOTE(CH3): TODO(CH3): Uncomment this block when finalizing the RMW implementation
+  // IGNORE GUARD CONDITIONS FOR NOW (They'll keep getting triggered super often, which is good for
+  // responsiveness but not so much for debugging)
+
+  // if (guard_conditions) {
+  //   size_t guard_conditions_ready = 0;
+  //
+  //   for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
+  //       auto guard_condition = static_cast<GuardCondition *>(guard_conditions->guard_conditions[i]);
+  //       if (guard_condition && guard_condition->hasTriggered()) {
+  //         if (finalize) {
+  //           // Setting to nullptr lets rcl know that this guard_condition is not ready
+  //           guard_conditions->guard_conditions[i] = nullptr;
+  //         }
+  //       } else {
+  //         guard_conditions_ready++;
+  //         stop_wait = true;
+  //       }
+  //   }
+  //
+  //   if (finalize && guard_conditions_ready > 0) {
+  //     RCUTILS_LOG_DEBUG_NAMED(
+  //       "rmw_zenoh_cpp", "[rmw_wait] GUARD CONDITIONS READY: %ld",
+  //       guard_conditions_ready);
+  //   }
+  // }
+
+  // EVENTS ====================================================================
+  // STUB: NULLIFY/IGNORE ALL EVENTS FOR NOW
+  // Notably, this causes the QoS warning to be suppressed..
+  // Since that arises from the taking of QoS events, which aren't supported by Zenoh at the moment
+  for (size_t i = 0; i < events->event_count; ++i) {
+    events->events[i] = nullptr;
+  }
+
   // TODO(CH3): Handle events
   // if (events) {
   //   for (size_t i = 0; i < events->event_count; ++i) {
@@ -109,30 +150,6 @@ bool check_wait_conditions(
   //     }
   //   }
   // }
-
-  // TODO(CH3): Handle guard conditions
-  // For now we'll wait because they keep getting triggered by the client libraries.
-  // if (guard_conditions) {
-  //   for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
-  //     void * data = guard_conditions->guard_conditions[i];
-  //     auto guard_condition = static_cast<GuardCondition *>(data);
-  //     if (guard_condition && guard_condition->hasTriggered()) {
-  //       RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_wait] GUARD CONDITION TRIGGERED");
-  //       return true;
-  //     }
-  //   }
-  // }
-
-  // STUB: NULLIFY/IGNORE ALL GUARD CONDITIONS AND EVENTS FOR NOW
-  // Notably, this causes the QoS warning to be suppressed..
-  // Since that arises from the taking of QoS events, which aren't supported by Zenoh at the moment
-  for (size_t i = 0; i < events->event_count; ++i) {
-    events->events[i] = nullptr;
-  }
-
-  for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
-    guard_conditions->guard_conditions[i] = nullptr;
-  }
 
   return stop_wait;
 }

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -42,7 +42,7 @@ bool check_wait_conditions(
         }
     }
 
-    if (finalize && subscriptions_ready != 0) {
+    if (finalize && subscriptions_ready > 0) {
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp", "[rmw_wait] SUBSCRIPTIONS READY: %ld",
         subscriptions_ready);

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -628,6 +628,8 @@ rmw_take_response(
   }
 
   *taken = true;
+  allocator->deallocate(cdr_buffer, allocator->state);
+
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -65,7 +65,7 @@ rmw_service_server_is_available(
 
   std::string key(client->service_name);
 
-  if (client_data->zn_availability_query_responses_.find(key) != 
+  if (client_data->zn_availability_query_responses_.find(key) !=
     client_data->zn_availability_query_responses_.end())
   {
     client_data->zn_availability_query_responses_.erase(key);
@@ -184,8 +184,8 @@ rmw_create_client(
   auto client_data = static_cast<rmw_client_data_t *>(client->data);
 
   // Obtain Zenoh session and create Zenoh resource for request messages
-  ZNSession * s = node->context->impl->session;
-  client_data->zn_session_ = s;
+  ZNSession * session = node->context->impl->session;
+  client_data->zn_session_ = session;
 
   // Obtain qualified request-response topics
   std::string zn_topic_key(client->service_name);
@@ -216,7 +216,7 @@ rmw_create_client(
   //
   // Another topic on another process might clash with the ID on this process, even within the
   // same Zenoh network! It is not a UUID!!
-  client_data->zn_request_topic_id_ = zn_declare_resource(s, client_data->zn_request_topic_key_);
+  client_data->zn_request_topic_id_ = zn_declare_resource(session, client_data->zn_request_topic_key_);
 
   // INSERT TYPE SUPPORT =======================================================
   // Init type support callbacks
@@ -351,7 +351,7 @@ rmw_create_client(
   // (Having a listener for queries on a separate process from the service seems to be all that is
   // necessary.
   //
-  // Also, the issue is most likely happening on the SERVICE SERVER'S SIDE! But somehow adding this
+  // Also, the issue is most likely happening on the SERVICE SERVER'session SIDE! But somehow adding this
   // queryable listener on the SERVICE CLIENT side fixes that issue.
   //
   // Additional note: Note that this means that for most use-cases (but not all), we should be fine.
@@ -359,7 +359,7 @@ rmw_create_client(
   // a delay between when the client and service starts (and the client is started first, and there
   // are no other processes anywhere on the network where the Zenoh queryable is being listened to.)
   zn_declare_queryable(
-    s,
+    session,
     client->service_name,
     STORAGE,
     [](ZNQuery * query){});

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -68,7 +68,7 @@ rmw_service_server_is_available(
     client_data->zn_availability_query_responses_.erase(key);
     *result = true;
   } else {
-    sleep(1); // Don't spam the service
+    sleep(0.5); // Don't spam the service
   }
 
   return RMW_RET_OK;

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -47,7 +47,9 @@ rmw_service_server_is_available(
   RMW_CHECK_ARGUMENT_FOR_NULL(result, RMW_RET_INVALID_ARGUMENT);
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    client->data,
+    "client implementation pointer is null",
+    RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN CLIENT MEMBERS =====================================================
   auto client_data = static_cast<rmw_client_data_t *>(client->data);
@@ -63,8 +65,9 @@ rmw_service_server_is_available(
 
   std::string key(client->service_name);
 
-  if (client_data->zn_availability_query_responses_.find(key)
-      != client_data->zn_availability_query_responses_.end()) {
+  if (client_data->zn_availability_query_responses_.find(key) != 
+    client_data->zn_availability_query_responses_.end())
+  {
     client_data->zn_availability_query_responses_.erase(key);
     *result = true;
   } else {
@@ -134,7 +137,8 @@ rmw_create_client(
 
   // OBTAIN TYPESUPPORT ========================================================
   const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
-    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
+    type_supports,
+    RMW_ZENOH_CPP_TYPESUPPORT_C);
 
   if (!type_support) {
     type_support = get_service_typesupport_handle(type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);
@@ -147,7 +151,8 @@ rmw_create_client(
 
   // CREATE CLIENT =============================================================
   rmw_client_t * client = static_cast<rmw_client_t *>(allocator->allocate(
-    sizeof(rmw_client_t), allocator->state));
+    sizeof(rmw_client_t),
+    allocator->state));
   if (!client) {
     RMW_SET_ERROR_MSG("failed to allocate rmw_client_t");
     return nullptr;
@@ -164,7 +169,8 @@ rmw_create_client(
   }
 
   client->data = static_cast<rmw_client_data_t *>(allocator->allocate(
-    sizeof(rmw_client_data_t), allocator->state));
+    sizeof(rmw_client_data_t),
+    allocator->state));
   new(client->data) rmw_client_data_t();
   if (!client->data) {
     RMW_SET_ERROR_MSG("failed to allocate client data");
@@ -500,10 +506,14 @@ rmw_send_request(const rmw_client_t * client, const void * ros_request, int64_t 
 
   // Object that serializes the data.
   eprosima::fastcdr::Cdr ser(
-    fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (!client_data->request_type_support_->serializeROSmessage(
-      ros_request, ser, client_data->request_type_support_impl_)) {
+      ros_request,
+      ser,
+      client_data->request_type_support_impl_)) {
     RMW_SET_ERROR_MSG("failed serialize ROS request message");
     allocator->deallocate(request_bytes, allocator->state);
     return RMW_RET_ERROR;
@@ -621,8 +631,8 @@ rmw_take_response(
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
     eprosima::fastcdr::Cdr::DDS_CDR);
   if (!client_data->response_type_support_->deserializeROSmessage(
-      deser, ros_response, client_data->response_type_support_impl_)
-  ) {
+      deser, ros_response, client_data->response_type_support_impl_))
+    {
     RMW_SET_ERROR_MSG("could not deserialize ROS response message");
     return RMW_RET_ERROR;
   }

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -71,6 +71,7 @@ rmw_service_server_is_available(
     client_data->zn_availability_query_responses_.erase(key);
     *result = true;
   } else {
+    // TODO(CH3): Change this if a better way to throttle availability checks is found
     sleep(0.5); // Don't spam the service
   }
 

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -27,8 +27,10 @@ rmw_service_server_is_available(
 {
   *result = false;
 
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_service_server_is_available] %s",
-                          client->service_name);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_service_server_is_available] %s",
+    client->service_name);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
@@ -44,7 +46,7 @@ rmw_service_server_is_available(
   RMW_CHECK_ARGUMENT_FOR_NULL(result, RMW_RET_INVALID_ARGUMENT);
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
-      client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN CLIENT MEMBERS =====================================================
   auto client_data = static_cast<rmw_client_data_t *>(client->data);
@@ -60,9 +62,9 @@ rmw_service_server_is_available(
 
   std::string key(client->service_name);
 
-  if (rmw_client_data_t::zn_availability_query_responses_.find(key)
-      != rmw_client_data_t::zn_availability_query_responses_.end()) {
-    rmw_client_data_t::zn_availability_query_responses_.erase(key);
+  if (client_data->zn_availability_query_responses_.find(key)
+      != client_data->zn_availability_query_responses_.end()) {
+    client_data->zn_availability_query_responses_.erase(key);
     *result = true;
   }
 
@@ -78,15 +80,20 @@ rmw_create_client(
   const char * service_name,
   const rmw_qos_profile_t * qos_profile)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_create_client] %s", service_name);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_client] %s with queue of depth %ld",
+    service_name,
+    qos_profile->depth);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node,
-                                   node->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return nullptr);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
   if (strlen(service_name) == 0) {
@@ -124,8 +131,7 @@ rmw_create_client(
 
   // OBTAIN TYPESUPPORT ========================================================
   const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
-    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C
-  );
+    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
 
   if (!type_support) {
     type_support = get_service_typesupport_handle(type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);
@@ -137,8 +143,8 @@ rmw_create_client(
   }
 
   // CREATE CLIENT =============================================================
-  rmw_client_t * client = static_cast<rmw_client_t *>(allocator->allocate(sizeof(rmw_client_t),
-                                                                          allocator->state));
+  rmw_client_t * client = static_cast<rmw_client_t *>(allocator->allocate(
+    sizeof(rmw_client_t), allocator->state));
   if (!client) {
     RMW_SET_ERROR_MSG("failed to allocate rmw_client_t");
     return nullptr;
@@ -154,8 +160,9 @@ rmw_create_client(
     return nullptr;
   }
 
-  client->data = static_cast<rmw_client_data_t *>(allocator->allocate(sizeof(rmw_client_data_t),
-                                                                      allocator->state));
+  client->data = static_cast<rmw_client_data_t *>(allocator->allocate(
+    sizeof(rmw_client_data_t), allocator->state));
+  new(client->data) rmw_client_data_t();
   if (!client->data) {
     RMW_SET_ERROR_MSG("failed to allocate client data");
     allocator->deallocate(const_cast<char *>(client->service_name), allocator->state);
@@ -164,7 +171,7 @@ rmw_create_client(
   }
 
   // CREATE CLIENT MEMBERS =====================================================
-  // Get typed pointer to implementation specific subscription data struct
+  // Get typed pointer to implementation specific client data struct
   auto client_data = static_cast<rmw_client_data_t *>(client->data);
 
   // Obtain Zenoh session and create Zenoh resource for request messages
@@ -174,8 +181,7 @@ rmw_create_client(
   // Obtain qualified request-response topics
   std::string zn_topic_key(client->service_name);
   client_data->zn_request_topic_key_ = rcutils_strdup(
-    (zn_topic_key + "/request").c_str(), *allocator
-  );
+    (zn_topic_key + "/request").c_str(), *allocator);
   if (!client_data->zn_request_topic_key_) {
     RMW_SET_ERROR_MSG("failed to allocate zenoh request topic key");
     allocator->deallocate(client->data, allocator->state);
@@ -186,8 +192,7 @@ rmw_create_client(
   }
 
   client_data->zn_response_topic_key_ = rcutils_strdup(
-    (zn_topic_key + "/response").c_str(), *allocator
-  );
+    (zn_topic_key + "/response").c_str(), *allocator);
   if (!client_data->zn_response_topic_key_) {
     RMW_SET_ERROR_MSG("failed to allocate zenoh response topic key");
     allocator->deallocate(const_cast<char *>(client_data->zn_request_topic_key_), allocator->state);
@@ -204,12 +209,13 @@ rmw_create_client(
   // same Zenoh network! It is not a UUID!!
   client_data->zn_request_topic_id_ = zn_declare_resource(s, client_data->zn_request_topic_key_);
 
+  // INSERT TYPE SUPPORT =======================================================
   // Init type support callbacks
   auto service_members = static_cast<const service_type_support_callbacks_t *>(type_support->data);
   auto request_members = static_cast<const message_type_support_callbacks_t *>(
-      service_members->request_members_->data);
+    service_members->request_members_->data);
   auto response_members = static_cast<const message_type_support_callbacks_t *>(
-      service_members->response_members_->data);
+    service_members->response_members_->data);
 
   client_data->typesupport_identifier_ = type_support->typesupport_identifier;
   client_data->request_type_support_impl_ = request_members;
@@ -221,12 +227,9 @@ rmw_create_client(
   new(client_data->request_type_support_) rmw_zenoh_cpp::RequestTypeSupport(service_members);
   if (!client_data->request_type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate RequestTypeSupport");
+    allocator->deallocate(const_cast<char *>(client_data->zn_request_topic_key_), allocator->state);
     allocator->deallocate(
-      const_cast<char *>(client_data->zn_request_topic_key_),
-      allocator->state);
-    allocator->deallocate(
-      const_cast<char *>(client_data->zn_response_topic_key_),
-      allocator->state);
+      const_cast<char *>(client_data->zn_response_topic_key_), allocator->state);
     allocator->deallocate(client->data, allocator->state);
 
     allocator->deallocate(const_cast<char *>(client->service_name), allocator->state);
@@ -235,13 +238,12 @@ rmw_create_client(
   }
 
   client_data->response_type_support_ = static_cast<rmw_zenoh_cpp::ResponseTypeSupport *>(
-      allocator->allocate(sizeof(rmw_zenoh_cpp::ResponseTypeSupport), allocator->state));
+    allocator->allocate(sizeof(rmw_zenoh_cpp::ResponseTypeSupport), allocator->state));
   new(client_data->response_type_support_) rmw_zenoh_cpp::ResponseTypeSupport(service_members);
   if (!client_data->response_type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate ResponseTypeSupport");
     allocator->deallocate(const_cast<char *>(client_data->zn_request_topic_key_), allocator->state);
-    allocator->deallocate(
-      const_cast<char *>(client_data->zn_response_topic_key_),
+    allocator->deallocate(const_cast<char *>(client_data->zn_response_topic_key_),
       allocator->state);
     allocator->deallocate(client_data->request_type_support_, allocator->state);
     allocator->deallocate(client->data, allocator->state);
@@ -251,15 +253,81 @@ rmw_create_client(
     return nullptr;
   }
 
-  // // Assign node pointer
+  // CONFIGURE CLIENT ==========================================================
+  // Assign node pointer
   client_data->node_ = node;
 
-  // Init Zenoh subscriber for response messages
-  client_data->zn_response_subscriber_ = zn_declare_subscriber(
+  // Assign and increment unique client ID atomically
+  client_data->client_id_ =
+    rmw_client_data_t::client_id_counter.fetch_add(1, std::memory_order_relaxed);
+
+  // Configure response message queue
+  client_data->queue_depth_ = qos_profile->depth;
+
+  // ADD CLIENT DATA TO TOPIC MAP ==============================================
+  // This will allow us to access the client data structs for this Zenoh topic key expression
+  // (This is for listening for service responses)
+  std::string topic_key(client_data->zn_response_topic_key_);
+  auto topic_map_iter = rmw_client_data_t::zn_topic_to_client_data.find(topic_key);
+
+  if (topic_map_iter == rmw_client_data_t::zn_topic_to_client_data.end()) {
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_client] New response topic detected: %s",
+      client_data->zn_response_topic_key_);
+
+    // If no elements for this Zenoh topic key expression exists, add it in
+    std::vector<rmw_client_data_t *> client_data_vec{client_data};
+    rmw_client_data_t::zn_topic_to_client_data[topic_key] = client_data_vec;
+
+    // We initialise subscribers ONCE (otherwise we'll get duplicate messages)
+    // The topic name will be the same for any duplicate subscribers, so it is ok
+    client_data->zn_response_subscriber_ = zn_declare_subscriber(
       client_data->zn_session_,
       client_data->zn_response_topic_key_,
       zn_subinfo_default(),  // NOTE(CH3): Default for now
       client_data->zn_response_sub_callback);
+
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_client] Zenoh subscriber declared for %s",
+      client_data->zn_response_topic_key_);
+  } else {
+    // Otherwise, append to the vector
+    topic_map_iter->second.push_back(client_data);
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_client] Client for %s (ID: %ld) added to topic map",
+    client_data->zn_response_topic_key_,
+    client_data->client_id_);
+
+  // ADD CLIENT DATA TO QUERYABLE MAP===========================================
+  // This will allow us to access the client data structs for this Zenoh queryable key expression
+  // (This is for checking service availability)
+  std::string queryable_key(client->service_name);
+  auto queryable_map_iter = rmw_client_data_t::zn_queryable_to_client_data.find(queryable_key);
+
+  if (queryable_map_iter == rmw_client_data_t::zn_queryable_to_client_data.end()) {
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_client] New queryable detected: %s",
+      client->service_name);
+
+    // If no elements for this Zenoh topic key expression exists, add it in
+    std::vector<rmw_client_data_t *> client_data_vec_{client_data};
+    rmw_client_data_t::zn_queryable_to_client_data[queryable_key] = client_data_vec_;
+  } else {
+    // Otherwise, append to the vector
+    queryable_map_iter->second.push_back(client_data);
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_client] Client for %s (ID: %ld) added to queryable map",
+    client->service_name,
+    client_data->client_id_);
 
   return client;
 }
@@ -274,23 +342,67 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node,
-                                   node->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(client,
-                                   client->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
-  // CLEANUP ===================================================================
+  // OBTAIN CLIENT MEMBERS =====================================================
   auto client_data = static_cast<rmw_client_data_t *>(client->data);
 
-  zn_undeclare_subscriber(client_data->zn_response_subscriber_);
+  // DELETE CLIENT DATA IN TOPIC MAP ===========================================
+  std::string key(client_data->zn_response_topic_key_);
+  auto map_iter = rmw_client_data_t::zn_topic_to_client_data.find(key);
 
+  if (map_iter == rmw_client_data_t::zn_topic_to_client_data.end()) {
+    RCUTILS_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp",
+      "client not found in Zenoh topic to client data map! %s",
+      client_data->zn_response_topic_key_);
+  } else {
+    // Delete the subscription data pointer in the Zenoh topic to subscription data map
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      if ((*it)->client_id_ == client_data->client_id_) {
+        map_iter->second.erase(it);
+        break;
+      }
+    }
+
+    // Delete the map element if no other client data pointers exist
+    // (That is, when no other clients are listening to the Zenoh response topic)
+    if (map_iter->second.empty()) {
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "[rmw_destroy_client] No more clients listening to %s",
+        client_data->zn_response_topic_key_);
+
+      // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
+      zn_undeclare_subscriber(client_data->zn_response_subscriber_);
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "[rmw_destroy_client] Zenoh subcriber undeclared for %s",
+        client_data->zn_response_topic_key_);
+
+      rmw_client_data_t::zn_topic_to_client_data.erase(map_iter);
+    }
+
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_destroy_client] Client for %s (ID: %ld) removed from topic map",
+      client_data->zn_response_topic_key_,
+      client_data->client_id_);
+  }
+
+  // CLEANUP ===================================================================
   allocator->deallocate(const_cast<char *>(client_data->zn_request_topic_key_), allocator->state);
   allocator->deallocate(const_cast<char *>(client_data->zn_response_topic_key_), allocator->state);
   allocator->deallocate(client_data->request_type_support_, allocator->state);
@@ -310,22 +422,27 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 rmw_ret_t
 rmw_send_request(const rmw_client_t * client, const void * ros_request, int64_t * sequence_id)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
-                          "[rmw_send_request] %s (%ld)",
-                          static_cast<rmw_client_data_t *>(client->data)->zn_request_topic_key_,
-                          static_cast<rmw_client_data_t *>(client->data)->zn_request_topic_id_);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_send_request] %s (%ld)",
+    static_cast<rmw_client_data_t *>(client->data)->zn_request_topic_key_,
+    static_cast<rmw_client_data_t *>(client->data)->zn_request_topic_id_);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_request, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(sequence_id, RMW_RET_INVALID_ARGUMENT);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(client,
-                                   client->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  RMW_CHECK_ARGUMENT_FOR_NULL(client->data, RMW_RET_ERROR);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+
+  // OBTAIN CLIENT MEMBERS ====================================================
   auto * client_data = static_cast<rmw_client_data_t *>(client->data);
 
   // ASSIGN ALLOCATOR ==========================================================
@@ -333,15 +450,16 @@ rmw_send_request(const rmw_client_t * client, const void * ros_request, int64_t 
     &(static_cast<rmw_client_data_t *>(client->data)->node_->context->options.allocator);
 
   // SERIALIZE DATA ============================================================
-  size_t max_data_length = (static_cast<rmw_client_data_t *>(client->data)
-                              ->request_type_support_->getEstimatedSerializedSize(ros_request));
+  size_t max_data_length = (
+    static_cast<rmw_client_data_t *>(client->data)
+    ->request_type_support_->getEstimatedSerializedSize(ros_request));
 
   // Account for metadata
   max_data_length += sizeof(std::int64_t); // Internal type of the atomic sequence ID
 
   // Init serialized message byte array
   char * request_bytes = static_cast<char *>(
-      allocator->allocate(max_data_length, allocator->state));
+    allocator->allocate(max_data_length, allocator->state));
   if (!request_bytes) {
     RMW_SET_ERROR_MSG("failed allocate request message bytes");
     allocator->deallocate(request_bytes, allocator->state);
@@ -353,10 +471,10 @@ rmw_send_request(const rmw_client_t * client, const void * ros_request, int64_t 
 
   // Object that serializes the data.
   eprosima::fastcdr::Cdr ser(
-      fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
 
   if (!client_data->request_type_support_->serializeROSmessage(
-          ros_request, ser, client_data->request_type_support_impl_)) {
+      ros_request, ser, client_data->request_type_support_impl_)) {
     RMW_SET_ERROR_MSG("failed serialize ROS request message");
     allocator->deallocate(request_bytes, allocator->state);
     return RMW_RET_ERROR;
@@ -376,10 +494,11 @@ rmw_send_request(const rmw_client_t * client, const void * ros_request, int64_t 
          meta_length);
 
   // PUBLISH ON ZENOH MIDDLEWARE LAYER =========================================
-  size_t wrid_ret = zn_write_wrid(client_data->zn_session_,
-                                  client_data->zn_request_topic_id_,
-                                  request_bytes,
-                                  data_length + meta_length);
+  size_t wrid_ret = zn_write_wrid(
+    client_data->zn_session_,
+    client_data->zn_request_topic_id_,
+    request_bytes,
+    data_length + meta_length);
 
   allocator->deallocate(request_bytes, allocator->state);
 
@@ -401,21 +520,23 @@ rmw_take_response(
   bool * taken)
 {
   *taken = false;
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_take_response");
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_response, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(client,
-                                   client->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
-      client->service_name, "client has no service name", RMW_RET_INVALID_ARGUMENT);
+    client->service_name, "client has no service name", RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-      client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN CLIENT MEMBERS =====================================================
   auto client_data = static_cast<rmw_client_data_t *>(client->data);
@@ -424,60 +545,60 @@ rmw_take_response(
   rcutils_allocator_t * allocator = &client_data->node_->context->options.allocator;
 
   // RETRIEVE SERIALIZED MESSAGE ===============================================
-  std::string key(client_data->zn_response_topic_key_);
+  std::unique_lock<std::mutex> lock(client_data->response_queue_mutex_);
 
-  if (client_data->zn_response_messages_.find(key) == client_data->zn_response_messages_.end()) {
+  if (client_data->zn_response_message_queue_.empty()) {
     // NOTE(CH3): It is correct to be returning RMW_RET_OK. The information that the message
-    // was not found is encoded in the fact that the taken out-parameter is still False.
+    // was not found is encoded in the fact that the taken-out parameter is still False.
     //
     // This tells rcl that the check for a new message was done, but no messages have come in yet.
     return RMW_RET_OK;
   }
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_take_response] Response found: %s", key.c_str());
 
-  auto response_bytes = client_data->zn_response_messages_[key];
+  // NOTE(CH3): Potential place to handle "QoS" (e.g. could pop from back so it is LIFO)
+  auto response_bytes_ptr = client_data->zn_response_message_queue_.back();
+  client_data->zn_response_message_queue_.pop_back();
+
+  client_data->response_queue_mutex_.unlock();
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_take] Response found: %s",
+    client_data->zn_response_topic_key_);
 
   // RETRIEVE METADATA =========================================================
   // TODO(CH3): Again, refactor this into a modular set of functions eventually
   size_t meta_length = sizeof(std::int64_t); // Internal type of the atomic sequence ID
 
   // Use metadata
-  memcpy(&request_header->request_id.sequence_number,
-         &response_bytes.back() + 1 - meta_length,
-         meta_length);
+  memcpy(
+    &request_header->request_id.sequence_number,
+    &response_bytes_ptr->back() + 1 - meta_length,
+    meta_length);
 
   // DESERIALIZE MESSAGE =======================================================
-  size_t data_length = response_bytes.size() - meta_length;
+  size_t data_length = response_bytes_ptr->size() - meta_length;
 
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-      allocator->allocate(data_length, allocator->state));
-  if (!cdr_buffer) {
-    RMW_SET_ERROR_MSG("failed allocate response message bytes");
-    allocator->deallocate(cdr_buffer, allocator->state);
-    return RMW_RET_ERROR;
-  }
-  memcpy(cdr_buffer, &response_bytes.front(), data_length);
-
-  // Remove stored message after successful retrieval
-  client_data->zn_response_messages_.erase(key);
+    allocator->allocate(data_length, allocator->state));
+  memcpy(cdr_buffer, &response_bytes_ptr->front(), data_length);
 
   // Object that manages the raw buffer.
   eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), data_length);
 
-  // Object that deserializes the data.
-  eprosima::fastcdr::Cdr deser(fastbuffer,
-                               eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-                               eprosima::fastcdr::Cdr::DDS_CDR);
-
+  // Object that deserializes the data
+  eprosima::fastcdr::Cdr deser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
   if (!client_data->response_type_support_->deserializeROSmessage(
-      deser, ros_response, client_data->response_type_support_impl_)) {
-    RMW_SET_ERROR_MSG("failed deserialize ROS response message");
+      deser, ros_response, client_data->response_type_support_impl_)
+  ) {
+    RMW_SET_ERROR_MSG("could not deserialize ROS response message");
     return RMW_RET_ERROR;
   }
 
   *taken = true;
-  allocator->deallocate(cdr_buffer, allocator->state);
-
   return RMW_RET_OK;
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_client.cpp
+++ b/rmw_zenoh_cpp/src/rmw_client.cpp
@@ -420,7 +420,9 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
         "[rmw_destroy_client] No more clients listening to %s",
         client_data->zn_response_topic_key_);
 
-      // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
+      // Only when there are no more active RMW clients listening to this Zenoh topic, do we
+      // undeclare the subscriber on Zenoh's end (which means no more Zenoh callbacks will trigger
+      // on this topic)
       zn_undeclare_subscriber(client_data->zn_response_subscriber_);
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp",

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -103,14 +103,14 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     SESSION_MODE = PEER;
   }
 
-  ZNSession * s = zn_open(SESSION_MODE, context->options.impl->session_locator, 0);
+  ZNSession * session = zn_open(SESSION_MODE, context->options.impl->session_locator, 0);
 
-  if (s == nullptr) {
+  if (session == nullptr) {
     RMW_SET_ERROR_MSG("failed to create Zenoh session when starting context");
     allocator->deallocate(context_impl, allocator->state);
     return RMW_RET_ERROR;
   } else {
-    context_impl->session = s;
+    context_impl->session = session;
     context_impl->is_shutdown = false;
   }
 

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -124,16 +124,16 @@ rmw_create_publisher(
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(type_support->data);
 
   // Create Zenoh resource
-  ZNSession * s = node->context->impl->session;
+  ZNSession * session = node->context->impl->session;
 
   // The topic ID must be unique within a single process, but separate processes can reuse IDs,
   // even in the same Zenoh network, because the ID is never transmitted over the wire.
   // Conversely, the ID used in two communicating processes cannot be used to determine if they are
   // using the same topic or not.
-  publisher_data->zn_topic_id_ = zn_declare_resource(s, publisher->topic_name);
+  publisher_data->zn_topic_id_ = zn_declare_resource(session, publisher->topic_name);
 
   // Assign publisher data members
-  publisher_data->zn_session_ = s;
+  publisher_data->zn_session_ = session;
   publisher_data->typesupport_identifier_ = type_support->typesupport_identifier;
   publisher_data->type_support_impl_ = type_support->data;
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp",

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -249,19 +249,9 @@ rmw_create_service(
     service_data->service_id_);
 
   // DECLARE SERVICE IS AVAILABLE ==============================================
-  // Init Zenoh queryable for availability checking
   service_data->zn_queryable_ = zn_declare_queryable(
-    s, service->service_name, EVAL,
-    [](ZNQuery * query) {
-      const zn_string * resource = zn_query_res_name(query);
-      const zn_string * predicate = zn_query_predicate(query);
-
-      std::string res(resource->val, resource->len);
-      std::string response("available");  // NOTE(CH3): The contents actually don't matter...
-
-      zn_send_reply(query, res.c_str(), (const unsigned char *)response.c_str(), response.length());
-    }
-  );
+    s, service->service_name, STORAGE,
+    rmw_service_data_t::zn_service_availability_queryable_callback);
 
   if (service_data->zn_queryable_ == 0) {
     RMW_SET_ERROR_MSG("failed to create availability queryable for service");

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -461,6 +461,8 @@ rmw_take_request(
   }
 
   *taken = true;
+  allocator->deallocate(cdr_buffer, allocator->state);
+
   return RMW_RET_OK;
 }
 

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -31,15 +31,16 @@ rmw_create_service(
     "rmw_zenoh_cpp",
     "[rmw_create_service] %s with queue of depth %ld",
     service_name,
-  qos_profile->depth);
+    qos_profile->depth);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node,
-                                   node->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return nullptr);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return nullptr);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
   if (strlen(service_name) == 0) {
@@ -81,7 +82,7 @@ rmw_create_service(
 
   // CREATE SERVICE ============================================================
   rmw_service_t * service = static_cast<rmw_service_t *>(
-      allocator->allocate(sizeof(rmw_service_t), allocator->state));
+    allocator->allocate(sizeof(rmw_service_t), allocator->state));
   if (!service) {
     RMW_SET_ERROR_MSG("failed to allocate rmw_service_t");
     return nullptr;
@@ -98,7 +99,8 @@ rmw_create_service(
   }
 
   service->data = static_cast<rmw_service_data_t *>(
-      allocator->allocate(sizeof(rmw_service_data_t), allocator->state));
+    allocator->allocate(sizeof(rmw_service_data_t), allocator->state));
+  new(service->data) rmw_service_data_t();
   if (!service->data) {
     RMW_SET_ERROR_MSG("failed to allocate service data");
     allocator->deallocate(const_cast<char *>(service->service_name), allocator->state);
@@ -108,7 +110,7 @@ rmw_create_service(
 
   // CREATE SERVICE MEMBERS ====================================================
   // Get typed pointer to implementation specific subscription data struct
-  auto service_data = static_cast<rmw_service_data_t *>(service->data);
+  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
 
   // Obtain Zenoh session and create Zenoh resource for response messages
   ZNSession * s = node->context->impl->session;
@@ -117,7 +119,7 @@ rmw_create_service(
   // Obtain qualified request-response topics
   std::string zn_topic_key(service->service_name);
   service_data->zn_request_topic_key_ = rcutils_strdup(
-      (zn_topic_key + "/request").c_str(), *allocator);
+    (zn_topic_key + "/request").c_str(), *allocator);
   if (!service_data->zn_request_topic_key_) {
     RMW_SET_ERROR_MSG("failed to allocate zenoh request topic key");
     allocator->deallocate(service->data, allocator->state);
@@ -128,7 +130,7 @@ rmw_create_service(
   }
 
   service_data->zn_response_topic_key_ = rcutils_strdup(
-      (zn_topic_key + "/response").c_str(), *allocator);
+    (zn_topic_key + "/response").c_str(), *allocator);
   if (!service_data->zn_response_topic_key_) {
     RMW_SET_ERROR_MSG("failed to allocate zenoh response topic key");
     allocator->deallocate(
@@ -142,18 +144,19 @@ rmw_create_service(
   }
 
   // The topic ID must be unique within a single process, but separate processes can reuse IDs,
-  // even in the same Zenoh network, because the ID is never transmitted over the wire. Conversely,
-  // the ID used in two communicating processes cannot be used to determine if they are using the
-  // same topic or not.
+  // even in the same Zenoh network, because the ID is never transmitted over the wire.
+  // Conversely, the ID used in two communicating processes cannot be used to determine if they are
+  // using the same topic or not.
   service_data->zn_response_topic_id_ = zn_declare_resource(
-      s, service_data->zn_response_topic_key_);
+    s, service_data->zn_response_topic_key_);
 
+  // INSERT TYPE SUPPORT =======================================================
   // Init type support callbacks
   auto service_members = static_cast<const service_type_support_callbacks_t *>(type_support->data);
   auto request_members = static_cast<const message_type_support_callbacks_t *>(
-      service_members->request_members_->data);
+    service_members->request_members_->data);
   auto response_members = static_cast<const message_type_support_callbacks_t *>(
-      service_members->response_members_->data);
+    service_members->response_members_->data);
 
   service_data->typesupport_identifier_ = type_support->typesupport_identifier;
   service_data->request_type_support_impl_ = request_members;
@@ -161,7 +164,7 @@ rmw_create_service(
 
   // Allocate and in-place assign new typesupport instances
   service_data->request_type_support_ = static_cast<rmw_zenoh_cpp::RequestTypeSupport *>(
-      allocator->allocate(sizeof(rmw_zenoh_cpp::RequestTypeSupport), allocator->state));
+    allocator->allocate(sizeof(rmw_zenoh_cpp::RequestTypeSupport), allocator->state));
   new(service_data->request_type_support_) rmw_zenoh_cpp::RequestTypeSupport(service_members);
   if (!service_data->request_type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate RequestTypeSupport");
@@ -179,7 +182,7 @@ rmw_create_service(
   }
 
   service_data->response_type_support_ = static_cast<rmw_zenoh_cpp::ResponseTypeSupport *>(
-      allocator->allocate(sizeof(rmw_zenoh_cpp::ResponseTypeSupport), allocator->state));
+    allocator->allocate(sizeof(rmw_zenoh_cpp::ResponseTypeSupport), allocator->state));
   new(service_data->response_type_support_) rmw_zenoh_cpp::ResponseTypeSupport(service_members);
   if (!service_data->response_type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate ResponseTypeSupport");
@@ -197,45 +200,90 @@ rmw_create_service(
     return nullptr;
   }
 
-  // // Assign node pointer
+  // CONFIGURE SERVICE =========================================================
+  // Assign node pointer
   service_data->node_ = node;
 
-  // Init Zenoh subscriber for request messages
-  service_data->zn_request_subscriber_ = zn_declare_subscriber(
+  // Assign and increment unique service ID atomically
+  service_data->service_id_ =
+    rmw_service_data_t::service_id_counter.fetch_add(1, std::memory_order_relaxed);
+
+  // Configure request message queue
+  service_data->queue_depth_ = qos_profile->depth;
+
+  // ADD SERVICE DATA TO TOPIC MAP =============================================
+  // This will allow us to access the service data structs for this Zenoh topic key expression
+  std::string key(service_data->zn_request_topic_key_);
+  auto map_iter = rmw_service_data_t::zn_topic_to_service_data.find(key);
+
+  if (map_iter == rmw_service_data_t::zn_topic_to_service_data.end()) {
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_service] New request topic detected: %s",
+      service_data->zn_request_topic_key_);
+
+    // If no elements for this Zenoh topic key expression exists, add it in
+    std::vector<rmw_service_data_t *> service_data_vec{service_data};
+    rmw_service_data_t::zn_topic_to_service_data[key] = service_data_vec;
+
+    // We initialise subscribers ONCE (otherwise we'll get duplicate messages)
+    // The topic name will be the same for any duplicate subscribers, so it is ok
+    service_data->zn_request_subscriber_ = zn_declare_subscriber(
       service_data->zn_session_,
       service_data->zn_request_topic_key_,
       zn_subinfo_default(),  // NOTE(CH3): Default for now
       service_data->zn_request_sub_callback);
 
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_create_service] Zenoh service declared for %s",
+      service_data->zn_request_topic_key_);
+  } else {
+    // Otherwise, append to the vector
+    map_iter->second.push_back(service_data);
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_service] Service for %s (ID: %ld) added to topic map",
+    service_data->zn_request_topic_key_,
+    service_data->service_id_);
+
+  // DECLARE SERVICE IS AVAILABLE ==============================================
   // Init Zenoh queryable for availability checking
   service_data->zn_queryable_ = zn_declare_queryable(
-      s,
-      service->service_name,
-      EVAL,
-      [](ZNQuery * query) {
-        const zn_string * resource = zn_query_res_name(query);
-        const zn_string * predicate = zn_query_predicate(query);
+    s, service->service_name, EVAL,
+    [](ZNQuery * query) {
+      const zn_string * resource = zn_query_res_name(query);
+      const zn_string * predicate = zn_query_predicate(query);
 
-        std::string key(resource->val, resource->len);
-        std::string response("available");  // NOTE(CH3): The contents actually don't matter...
+      std::string res(resource->val, resource->len);
+      std::string response("available");  // NOTE(CH3): The contents actually don't matter...
 
-        zn_send_reply(
-          query,
-          key.c_str(),
-          (const unsigned char *)response.c_str(),
-          response.length());
-      }
+      zn_send_reply(query, res.c_str(), (const unsigned char *)response.c_str(), response.length());
+    }
   );
+
   if (service_data->zn_queryable_ == 0) {
     RMW_SET_ERROR_MSG("failed to create availability queryable for service");
-    zn_undeclare_subscriber(service_data->zn_request_subscriber_);
 
-    allocator->deallocate(
-      const_cast<char *>(service_data->zn_request_topic_key_),
-      allocator->state);
-    allocator->deallocate(
-      const_cast<char *>(service_data->zn_response_topic_key_),
-      allocator->state);
+    // Delete the subscription data pointer in the Zenoh topic to subscription data map
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      if ((*it)->service_id_ == service_data->service_id_) {
+        map_iter->second.erase(it);
+        break;
+      }
+    }
+
+    // Delete the map element if no other subscription data pointers exist
+    // (That is, when no other subscriptions are listening to the Zenoh topic)
+    if (map_iter->second.empty()) {
+      zn_undeclare_subscriber(service_data->zn_request_subscriber_);
+      rmw_service_data_t::zn_topic_to_service_data.erase(map_iter);
+    }
+
+    allocator->deallocate(const_cast<char *>(service_data->zn_request_topic_key_), allocator->state);
+    allocator->deallocate(const_cast<char *>(service_data->zn_response_topic_key_), allocator->state);
     allocator->deallocate(service_data->request_type_support_, allocator->state);
     allocator->deallocate(service_data->response_type_support_, allocator->state);
     allocator->deallocate(service->data, allocator->state);
@@ -271,10 +319,52 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
   // OBTAIN SERVICE MEMBERS ====================================================
-  auto service_data = static_cast<rmw_service_data_t *>(service->data);
+  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
+
+  // DELETE SUBSCRIPTION DATA IN TOPIC MAP =====================================
+  std::string key(service_data->zn_request_topic_key_);
+  auto map_iter = rmw_service_data_t::zn_topic_to_service_data.find(key);
+
+  if (map_iter == rmw_service_data_t::zn_topic_to_service_data.end()) {
+    RCUTILS_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp",
+      "service not found in Zenoh topic to service data map! %s",
+      service_data->zn_request_topic_key_);
+  } else {
+    // Delete the subscription data pointer in the Zenoh topic to subscription data map
+    for (auto it = map_iter->second.begin(); it != map_iter->second.end(); ++it) {
+      if ((*it)->service_id_ == service_data->service_id_) {
+        map_iter->second.erase(it);
+        break;
+      }
+    }
+
+    // Delete the map element if no other subscription data pointers exist
+    // (That is, when no other subscriptions are listening to the Zenoh topic)
+    if (map_iter->second.empty()) {
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "[rmw_destroy_service] No more services listening to %s",
+        service_data->zn_request_topic_key_);
+
+      // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
+      zn_undeclare_subscriber(service_data->zn_request_subscriber_);
+      RCUTILS_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "[rmw_destroy_serice] Zenoh subcriber undeclared for %s",
+        service_data->zn_request_topic_key_);
+
+      rmw_service_data_t::zn_topic_to_service_data.erase(map_iter);
+    }
+
+    RCUTILS_LOG_DEBUG_NAMED(
+      "rmw_zenoh_cpp",
+      "[rmw_destroy_serice] Service for %s (ID: %ld) removed from topic map",
+      service_data->zn_request_topic_key_,
+      service_data->service_id_);
+  }
 
   // CLEANUP ===================================================================
-  zn_undeclare_subscriber(service_data->zn_request_subscriber_);
   zn_undeclare_queryable(service_data->zn_queryable_);
 
   allocator->deallocate(const_cast<char *>(service_data->zn_request_topic_key_), allocator->state);
@@ -310,33 +400,40 @@ rmw_take_request(
     service,
     service->implementation_identifier,
     eclipse_zenoh_identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION
-  );
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
-      service->service_name, "service has no service name", RMW_RET_INVALID_ARGUMENT);
+    service->service_name, "service has no service name", RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-      service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN SERVICE MEMBERS ====================================================
-  auto service_data = static_cast<rmw_service_data_t *>(service->data);
+  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
 
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &service_data->node_->context->options.allocator;
 
   // RETRIEVE SERIALIZED MESSAGE ===============================================
-  std::string key(service_data->zn_request_topic_key_);
+  std::unique_lock<std::mutex> lock(service_data->request_queue_mutex_);
 
-  if (service_data->zn_request_messages_.find(key) == service_data->zn_request_messages_.end()) {
+  if (service_data->zn_request_message_queue_.empty()) {
     // NOTE(CH3): It is correct to be returning RMW_RET_OK. The information that the message
     // was not found is encoded in the fact that the taken-out parameter is still False.
     //
     // This tells rcl that the check for a new message was done, but no messages have come in yet.
     return RMW_RET_OK;
   }
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_take_request] Request found: %s", key.c_str());
 
-  auto request_bytes = service_data->zn_request_messages_[key];
+  // NOTE(CH3): Potential place to handle "QoS" (e.g. could pop from back so it is LIFO)
+  auto request_bytes_ptr = service_data->zn_request_message_queue_.back();
+  service_data->zn_request_message_queue_.pop_back();
+
+  service_data->request_queue_mutex_.unlock();
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_take] Request found: %s",
+    service_data->zn_request_topic_key_);
 
   // RETRIEVE METADATA =========================================================
   //
@@ -345,31 +442,30 @@ rmw_take_request(
   size_t meta_length = sizeof(rmw_client_data_t::sequence_id);
 
   // Use metadata
-  memcpy(&request_header->request_id.sequence_number,
-         &request_bytes.back() + 1 - meta_length,
-         meta_length);
+  memcpy(
+    &request_header->request_id.sequence_number,
+    &request_bytes_ptr->back() + 1 - meta_length,
+    meta_length);
 
   // DESERIALIZE MESSAGE =======================================================
-  size_t data_length = request_bytes.size() - meta_length;
+  size_t data_length = request_bytes_ptr->size() - meta_length;
 
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-      allocator->allocate(data_length, allocator->state));
-  memcpy(cdr_buffer, &request_bytes.front(), data_length);
-
-  // Remove stored message after successful retrieval
-  service_data->zn_request_messages_.erase(key);
+    allocator->allocate(data_length, allocator->state));
+  memcpy(cdr_buffer, &request_bytes_ptr->front(), data_length);
 
   // Object that manages the raw buffer.
   eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(cdr_buffer), data_length);
 
   // Object that deserializes the data
-  eprosima::fastcdr::Cdr deser(fastbuffer,
-                               eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-                               eprosima::fastcdr::Cdr::DDS_CDR);
+  eprosima::fastcdr::Cdr deser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
   if (!service_data->request_type_support_->deserializeROSmessage(
       deser, ros_request, service_data->request_type_support_impl_)
   ) {
-    RMW_SET_ERROR_MSG("could not deserialize request message");
+    RMW_SET_ERROR_MSG("could not deserialize ROS request message");
     return RMW_RET_ERROR;
   }
 
@@ -384,21 +480,23 @@ rmw_send_response(const rmw_service_t * service,
                   rmw_request_id_t * request_header,  // In parameter
                   void * ros_response)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_send_response] %s (%ld)",
-                          service->service_name,
-                          static_cast<rmw_service_data_t *>(service->data)->zn_response_topic_id_);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp", "[rmw_send_response] %s (%ld)",
+    service->service_name,
+    static_cast<rmw_service_data_t *>(service->data)->zn_response_topic_id_);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_response, RMW_RET_INVALID_ARGUMENT);
 
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(service,
-                                   service->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
-      service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN SERVICE MEMBERS ====================================================
   auto * service_data = static_cast<rmw_service_data_t *>(service->data);
@@ -416,17 +514,18 @@ rmw_send_response(const rmw_service_t * service,
 
   // Init serialized message byte array
   char * response_bytes = static_cast<char *>(
-      allocator->allocate(max_data_length, allocator->state));
+    allocator->allocate(max_data_length, allocator->state));
 
   // Object that manages the raw buffer
   eprosima::fastcdr::FastBuffer fastbuffer(response_bytes, max_data_length);
 
   // Object that serializes the data
-  eprosima::fastcdr::Cdr ser(fastbuffer,
-                             eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-                             eprosima::fastcdr::Cdr::DDS_CDR);
+  eprosima::fastcdr::Cdr ser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
   if (!service_data->response_type_support_->serializeROSmessage(
-        ros_response, ser, service_data->response_type_support_impl_)) {
+      ros_response, ser, service_data->response_type_support_impl_)) {
     allocator->deallocate(response_bytes, allocator->state);
     return RMW_RET_ERROR;
   }
@@ -436,15 +535,17 @@ rmw_send_response(const rmw_service_t * service,
   // ADD METADATA ==============================================================
   // TODO(CH3): Again, refactor this into a modular set of functions eventually
   size_t meta_length = sizeof(request_header->sequence_number);
-  memcpy(&response_bytes[data_length],
-         reinterpret_cast<char *>(&request_header->sequence_number),
-         meta_length);
+  memcpy(
+    &response_bytes[data_length],
+    reinterpret_cast<char *>(&request_header->sequence_number),
+    meta_length);
 
   // PUBLISH ON ZENOH MIDDLEWARE LAYER =========================================
-  size_t wrid_ret = zn_write_wrid(service_data->zn_session_,
-                                  service_data->zn_response_topic_id_,
-                                  response_bytes,
-                                  data_length + meta_length);
+  size_t wrid_ret = zn_write_wrid(
+    service_data->zn_session_,
+    service_data->zn_response_topic_id_,
+    response_bytes,
+    data_length + meta_length);
 
   allocator->deallocate(response_bytes, allocator->state);
 

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -306,14 +306,16 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(node,
-                                   node->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(service,
-                                   service->implementation_identifier,
-                                   eclipse_zenoh_identifier,
-                                   return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    eclipse_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   // OBTAIN ALLOCATOR ==========================================================
   rcutils_allocator_t * allocator = &node->context->options.allocator;

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -69,7 +69,8 @@ rmw_create_service(
 
   // OBTAIN TYPESUPPORT ========================================================
   const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
-    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
+    type_supports,
+    RMW_ZENOH_CPP_TYPESUPPORT_C);
 
   if (!type_support) {
     type_support = get_service_typesupport_handle(type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);
@@ -82,7 +83,8 @@ rmw_create_service(
 
   // CREATE SERVICE ============================================================
   rmw_service_t * service = static_cast<rmw_service_t *>(
-    allocator->allocate(sizeof(rmw_service_t), allocator->state));
+    allocator->allocate(sizeof(rmw_service_t),
+    allocator->state));
   if (!service) {
     RMW_SET_ERROR_MSG("failed to allocate rmw_service_t");
     return nullptr;
@@ -99,7 +101,8 @@ rmw_create_service(
   }
 
   service->data = static_cast<rmw_service_data_t *>(
-    allocator->allocate(sizeof(rmw_service_data_t), allocator->state));
+    allocator->allocate(sizeof(rmw_service_data_t),
+    allocator->state));
   new(service->data) rmw_service_data_t();
   if (!service->data) {
     RMW_SET_ERROR_MSG("failed to allocate service data");
@@ -119,7 +122,8 @@ rmw_create_service(
   // Obtain qualified request-response topics
   std::string zn_topic_key(service->service_name);
   service_data->zn_request_topic_key_ = rcutils_strdup(
-    (zn_topic_key + "/request").c_str(), *allocator);
+    (zn_topic_key + "/request").c_str(),
+    *allocator);
   if (!service_data->zn_request_topic_key_) {
     RMW_SET_ERROR_MSG("failed to allocate zenoh request topic key");
     allocator->deallocate(service->data, allocator->state);
@@ -130,11 +134,13 @@ rmw_create_service(
   }
 
   service_data->zn_response_topic_key_ = rcutils_strdup(
-    (zn_topic_key + "/response").c_str(), *allocator);
+    (zn_topic_key + "/response").c_str(),
+    *allocator);
   if (!service_data->zn_response_topic_key_) {
     RMW_SET_ERROR_MSG("failed to allocate zenoh response topic key");
     allocator->deallocate(
-      const_cast<char *>(service_data->zn_request_topic_key_), allocator->state);
+      const_cast<char *>(service_data->zn_request_topic_key_),
+      allocator->state);
     allocator->deallocate(service->data, allocator->state);
 
     allocator->deallocate(const_cast<char *>(service->service_name), allocator->state);
@@ -147,7 +153,8 @@ rmw_create_service(
   // Conversely, the ID used in two communicating processes cannot be used to determine if they are
   // using the same topic or not.
   service_data->zn_response_topic_id_ = zn_declare_resource(
-    s, service_data->zn_response_topic_key_);
+    s,
+    service_data->zn_response_topic_key_);
 
   // INSERT TYPE SUPPORT =======================================================
   // Init type support callbacks
@@ -163,7 +170,8 @@ rmw_create_service(
 
   // Allocate and in-place assign new typesupport instances
   service_data->request_type_support_ = static_cast<rmw_zenoh_cpp::RequestTypeSupport *>(
-    allocator->allocate(sizeof(rmw_zenoh_cpp::RequestTypeSupport), allocator->state));
+    allocator->allocate(sizeof(rmw_zenoh_cpp::RequestTypeSupport),
+    allocator->state));
   new(service_data->request_type_support_) rmw_zenoh_cpp::RequestTypeSupport(service_members);
   if (!service_data->request_type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate RequestTypeSupport");
@@ -181,7 +189,8 @@ rmw_create_service(
   }
 
   service_data->response_type_support_ = static_cast<rmw_zenoh_cpp::ResponseTypeSupport *>(
-    allocator->allocate(sizeof(rmw_zenoh_cpp::ResponseTypeSupport), allocator->state));
+    allocator->allocate(sizeof(rmw_zenoh_cpp::ResponseTypeSupport),
+    allocator->state));
   new(service_data->response_type_support_) rmw_zenoh_cpp::ResponseTypeSupport(service_members);
   if (!service_data->response_type_support_) {
     RMW_SET_ERROR_MSG("failed to allocate ResponseTypeSupport");
@@ -250,7 +259,9 @@ rmw_create_service(
 
   // DECLARE SERVICE IS AVAILABLE ==============================================
   service_data->zn_queryable_ = zn_declare_queryable(
-    s, service->service_name, STORAGE,
+    s,
+    service->service_name,
+    STORAGE,
     rmw_service_data_t::zn_service_availability_queryable_callback);
 
   if (service_data->zn_queryable_ == 0) {
@@ -442,7 +453,8 @@ rmw_take_request(
   size_t data_length = request_bytes_ptr->size() - meta_length;
 
   unsigned char * cdr_buffer = static_cast<unsigned char *>(
-    allocator->allocate(data_length, allocator->state));
+    allocator->allocate(data_length,
+    allocator->state));
   memcpy(cdr_buffer, &request_bytes_ptr->front(), data_length);
 
   // Object that manages the raw buffer.
@@ -490,7 +502,9 @@ rmw_send_response(const rmw_service_t * service,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    service->data,
+    "service implementation pointer is null",
+    RMW_RET_INVALID_ARGUMENT);
 
   // OBTAIN SERVICE MEMBERS ====================================================
   auto * service_data = static_cast<rmw_service_data_t *>(service->data);
@@ -509,7 +523,8 @@ rmw_send_response(const rmw_service_t * service,
 
   // Init serialized message byte array
   char * response_bytes = static_cast<char *>(
-    allocator->allocate(max_data_length, allocator->state));
+    allocator->allocate(max_data_length,
+    allocator->state));
   if (!response_bytes) {
     RMW_SET_ERROR_MSG("failed allocate response message bytes");
     allocator->deallocate(response_bytes, allocator->state);
@@ -521,9 +536,14 @@ rmw_send_response(const rmw_service_t * service,
 
   // Object that serializes the data
   eprosima::fastcdr::Cdr ser(
-    fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
   if (!service_data->response_type_support_->serializeROSmessage(
-      ros_response, ser, service_data->response_type_support_impl_)) {
+      ros_response,
+      ser,
+      service_data->response_type_support_impl_))
+    {
     allocator->deallocate(response_bytes, allocator->state);
     return RMW_RET_ERROR;
   }

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -27,7 +27,11 @@ rmw_create_service(
   const char * service_name,
   const rmw_qos_profile_t * qos_profile)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_create_service] %s", service_name);
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_service] %s with queue of depth %ld",
+    service_name,
+  qos_profile->depth);
 
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
@@ -64,7 +68,7 @@ rmw_create_service(
 
   // OBTAIN TYPESUPPORT ========================================================
   const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
-      type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
+    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
 
   if (!type_support) {
     type_support = get_service_typesupport_handle(type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -116,8 +116,8 @@ rmw_create_service(
   auto * service_data = static_cast<rmw_service_data_t *>(service->data);
 
   // Obtain Zenoh session and create Zenoh resource for response messages
-  ZNSession * s = node->context->impl->session;
-  service_data->zn_session_ = s;
+  ZNSession * session = node->context->impl->session;
+  service_data->zn_session_ = session;
 
   // Obtain qualified request-response topics
   std::string zn_topic_key(service->service_name);
@@ -153,7 +153,7 @@ rmw_create_service(
   // Conversely, the ID used in two communicating processes cannot be used to determine if they are
   // using the same topic or not.
   service_data->zn_response_topic_id_ = zn_declare_resource(
-    s,
+    session,
     service_data->zn_response_topic_key_);
 
   // INSERT TYPE SUPPORT =======================================================
@@ -259,7 +259,7 @@ rmw_create_service(
 
   // DECLARE SERVICE IS AVAILABLE ==============================================
   service_data->zn_queryable_ = zn_declare_queryable(
-    s,
+    session,
     service->service_name,
     STORAGE,
     rmw_service_data_t::zn_service_availability_queryable_callback);

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -349,7 +349,9 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
         "[rmw_destroy_service] No more services listening to %s",
         service_data->zn_request_topic_key_);
 
-      // We undeclare subscribers ONCE no active Zenoh services are listening on this Zenoh topic
+      // Only when there are no more active RMW services listening to this Zenoh topic, do we
+      // undeclare the subscriber on Zenoh's end (which means no more Zenoh callbacks will trigger
+      // on this topic)
       zn_undeclare_subscriber(service_data->zn_request_subscriber_);
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp",

--- a/rmw_zenoh_cpp/src/rmw_service.cpp
+++ b/rmw_zenoh_cpp/src/rmw_service.cpp
@@ -441,7 +441,7 @@ rmw_take_request(
   //
   // TODO(CH3): Refactor this into its own modular set of functions eventually to make adding
   // more metadata convenient
-  size_t meta_length = sizeof(rmw_client_data_t::sequence_id);
+  size_t meta_length = sizeof(std::int64_t); // Internal type of the atomic sequence ID
 
   // Use metadata
   memcpy(

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -127,12 +127,12 @@ rmw_create_subscription(
   auto * callbacks = static_cast<const message_type_support_callbacks_t *>(type_support->data);
 
   // Obtain Zenoh session
-  ZNSession * s = node->context->impl->session;
+  ZNSession * session = node->context->impl->session;
 
   // Get typed pointer to implementation specific subscription data struct
   auto * subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
 
-  subscription_data->zn_session_ = s;
+  subscription_data->zn_session_ = session;
   subscription_data->typesupport_identifier_ = type_support->typesupport_identifier;
   subscription_data->type_support_impl_ = type_support->data;
 

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -374,6 +374,8 @@ rmw_take(
   }
 
   *taken = true;
+  allocator->deallocate(cdr_buffer, allocator->state);
+
   return RMW_RET_OK;
 }
 
@@ -472,6 +474,8 @@ rmw_take_with_info(
   }
 
   *taken = true;
+  allocator->deallocate(cdr_buffer, allocator->state);
+
   return RMW_RET_OK;
 }
 

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -264,7 +264,9 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
         "[rmw_destroy_subscription] No more subscriptions listening to %s",
         subscription->topic_name);
 
-      // We undeclare subscribers ONCE no active subscribers are listening on this Zenoh topic
+      // Only when there are no more active RMW subscriptions listening to this Zenoh topic, do we
+      // undeclare the subscriber on Zenoh's end (which means no more Zenoh callbacks will trigger
+      // on this topic)
       zn_undeclare_subscriber(subscription_data->zn_subscriber_);
       RCUTILS_LOG_DEBUG_NAMED(
         "rmw_zenoh_cpp",

--- a/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
+++ b/rmw_zenoh_cpp/src/rmw_wait_sets.cpp
@@ -170,7 +170,7 @@ rmw_wait(  // All parameters are in parameters
     if (!wait_timeout) {
       // TODO(CH3): Remove this magic number once stable. This is to slow things down so things are
       // visible with all the printouts flying everywhere.
-      condition_variable->wait_for(lock, std::chrono::milliseconds(1500), predicate);
+      condition_variable->wait_for(lock, std::chrono::milliseconds(500), predicate);
     } else if (wait_timeout->sec > 0 || wait_timeout->nsec > 0) {
       auto wait_time = std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::seconds(wait_timeout->sec));


### PR DESCRIPTION
This PR is like https://github.com/osrf/rmw_zenoh/pull/27 but for SERVICES (both servers and clients)!

It implements instanced message queues for services (so we no longer need to rely on a static message map.) It also does the same for availability query responses.

This also means that we can now maintain request and response message queues of varying depth!

All other benefits in https://github.com/osrf/rmw_zenoh/pull/27 analogously apply to services. Wait has been updated to reflect this as well.

ALSO: rmw_wait has been edited to ignore guard conditions and (QoS) events. This will suppress the issues we had with invalid QoS warnings, but not solve the underlying issue. (On the other hand, events are supposed to be stubbed out anyway, so...)

## Extra Notes
The bug where a service will not respond to a client that was started before it has been fixed. But the fix is unintuitive and I still do not know why it happens. A very long comment chunk has been added to the fix (which is in `rmw_create_client`) to detail this.

I've also added a magic number to cause clients to not spam service availability checks so often. (I've found that Zenoh queryables sometimes fail or get stuck if they receive queries at more than ~200Hz. Though I did not strictly profile this.)

To test it, first run the client:
```
RMW_IMPLEMENTATION=rmw_zenoh_cpp ros2 run zenoh_ros_services client_main
```

Then run the server in a different process.
```
RMW_IMPLEMENTATION=rmw_zenoh_cpp ros2 run zenoh_ros_services service_main
```

Vice versa should work as before.

Remember to use https://github.com/methylDragon/zenoh_ros_examples/ and remember that you may use --ros-args --log-level debug to see the debug logs.