### PR TITLE
Set constant QoS

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(rmw_zenoh_cpp
   src/impl/client_impl.cpp
   src/impl/type_support_common.cpp
   src/impl/qos.cpp
+  src/impl/debug_helpers.cpp
 )
 target_link_libraries(rmw_zenoh_cpp
   fastcdr

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -17,7 +17,7 @@
 
 void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
 {
-  const char * reliability_string = NULL;
+  const char * reliability_string = nullptr;
   switch (qos_profile->reliability) {
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
       reliability_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -73,7 +73,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       break;
   }
 
-  const char * liveliness_string = NULL;
+  const char * liveliness_string = nullptr;
   switch (qos_profile->liveliness) {
     case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
       liveliness_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -81,9 +81,10 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC:
       liveliness_string = "automatic";
       break;
-
-    // we want to print the debug message, but not trigger the compiler warning
-    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC+1:
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC + 1:
+      // Use the previous enum value + 1 to print the debug message for
+      // RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_NODE without triggering the compiler warning for using
+      // a deprecated value
       liveliness_string = "manual by node (deprecated)";
       break;
     case RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC:

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -117,7 +117,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     "    liveliness lease duration: (%zu, %zu)",
     qos_profile->liveliness_lease_duration.sec,
     qos_profile->liveliness_lease_duration.nsec);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    avoid ros namespace conventions: %s",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    avoid ros namespace conventions: %s",
     qos_profile->avoid_ros_namespace_conventions ? "true" : "false");
 
 }

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "debug_helpers.hpp"
 #include "rcutils/logging_macros.h"
 

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -18,8 +18,7 @@
 void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
 {
   const char * reliability_string = NULL;
-  switch (qos_profile->reliability)
-  {
+  switch (qos_profile->reliability) {
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
       reliability_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -55,8 +55,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       break;
   }
   const char * durability_string = NULL;
-  switch (qos_profile->durability)
-  {
+  switch (qos_profile->durability) {
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       durability_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -122,5 +122,4 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     "rmw_zenoh_cpp",
     "    avoid ros namespace conventions: %s",
     qos_profile->avoid_ros_namespace_conventions ? "true" : "false");
-
 }

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -106,7 +106,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     "    deadline: (%zu, %zu)",
     qos_profile->deadline.sec,
     qos_profile->deadline.nsec);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    lifespan: (%zu, %zu)",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    lifespan: (%zu, %zu)",
     qos_profile->lifespan.sec,
     qos_profile->lifespan.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness: %s", liveliness_string);

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -1,0 +1,107 @@
+#include "debug_helpers.hpp"
+#include "rcutils/logging_macros.h"
+
+void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
+{
+  const char * reliability_string = NULL;
+  switch (qos_profile->reliability)
+  {
+    case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
+      reliability_string = "system default";
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_RELIABLE:
+      reliability_string = "reliable";
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT:
+      reliability_string = "best effort";
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
+      reliability_string = "unknown";
+      break;
+    default:
+      reliability_string = "invalid";
+      break;
+  }
+
+  const char * history_string = NULL;
+  switch (qos_profile->history)
+  {
+    case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
+      history_string = "system default";
+      break;
+    case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
+      history_string = "keep last";
+      break;
+    case RMW_QOS_POLICY_HISTORY_KEEP_ALL:
+      history_string = "keep all";
+      break;
+    case RMW_QOS_POLICY_HISTORY_UNKNOWN:
+      history_string = "unknown";
+      break;
+    default:
+      history_string = "invalid";
+      break;
+  }
+  const char * durability_string = NULL;
+  switch (qos_profile->durability)
+  {
+    case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
+      durability_string = "system default";
+      break;
+    case RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL:
+      durability_string = "transient local";
+      break;
+    case RMW_QOS_POLICY_DURABILITY_VOLATILE:
+      durability_string = "volatile";
+      break;
+    case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
+      durability_string = "unknown";
+      break;
+    default:
+      durability_string = "invalid";
+      break;
+  }
+
+  const char * liveliness_string = NULL;
+  switch (qos_profile->liveliness)
+  {
+    case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
+      liveliness_string = "system default";
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC:
+      liveliness_string = "automatic";
+      break;
+
+    // we want to print the debug message, but not trigger the compiler warning
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC+1:
+      liveliness_string = "manual by node (deprecated)";
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC:
+      liveliness_string = "manual by topic";
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
+      liveliness_string = "unknown";
+      break;
+    default:
+      liveliness_string = "invalid";
+      break;
+  }
+
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    reliability: %s", reliability_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    history: %s", history_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    depth: %zu", qos_profile->depth);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    durability: %s", durability_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    deadline: (%zu, %zu)",
+    qos_profile->deadline.sec,
+    qos_profile->deadline.nsec);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    lifespan: (%zu, %zu)",
+    qos_profile->lifespan.sec,
+    qos_profile->lifespan.nsec);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness: %s", liveliness_string);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness lease duration: (%zu, %zu)",
+    qos_profile->liveliness_lease_duration.sec,
+    qos_profile->liveliness_lease_duration.nsec);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    avoid ros namespace conventions: %s",
+    qos_profile->avoid_ros_namespace_conventions ? "true" : "false");
+
+}

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -112,7 +112,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
     qos_profile->lifespan.sec,
     qos_profile->lifespan.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness: %s", liveliness_string);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    liveliness lease duration: (%zu, %zu)",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    liveliness lease duration: (%zu, %zu)",
     qos_profile->liveliness_lease_duration.sec,
     qos_profile->liveliness_lease_duration.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    avoid ros namespace conventions: %s",

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -101,7 +101,9 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    history: %s", history_string);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    depth: %zu", qos_profile->depth);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    durability: %s", durability_string);
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    deadline: (%zu, %zu)",
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "    deadline: (%zu, %zu)",
     qos_profile->deadline.sec,
     qos_profile->deadline.nsec);
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "    lifespan: (%zu, %zu)",

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -74,8 +74,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
   }
 
   const char * liveliness_string = NULL;
