### PR TITLE
Don't delete resources allocated by Zenoh

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -175,7 +175,6 @@ rmw_context_fini(rmw_context_t * context)
 
   // CLEANUP ===================================================================
   // Deallocate implementation specific members
-  allocator->deallocate(context->impl->session, allocator->state);
   allocator->deallocate(context->impl, allocator->state);
 
   // Reset context


### PR DESCRIPTION
The `session` value is allocated by Zenoh internally when it creates a new session. Deleting it here creates a race condition that means Zenoh's internal threads may try to access this memory for shutting down after it has been freed. Don't delete it, let Zenoh clean it up itself.