### PR TITLE
QoS logging during pub/sub creation

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(rmw_zenoh_cpp
   src/impl/client_impl.cpp
   src/impl/type_support_common.cpp
   src/impl/qos.cpp
+  src/impl/debug_helpers.cpp
 )
 target_link_libraries(rmw_zenoh_cpp
   fastcdr

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -17,7 +17,7 @@
 
 void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
 {
-  const char * reliability_string = NULL;
+  const char * reliability_string = nullptr;
   switch (qos_profile->reliability) {
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
       reliability_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -73,7 +73,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       break;
   }
 
-  const char * liveliness_string = NULL;
+  const char * liveliness_string = nullptr;
   switch (qos_profile->liveliness) {
     case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
       liveliness_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -81,9 +81,10 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC:
       liveliness_string = "automatic";
       break;
-
-    // we want to print the debug message, but not trigger the compiler warning
-    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC+1:
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC + 1:
+      // Use the previous enum value + 1 to print the debug message for
+      // RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE without triggering the compiler warning for using
+      // a deprecated value
       liveliness_string = "manual by node (deprecated)";
       break;
     case RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC:

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -117,7 +117,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     "    liveliness lease duration: (%zu, %zu)",
     qos_profile->liveliness_lease_duration.sec,
     qos_profile->liveliness_lease_duration.nsec);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    avoid ros namespace conventions: %s",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    avoid ros namespace conventions: %s",
     qos_profile->avoid_ros_namespace_conventions ? "true" : "false");
 
 }

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "debug_helpers.hpp"
 #include "rcutils/logging_macros.h"
 

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -18,8 +18,7 @@
 void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
 {
   const char * reliability_string = NULL;
-  switch (qos_profile->reliability)
-  {
+  switch (qos_profile->reliability) {
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
       reliability_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -55,8 +55,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       break;
   }
   const char * durability_string = NULL;
-  switch (qos_profile->durability)
-  {
+  switch (qos_profile->durability) {
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       durability_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -122,5 +122,4 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     "rmw_zenoh_cpp",
     "    avoid ros namespace conventions: %s",
     qos_profile->avoid_ros_namespace_conventions ? "true" : "false");
-
 }

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -106,7 +106,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     "    deadline: (%zu, %zu)",
     qos_profile->deadline.sec,
     qos_profile->deadline.nsec);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    lifespan: (%zu, %zu)",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    lifespan: (%zu, %zu)",
     qos_profile->lifespan.sec,
     qos_profile->lifespan.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness: %s", liveliness_string);

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -1,0 +1,107 @@
+#include "debug_helpers.hpp"
+#include "rcutils/logging_macros.h"
+
+void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
+{
+  const char * reliability_string = NULL;
+  switch (qos_profile->reliability)
+  {
+    case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
+      reliability_string = "system default";
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_RELIABLE:
+      reliability_string = "reliable";
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT:
+      reliability_string = "best effort";
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
+      reliability_string = "unknown";
+      break;
+    default:
+      reliability_string = "invalid";
+      break;
+  }
+
+  const char * history_string = NULL;
+  switch (qos_profile->history)
+  {
+    case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
+      history_string = "system default";
+      break;
+    case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
+      history_string = "keep last";
+      break;
+    case RMW_QOS_POLICY_HISTORY_KEEP_ALL:
+      history_string = "keep all";
+      break;
+    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
+      history_string = "unknown";
+      break;
+    default:
+      history_string = "invalid";
+      break;
+  }
+  const char * durability_string = NULL;
+  switch (qos_profile->durability)
+  {
+    case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
+      durability_string = "system default";
+      break;
+    case RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL:
+      durability_string = "transient local";
+      break;
+    case RMW_QOS_POLICY_DURABILITY_VOLATILE:
+      durability_string = "volatile";
+      break;
+    case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
+      durability_string = "unknown";
+      break;
+    default:
+      durability_string = "invalid";
+      break;
+  }
+
+  const char * liveliness_string = NULL;
+  switch (qos_profile->liveliness)
+  {
+    case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
+      liveliness_string = "system default";
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC:
+      liveliness_string = "automatic";
+      break;
+
+    // we want to print the debug message, but not trigger the compiler warning
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC+1:
+      liveliness_string = "manual by node (deprecated)";
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC:
+      liveliness_string = "manual by topic";
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
+      liveliness_string = "unknown";
+      break;
+    default:
+      liveliness_string = "invalid";
+      break;
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    reliability: %s", reliability_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    history: %s", history_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    depth: %zu", qos_profile->depth);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    durability: %s", durability_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    deadline: (%zu, %zu)",
+    qos_profile->deadline.sec,
+    qos_profile->deadline.nsec);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    lifespan: (%zu, %zu)",
+    qos_profile->lifespan.sec,
+    qos_profile->lifespan.nsec);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness: %s", liveliness_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness lease duration: (%zu, %zu)",
+    qos_profile->liveliness_lease_duration.sec,
+    qos_profile->liveliness_lease_duration.nsec);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    avoid ros namespace conventions: %s",
+    qos_profile->avoid_ros_namespace_conventions ? "true" : "false");
+
+}

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -112,7 +112,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     qos_profile->lifespan.sec,
     qos_profile->lifespan.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness: %s", liveliness_string);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness lease duration: (%zu, %zu)",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    liveliness lease duration: (%zu, %zu)",
     qos_profile->liveliness_lease_duration.sec,
     qos_profile->liveliness_lease_duration.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    avoid ros namespace conventions: %s",

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -101,7 +101,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    history: %s", history_string);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    depth: %zu", qos_profile->depth);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    durability: %s", durability_string);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    deadline: (%zu, %zu)",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    deadline: (%zu, %zu)",
     qos_profile->deadline.sec,
     qos_profile->deadline.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    lifespan: (%zu, %zu)",

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -74,8 +74,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
   }
 
   const char * liveliness_string = NULL;
