### PR TITLE
Fix exports

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -64,6 +64,7 @@ ament_target_dependencies(rmw_zenoh_cpp
   rcutils
   rmw
   zenoh
+  zenoh_vendor
   rosidl_typesupport_zenoh_c
   rosidl_typesupport_zenoh_cpp
   rosidl_generator_c
@@ -83,7 +84,7 @@ ament_export_dependencies(rosidl_typesupport_zenoh_c)
 ament_export_dependencies(rosidl_generator_c)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
-ament_export_dependencies(zenoh)
+ament_export_dependencies(zenoh_vendor)
 
 register_rmw_implementation(
   "c:rosidl_typesupport_c:rosidl_typesupport_zenoh_c"

--- a/rmw_zenoh_cpp/rmw_zenoh_cpp-extras.cmake
+++ b/rmw_zenoh_cpp/rmw_zenoh_cpp-extras.cmake
@@ -14,11 +14,9 @@
 
 # copied from rmw_fastrtps_cpp/rmw_fastrtps_cpp-extras.cmake
 
-find_package(fastrtps_cmake_module REQUIRED)
-find_package(fastcdr REQUIRED CONFIG)
-find_package(fastrtps REQUIRED CONFIG)
-find_package(FastRTPS REQUIRED MODULE)
+find_package(zenoh_vendor REQUIRED)
+find_package(zenoh REQUIRED)
 
-list(APPEND rmw_fastrtps_cpp_INCLUDE_DIRS ${FastRTPS_INCLUDE_DIR})
+list(APPEND rmw_zenoh_cpp_INCLUDE_DIRS ${zenoh_INCLUDE_DIRS})
 # specific order: dependents before dependencies
-list(APPEND rmw_fastrtps_cpp_LIBRARIES fastrtps fastcdr)
+list(APPEND rmw_zenoh_cpp_LIBRARIES ${zenoh_LIBRARIES})


### PR DESCRIPTION
This PR fixes the exports so that downstream packages have access to zenoh include dirs and libraries.