### PR TITLE
Bring zenoh router via vendor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,6 @@ Install latest rustc.
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
-Install zenohd router
-> Note: The manual zenoh router installation won't be required in the future.
-```bash
-echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
-sudo apt update && sudo apt install zenoh -y
-```
-
 Build `rmw_zenoh_cpp`
 
 ```bash

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>zenoh_c_vendor</build_depend>
+  <build_depend>zenohd_vendor</build_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>fastcdr</depend>

--- a/zenohd_vendor/CMakeLists.txt
+++ b/zenohd_vendor/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16)
+project(zenohd_vendor)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+
+find_package(ament_cmake REQUIRED)
+
+include(ExternalProject)
+
+ExternalProject_Add(
+    zenoh
+    PREFIX ${CMAKE_BINARY_DIR}/_cargo_deps
+    GIT_REPOSITORY https://github.com/eclipse-zenoh/zenoh.git
+    GIT_TAG master
+    BUILD_COMMAND cargo build --package zenohd --release
+    CONFIGURE_COMMAND "" # Disable the configure step
+    INSTALL_COMMAND ""
+    BUILD_IN_SOURCE 1
+)
+
+# Install the zenohd executable from the rust crate
+install(
+    PROGRAMS ${CMAKE_BINARY_DIR}/_cargo_deps/src/zenoh/target/release/zenohd
+    DESTINATION bin
+)
+
+# TODO(francocipollone): Install zenoh router plugins
+
+ament_package()

--- a/zenohd_vendor/package.xml
+++ b/zenohd_vendor/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>zenohd_vendor</name>
+  <version>0.0.1</version>
+  <description>Vendor pkg to install zenoh router</description>
+  <maintainer email="franco.c@ekumenlabs.com">FrancoCipollone</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <!-- <build_depend>cargo</build_depend> -->
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
Related to #64 

### Summary

This is an open debate for bringing zenoh router into the workspace.
A simple implementation is proposed here for the time being.


### Pendings
 - [x] Verify this is the implementation we want
 - [x] Update readme file 
 
 ### Test it 
 
 `zenohd` by default uses a configuration in which it uses rest API plugin. In our case we are not using plugins and therefore we are not bringing them for the time being.
For testing it there, after colcon build + source install:

Run `ros2 run rmw_zenoh_cpp init_rmw_zenoh_router`