-  switch (qos_profile->liveliness)
-  {
+  switch (qos_profile->liveliness) {
     case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
       liveliness_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -36,7 +36,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       break;
   }
 
-  const char * history_string = NULL;
+  const char * history_string = nullptr;
   switch (qos_profile->history) {
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
       history_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -54,7 +54,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       history_string = "invalid";
       break;
   }
-  const char * durability_string = NULL;
+  const char * durability_string = nullptr;
   switch (qos_profile->durability) {
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       durability_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -37,8 +37,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
   }
 
   const char * history_string = NULL;
-  switch (qos_profile->history)
-  {
+  switch (qos_profile->history) {
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
       history_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -10,4 +10,4 @@ void log_debug_qos_profile(const rmw_qos_profile_t * qos_profile);
 
 }
 
-#endif
+#endif  // IMPL__DEBUG_HELPERS_HPP_

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -1,0 +1,13 @@
+#ifndef RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
+#define RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
+
+#include "rmw/types.h"
+
+namespace rmw_zenoh_cpp
+{
+
+void log_debug_qos_profile(const rmw_qos_profile_t * qos_profile);
+
+}
+
+#endif

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__DEBUG_HELPERS_HPP_
 #define IMPL__DEBUG_HELPERS_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -1,5 +1,5 @@
-#ifndef RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
-#define RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
+#ifndef IMPL__DEBUG_HELPERS_HPP_
+#define IMPL__DEBUG_HELPERS_HPP_
 
 #include "rmw/types.h"
 

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -28,8 +28,6 @@
 #include "impl/pubsub_impl.hpp"
 #include "impl/qos.hpp"
 #include "impl/type_support_common.hpp"
-
-
 #include "impl/debug_helpers.hpp"
 
 extern "C"

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -75,7 +75,7 @@ rmw_create_publisher(
   // }
 
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_publisher() qos_profile:");
-  log_debug_qos_profile(qos_profile);
+  rmw_zenoh_cpp::log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -31,7 +31,6 @@
 
 
 #include "impl/debug_helpers.hpp"
-using rmw_zenoh_cpp::log_debug_qos_profile;
 
 extern "C"
 {

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -30,6 +30,9 @@
 #include "impl/type_support_common.hpp"
 
 
+#include "impl/debug_helpers.hpp"
+using rmw_zenoh_cpp::log_debug_qos_profile;
+
 extern "C"
 {
 #include "zenoh/zenoh-ffi.h"
@@ -70,6 +73,9 @@ rmw_create_publisher(
   //   RMW_SET_ERROR_MSG("expected configured QoS profile");
   //   return nullptr;
   // }
+
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_publisher() qos_profile:");
+  log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -33,7 +33,6 @@
 #include "impl/type_support_common.hpp"
 
 #include "impl/debug_helpers.hpp"
-using rmw_zenoh_cpp::log_debug_qos_profile;
 
 extern "C"
 {

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -31,7 +31,6 @@
 #include "impl/pubsub_impl.hpp"
 #include "impl/qos.hpp"
 #include "impl/type_support_common.hpp"
-
 #include "impl/debug_helpers.hpp"
 
 extern "C"

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -32,6 +32,9 @@
 #include "impl/qos.hpp"
 #include "impl/type_support_common.hpp"
 
+#include "impl/debug_helpers.hpp"
+using rmw_zenoh_cpp::log_debug_qos_profile;
+
 extern "C"
 {
 #include "zenoh/zenoh-ffi.h"
@@ -75,6 +78,9 @@ rmw_create_subscription(
   //   RMW_SET_ERROR_MSG("expected configured QoS profile");
   //   return nullptr;
   // }
+
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_subscriber() qos_profile:");
+  log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -79,7 +79,7 @@ rmw_create_subscription(
   // }
 
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_subscriber() qos_profile:");
-  log_debug_qos_profile(qos_profile);
+  rmw_zenoh_cpp::log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);


### PR DESCRIPTION
Adds `DEBUG` log messages that print the requested QoS for publisher and subscribers.