### PR TITLE
Make rmw_zenoh compatible with zenoh_plugin_dds

### DIFF
--- a/rmw_zenoh_common_cpp/CMakeLists.txt
+++ b/rmw_zenoh_common_cpp/CMakeLists.txt
@@ -22,6 +22,10 @@ find_package(rosidl_typesupport_zenoh_cpp REQUIRED)
 
 include_directories(include)
 
+if(DEFINED ZENOH_DDS_COMPAT)
+  add_definitions(-DZENOH_DDS_COMPAT=${ZENOH_DDS_COMPAT})
+endif()
+
 add_library(rmw_zenoh_common_cpp
   src/rmw_zenoh_common_event.cpp
   src/rmw_zenoh_common_get_node_info_and_types.cpp

--- a/rmw_zenoh_common_cpp/include/rmw_zenoh_common_cpp/rmw_zenoh_common.h
+++ b/rmw_zenoh_common_cpp/include/rmw_zenoh_common_cpp/rmw_zenoh_common.h
@@ -15,6 +15,8 @@
 #ifndef RMW_ZENOH_COMMON_CPP__RMW_ZENOH_COMMON_H_
 #define RMW_ZENOH_COMMON_CPP__RMW_ZENOH_COMMON_H_
 
+#define ZN_TOPIC_PREFIX "/rt"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/rmw_zenoh_common_cpp/src/rmw_zenoh_common_publisher.cpp
+++ b/rmw_zenoh_common_cpp/src/rmw_zenoh_common_publisher.cpp
@@ -154,7 +154,8 @@ rmw_zenoh_common_create_publisher(
   // even in the same Zenoh network, because the ID is never transmitted over the wire.
   // Conversely, the ID used in two communicating processes cannot be used to determine if they are
   // using the same topic or not.
-  publisher_data->zn_topic_id_ = zn_declare_resource(session, zn_rname(publisher->topic_name));
+  std::string zn_topic_name = std::string(ZN_TOPIC_PREFIX) + publisher->topic_name;
+  publisher_data->zn_topic_id_ = zn_declare_resource(session, zn_rname(zn_topic_name.c_str()));
 
   // Assign publisher data members
   publisher_data->zn_session_ = session;

--- a/rmw_zenoh_common_cpp/src/rmw_zenoh_common_publisher.cpp
+++ b/rmw_zenoh_common_cpp/src/rmw_zenoh_common_publisher.cpp
@@ -154,7 +154,11 @@ rmw_zenoh_common_create_publisher(
   // even in the same Zenoh network, because the ID is never transmitted over the wire.
   // Conversely, the ID used in two communicating processes cannot be used to determine if they are
   // using the same topic or not.
-  std::string zn_topic_name = std::string(ZN_TOPIC_PREFIX) + publisher->topic_name;
+  #ifdef ZENOH_DDS_COMPAT
+    std::string zn_topic_name = std::string(ZN_TOPIC_PREFIX) + publisher->topic_name; 
+  #else
+    const std::string &zn_topic_name = publisher->topic_name;
+  #endif
   publisher_data->zn_topic_id_ = zn_declare_resource(session, zn_rname(zn_topic_name.c_str()));
 
   // Assign publisher data members

--- a/rmw_zenoh_common_cpp/src/rmw_zenoh_common_subscriber.cpp
+++ b/rmw_zenoh_common_cpp/src/rmw_zenoh_common_subscriber.cpp
@@ -201,7 +201,11 @@ rmw_zenoh_common_create_subscription(
 
     // We initialise subscribers ONCE (otherwise we'll get duplicate messages)
     // The topic name will be the same for any duplicate subscribers, so it is ok
-    std::string zn_topic_name = std::string(ZN_TOPIC_PREFIX) + subscription->topic_name;
+    #ifdef ZENOH_DDS_COMPAT
+      std::string zn_topic_name = std::string(ZN_TOPIC_PREFIX) + subscription->topic_name;
+    #else
+      const std::string &zn_topic_name = subscription->topic_name;
+    #endif
     subscription_data->zn_subscriber_ = zn_declare_subscriber(
       subscription_data->zn_session_,
       zn_rname(zn_topic_name.c_str()),

--- a/rmw_zenoh_common_cpp/src/rmw_zenoh_common_subscriber.cpp
+++ b/rmw_zenoh_common_cpp/src/rmw_zenoh_common_subscriber.cpp
@@ -201,9 +201,10 @@ rmw_zenoh_common_create_subscription(
 
     // We initialise subscribers ONCE (otherwise we'll get duplicate messages)
     // The topic name will be the same for any duplicate subscribers, so it is ok
+    std::string zn_topic_name = std::string(ZN_TOPIC_PREFIX) + subscription->topic_name;
     subscription_data->zn_subscriber_ = zn_declare_subscriber(
       subscription_data->zn_session_,
-      zn_rname(subscription->topic_name),
+      zn_rname(zn_topic_name.c_str()),
       zn_subinfo_default(),  // NOTE(CH3): Default for now
       subscription_data->zn_sub_callback,
       nullptr);


### PR DESCRIPTION
zenoh_plugin_dds adds a /rt prefix to every ROS2 topic in Zenoh.
This change adds the same prefix to rmw_zenoh. 

This way nodes using rmw_zenoh may communicate with nodes running a DDS based ROS2 backend with the zenoh-bridge-dds in the middle.

We tested this change with the following configuration:
- a node running on Linux with the CycloneDDS backend
- zenoh-bridge-dds
- zenoh-router 
- and an Android app using rmw_zenoh connecting to the router in client mode.
