### PR TITLE
Update CARGO_BUILD_FLAG

### DIFF
--- a/zenoh_vendor/CMakeLists.txt
+++ b/zenoh_vendor/CMakeLists.txt
@@ -10,7 +10,7 @@ if(DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CARGO_BUILD_FLAG "")
+  set(CARGO_BUILD_FLAG "Debug")
   set(ZENOH_OBJECTS_DIR "debug")
 else()
   set(CARGO_BUILD_FLAG "--release")


### PR DESCRIPTION
This updates `CARGO_BUILD_FLAG` to match `BUILD_TYPE` in https://github.com/eclipse-zenoh/zenoh-c/blob/master/Makefile#L27