-  switch (qos_profile->liveliness)
-  {
+  switch (qos_profile->liveliness) {
     case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
       liveliness_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -36,7 +36,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       break;
   }
 
-  const char * history_string = NULL;
+  const char * history_string = nullptr;
   switch (qos_profile->history) {
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
       history_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -54,7 +54,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
       history_string = "invalid";
       break;
   }
-  const char * durability_string = NULL;
+  const char * durability_string = nullptr;
   switch (qos_profile->durability) {
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
       durability_string = "system default";

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.cpp
@@ -37,8 +37,7 @@ void rmw_zenoh_cpp::log_debug_qos_profile(const rmw_qos_profile_t * qos_profile)
   }
 
   const char * history_string = NULL;
-  switch (qos_profile->history)
-  {
+  switch (qos_profile->history) {
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
       history_string = "system default";
       break;

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -10,4 +10,4 @@ void log_debug_qos_profile(const rmw_qos_profile_t * qos_profile);
 
 }
 
-#endif
+#endif  // IMPL__DEBUG_HELPERS_HPP_

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -1,0 +1,13 @@
+#ifndef RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
+#define RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
+
+#include "rmw/types.h"
+
+namespace rmw_zenoh_cpp
+{
+
+void log_debug_qos_profile(const rmw_qos_profile_t * qos_profile);
+
+}
+
+#endif

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -1,3 +1,17 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef IMPL__DEBUG_HELPERS_HPP_
 #define IMPL__DEBUG_HELPERS_HPP_
 

--- a/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
+++ b/rmw_zenoh_cpp/src/impl/debug_helpers.hpp
@@ -1,5 +1,5 @@
-#ifndef RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
-#define RMW_ZENOH_CPP__DEBUG_HELPERS_HPP_
+#ifndef IMPL__DEBUG_HELPERS_HPP_
+#define IMPL__DEBUG_HELPERS_HPP_
 
 #include "rmw/types.h"
 

--- a/rmw_zenoh_cpp/src/impl/wait_impl.cpp
+++ b/rmw_zenoh_cpp/src/impl/wait_impl.cpp
@@ -148,23 +148,15 @@ bool check_wait_conditions(
   // }
 
   // EVENTS ====================================================================
-  // STUB: NULLIFY/IGNORE ALL EVENTS FOR NOW
-  // Notably, this causes the QoS warning to be suppressed..
-  // Since that arises from the taking of QoS events, which aren't supported by Zenoh at the moment
+  // currently rmw_zenoh_cpp does not handle any events. In the future, if it
+  // does, we'll need to handle it appropriately. This error message is left
+  // here to help remember this, if we accidentally enable some event in the
+  // future.
+
   for (size_t i = 0; i < events->event_count; ++i) {
+    RCUTILS_LOG_ERROR_NAMED("rmw_zenoh_cpp", "woah! we're ignoring an event!");
     events->events[i] = nullptr;
   }
-
-  // TODO(CH3): Handle events
-  // if (events) {
-  //   for (size_t i = 0; i < events->event_count; ++i) {
-  //     auto event = static_cast<rmw_event_t *>(events->events[i]);
-  //     auto custom_event_info = static_cast<rmw_publisher_data_t *>(event->data);
-  //     if (custom_event_info->getListener()->hasEvent(event->event_type)) {
-  //       return true;
-  //     }
-  //   }
-  // }
 
   return stop_wait;
 }

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -29,10 +29,25 @@ extern "C"
 rmw_ret_t
 rmw_take_event(const rmw_event_t * event_handle, void * event_info, bool * taken)
 {
-  (void)event_handle;
   (void)event_info;
 
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_take_event (STUB)");
+  // Because we are currently not (intentionally) requesting any events, this
+  // message is a warning to future-us that we aren't expecting to be here!
+  RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp", "rmw_take_event() WOAH");
+
+  switch (event_handle->event_type) {
+    case RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE:
+      RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp", "rmw_take_event(): requested qos incompatible");
+      break;
+
+    case RMW_EVENT_OFFERED_QOS_INCOMPATIBLE:
+      RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp", "rmw_take_event(): offered qos incompatible");
+      break;
+
+    default:
+      break;
+  }
+
   *taken = true;
 
   return RMW_RET_OK;
@@ -44,7 +59,7 @@ rmw_publisher_event_init(
   const rmw_publisher_t * publisher,
   rmw_event_type_t event_type)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_publisher_event_init (STUB)");
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_publisher_event_init");
 
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(event, RMW_RET_INVALID_ARGUMENT);
@@ -59,15 +74,13 @@ rmw_publisher_event_init(
     eclipse_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  // TODO(CH3) NOTE(CH3): Check if event type is supported
-  // Most likely no. It seems to be a DDS QoS specific thing
-  // if (!internal::is_event_supported(event_type)) {
-  //   RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-  //     "provided event_type is not supported by %s",
-  //     identifier);
-  //   return RMW_RET_UNSUPPORTED;
-  // }
+  if (event_type == RMW_EVENT_OFFERED_QOS_INCOMPATIBLE)
+  {
+    // Because rmw_zenoh_cpp does not currently have multiple QoS, we will not be handling this event.
+    return RMW_RET_UNSUPPORTED;
+  }
 
+  RCUTILS_LOG_ERROR_NAMED("rmw_zenoh_cpp", "accepting rmw_subscriber_event_init() for unhandled event!");
   event->implementation_identifier = publisher->implementation_identifier;
   event->data = publisher->data;
   event->event_type = event_type;
@@ -97,15 +110,13 @@ rmw_subscription_event_init(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION
   );
 
-  // TODO(CH3) NOTE(CH3): Check if event type is supported
-  // Most likely no. It seems to be a DDS QoS specific thing
-  // if (!internal::is_event_supported(event_type)) {
-  //   RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-  //     "provided event_type is not supported by %s",
-  //     identifier);
-  //   return RMW_RET_UNSUPPORTED;
-  // }
+  if (event_type == RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE)
+  {
+    // Because rmw_zenoh_cpp does not currently have multiple QoS, we will not be handling this event.
+    return RMW_RET_UNSUPPORTED;
+  }
 
+  RCUTILS_LOG_ERROR_NAMED("rmw_zenoh_cpp", "accepting rmw_subscriber_event_init() for unhandled event!");
   event->implementation_identifier = subscription->implementation_identifier;
   event->data = subscription->data;
   event->event_type = event_type;

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -28,8 +28,6 @@
 #include "impl/pubsub_impl.hpp"
 #include "impl/qos.hpp"
 #include "impl/type_support_common.hpp"
-
-
 #include "impl/debug_helpers.hpp"
 
 extern "C"

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -75,7 +75,7 @@ rmw_create_publisher(
   // }
 
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_publisher() qos_profile:");
-  log_debug_qos_profile(qos_profile);
+  rmw_zenoh_cpp::log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -31,7 +31,6 @@
 
 
 #include "impl/debug_helpers.hpp"
-using rmw_zenoh_cpp::log_debug_qos_profile;
 
 extern "C"
 {

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -30,6 +30,9 @@
 #include "impl/type_support_common.hpp"
 
 
+#include "impl/debug_helpers.hpp"
+using rmw_zenoh_cpp::log_debug_qos_profile;
+
 extern "C"
 {
 #include "zenoh/zenoh-ffi.h"
@@ -70,6 +73,9 @@ rmw_create_publisher(
   //   RMW_SET_ERROR_MSG("expected configured QoS profile");
   //   return nullptr;
   // }
+
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_publisher() qos_profile:");
+  log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(publisher_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);

--- a/rmw_zenoh_cpp/src/rmw_publisher.cpp
+++ b/rmw_zenoh_cpp/src/rmw_publisher.cpp
@@ -293,16 +293,18 @@ rmw_publisher_get_actual_qos(const rmw_publisher_t * publisher, rmw_qos_profile_
     publisher->implementation_identifier,
     eclipse_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  auto publisher_data = static_cast<rmw_publisher_data_t *>(publisher->data);
-  RCUTILS_LOG_DEBUG_NAMED(
-    "rmw_zenoh_cpp",
-    "Returning placeholder hard-coded QoS for publisher on topic with ID %ld",
-    publisher_data->zn_topic_id_);
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_publisher_get_actual_qos (STUB)");
+
   qos_profile->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-  qos_profile->depth = 1;
+  qos_profile->depth = 1000;
   qos_profile->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   qos_profile->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-  qos_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+  qos_profile->deadline = RMW_QOS_DEADLINE_DEFAULT;
+  qos_profile->lifespan = RMW_QOS_LIFESPAN_DEFAULT;
+  qos_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+  qos_profile->liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+
+  rmw_zenoh_cpp::log_debug_qos_profile(qos_profile);
   return RMW_RET_OK;
 }
 

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -33,7 +33,6 @@
 #include "impl/type_support_common.hpp"
 
 #include "impl/debug_helpers.hpp"
-using rmw_zenoh_cpp::log_debug_qos_profile;
 
 extern "C"
 {

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -566,12 +566,17 @@ rmw_subscription_get_actual_qos(
     subscription->implementation_identifier,
     eclipse_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  auto subscription_data = static_cast<rmw_subscription_data_t *>(subscription->data);
+
   qos_profile->history = RMW_QOS_POLICY_HISTORY_KEEP_LAST;
-  qos_profile->depth = subscription_data->queue_depth_;
+  qos_profile->depth = 1000;
   qos_profile->reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   qos_profile->durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
-  qos_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
+  qos_profile->deadline = RMW_QOS_DEADLINE_DEFAULT;
+  qos_profile->lifespan = RMW_QOS_LIFESPAN_DEFAULT;
+  qos_profile->liveliness = RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT;
+  qos_profile->liveliness_lease_duration = RMW_QOS_LIVELINESS_LEASE_DURATION_DEFAULT;
+
+  rmw_zenoh_cpp::log_debug_qos_profile(qos_profile);
   return RMW_RET_OK;
 }
 

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -31,7 +31,6 @@
 #include "impl/pubsub_impl.hpp"
 #include "impl/qos.hpp"
 #include "impl/type_support_common.hpp"
-
 #include "impl/debug_helpers.hpp"
 
 extern "C"

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -32,6 +32,9 @@
 #include "impl/qos.hpp"
 #include "impl/type_support_common.hpp"
 
+#include "impl/debug_helpers.hpp"
+using rmw_zenoh_cpp::log_debug_qos_profile;
+
 extern "C"
 {
 #include "zenoh/zenoh-ffi.h"
@@ -75,6 +78,9 @@ rmw_create_subscription(
   //   RMW_SET_ERROR_MSG("expected configured QoS profile");
   //   return nullptr;
   // }
+
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_subscriber() qos_profile:");
+  log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);

--- a/rmw_zenoh_cpp/src/rmw_subscriber.cpp
+++ b/rmw_zenoh_cpp/src/rmw_subscriber.cpp
@@ -79,7 +79,7 @@ rmw_create_subscription(
   // }
 
   RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "rmw_create_subscriber() qos_profile:");
-  log_debug_qos_profile(qos_profile);
+  rmw_zenoh_cpp::log_debug_qos_profile(qos_profile);
 
   RMW_CHECK_ARGUMENT_FOR_NULL(subscription_options, nullptr);
   RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);


### PR DESCRIPTION
Builds on #32 

Hard-codes QoS to reflect the TCP behavior of Zenoh. Removes the QoS events from the waitset because they aren't relevant anymore, with "static" QoS. Adds some debug/error messages to help future developers hopefully be less-confused than I was :smiley: