### PR TITLE
Refactor GraphCache to support multiple types for the same topic.

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(rmw_zenoh_cpp SHARED
   src/detail/identifier.cpp
   src/detail/graph_cache.cpp
   src/detail/guard_condition.cpp
+  src/detail/liveliness_utils.cpp
   src/detail/message_type_support.cpp
   src/detail/rmw_data_types.cpp
   src/detail/service_type_support.cpp

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -425,16 +426,13 @@ void GraphCache::parse_del(const std::string & keyexpr)
         // Here we iterate throught the list of publishers and remove the one
         // with matching name, type and qos.
         // TODO(Yadunund): This can be more optimal than O(n) with some caching.
-        auto erase_it = found_node->pubs.begin();
-        for (; erase_it != found_node->pubs.end(); ++erase_it) {
-          const auto & pub = *erase_it;
-          if (pub.topic == node->pubs.at(0).topic &&
+        auto erase_it = std::find_if(
+          found_node->pubs.begin(), found_node->pubs.end(),
+          [&node](const auto & pub) {
+            return pub.topic == node->pubs.at(0).topic &&
             pub.type == node->pubs.at(0).type &&
-            pub.qos == node->pubs.at(0).qos)
-          {
-            break;
-          }
-        }
+            pub.qos == node->pubs.at(0).qos;
+          });
         if (erase_it != found_node->pubs.end()) {
           found_node->pubs.erase(erase_it);
           // Bookkeeping

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -93,14 +93,15 @@ void GraphCache::parse_put(const std::string & keyexpr)
             graph_topic_data->info_.type_,
             graph_topic_data));
         if (!type_insertion.second) {
-          // We have another instance of a pub/sub over the same topic and type so we increment the counters.
+          // We have another instance of a pub/sub over the same topic and type so we increment
+          // the counters.
           auto & existing_graph_topic = type_insertion.first->second;
           existing_graph_topic->stats_.pub_count_ += pub_count;
           existing_graph_topic->stats_.pub_count_ += sub_count;
         }
       }
 
-      // Bookkeeping: We update graph_topic_ which keeps track of topics across all nodes in the graph.
+      // Bookkeeping: Update graph_topic_ which keeps track of topics across all nodes in the graph.
       if (update_cache) {
         auto cache_topic_it = graph_topics_.find(entity.topic_info()->name_);
         if (cache_topic_it == graph_topics_.end()) {
@@ -113,8 +114,8 @@ void GraphCache::parse_put(const std::string & keyexpr)
             {entity.topic_info()->type_, topic_data_ptr}
           };
         } else {
-          // If a TopicData entry for the same type exists in the topic map, update pub/sub counts or
-          // else create an new TopicData.
+          // If a TopicData entry for the same type exists in the topic map, update pub/sub counts
+          // or else create an new TopicData.
           auto topic_data_insertion =
             cache_topic_it->second.insert(std::make_pair(entity.topic_info()->type_, nullptr));
           if (topic_data_insertion.second) {
@@ -251,7 +252,7 @@ void GraphCache::parse_del(const std::string & keyexpr)
         return;
       }
 
-      // Decrement the relevant counters. Check if both counters are 0 and if so remove from graph_node.
+      // Decrement the relevant counters. If both counters are 0 remove from graph_node.
       auto & existing_topic_data = topic_data_it->second;
       existing_topic_data->stats_.pub_count_ -= pub_count;
       existing_topic_data->stats_.sub_count_ -= sub_count;
@@ -265,7 +266,7 @@ void GraphCache::parse_del(const std::string & keyexpr)
         topic_map.erase(entity.topic_info()->name_);
       }
 
-      // Bookkeeping: We update graph_topic_ which keeps track of topics across all nodes in the graph.
+      // Bookkeeping: Update graph_topic_ which keeps track of topics across all nodes in the graph.
       if (update_cache) {
         auto cache_topic_it = graph_topics_.find(entity.topic_info()->name_);
         if (cache_topic_it == graph_topics_.end()) {
@@ -276,7 +277,7 @@ void GraphCache::parse_del(const std::string & keyexpr)
         } else {
           auto cache_topic_data_it = cache_topic_it->second.find(entity.topic_info()->type_);
           if (cache_topic_data_it != cache_topic_it->second.end()) {
-            // Decrement the relevant counters. Check if both counters are 0 and if so remove from cache.
+            // Decrement the relevant counters. If both counters are 0 remove from cache.
             cache_topic_data_it->second->stats_.pub_count_ -= pub_count;
             cache_topic_data_it->second->stats_.sub_count_ -= sub_count;
             if (cache_topic_data_it->second->stats_.pub_count_ == 0 &&
@@ -289,7 +290,6 @@ void GraphCache::parse_del(const std::string & keyexpr)
               graph_topics_.erase(cache_topic_it);
             }
           }
-
         }
       }
 
@@ -321,17 +321,18 @@ void GraphCache::parse_del(const std::string & keyexpr)
   if (entity.type() == EntityType::Node) {
     // Node
     // The liveliness tokens to remove pub/subs should be received before the one to remove a node
-    // given the reliability QoS for liveliness subs. However, if we find any pubs/subs present in the node below,
-    // we should update the count in graph_topics_.
+    // given the reliability QoS for liveliness subs. However, if we find any pubs/subs present in
+    // the node below, we should update the count in graph_topics_.
     const auto graph_node = node_it->second;
     if (!graph_node->pubs_.empty() || !graph_node->subs_.empty()) {
       RCUTILS_LOG_WARN_NAMED(
         "rmw_zenoh_cpp",
-        "Received liveliness token to remove node /%s from the graph before all pub/subs for this node have been removed. "
-        "Report this issue.",
+        "Received liveliness token to remove node /%s from the graph before all pub/subs for this "
+        "node have been removed. Report this issue.",
         entity.node_info().name_.c_str()
       );
-      // TODO(Yadunund): Iterate through the nodes pubs_ and subs_ and decrement topic count in graph_topics_.
+      // TODO(Yadunund): Iterate through the nodes pubs_ and subs_ and decrement topic count in
+      // graph_topics_.
     }
     ns_it->second.erase(entity.node_info().name_);
     RCUTILS_LOG_WARN_NAMED(

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -115,13 +115,7 @@ void GraphCache::parse_put(const std::string & keyexpr)
       GraphNode::TopicMap::iterator cache_topic_it = graph_topics_.find(topic_info.name_);
       if (cache_topic_it == graph_topics_.end()) {
         // First time this topic name is added to the graph.
-        auto topic_data_ptr = std::make_shared<TopicData>(
-          topic_info,
-          TopicStats{pub_count, sub_count}
-        );
-        graph_topics_[topic_info.name_] = GraphNode::TopicDataMap{
-          {topic_info.type_, topic_data_ptr}
-        };
+        graph_topics_[topic_info.name_] = std::move(topic_data_map);
       } else {
         // If a TopicData entry for the same type exists in the topic map, update pub/sub counts
         // or else create an new TopicData.
@@ -176,7 +170,7 @@ void GraphCache::parse_put(const std::string & keyexpr)
   if (ns_it == graph_.end()) {
     NodeMap node_map = {
       {entity.node_name(), make_graph_node(entity)}};
-    graph_.insert(std::make_pair(entity.node_namespace(), std::move(node_map)));
+    graph_.emplace(std::make_pair(entity.node_namespace(), std::move(node_map)));
     RCUTILS_LOG_WARN_NAMED(
       "rmw_zenoh_cpp", "Added node /%s to a new namespace %s in the graph.",
       entity.node_name().c_str(),

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -91,7 +91,17 @@ public:
   rmw_ret_t get_topic_names_and_types(
     rcutils_allocator_t * allocator,
     bool no_demangle,
-    rmw_names_and_types_t * topic_names_and_types);
+    rmw_names_and_types_t * topic_names_and_types) const;
+
+  rmw_ret_t count_publishers(
+    const rmw_node_t * node,
+    const char * topic_name,
+    size_t * count) const;
+
+  rmw_ret_t count_subscriptions(
+    const rmw_node_t * node,
+    const char * topic_name,
+    size_t * count) const;
 
 private:
   /*

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -43,6 +43,7 @@ struct TopicStats
 };
 using TopicStatsPtr = std::unique_ptr<TopicStats>;
 using TopicInfo = liveliness::TopicInfo;
+
 ///=============================================================================
 struct TopicData
 {
@@ -64,18 +65,10 @@ struct GraphNode
   // TODO(Yadunund): Should enclave be the parent to the namespace key and not within a Node?
   std::string enclave_;
 
-  // Hash topic data using "type" string to only support unique topic_types.
-  // TODO(Yadunund): Should we also factor the "qos" into the cache?
-  struct TopicDataHash
-  {
-    std::size_t operator()(const TopicDataPtr & data) const
-    {
-      return std::hash<std::string>{}(data->info_.type_);
-    }
-  };
-  // Map topic name to a set of TopicData to support multiple types per topic.
-  using TopicDataSet = std::unordered_set<TopicDataPtr, TopicDataHash>;
-  using TopicMap = std::unordered_map<std::string, TopicDataSet>;
+  // Map topic type to TopicData
+  using TopicDataMap = std::unordered_map<std::string, TopicDataPtr>;
+  // Map topic name to TopicDataMap
+  using TopicMap = std::unordered_map<std::string, TopicDataMap>;
   TopicMap pubs_ = {};
   TopicMap subs_ = {};
 };

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -41,16 +41,15 @@ struct TopicStats
   // Constructor which initializes counters to 0.
   TopicStats(std::size_t pub_count, std::size_t sub_count);
 };
-using TopicInfo = liveliness::TopicInfo;
 
 ///=============================================================================
 struct TopicData
 {
-  TopicInfo info_;
+  liveliness::TopicInfo info_;
   TopicStats stats_;
 
   TopicData(
-    TopicInfo info,
+    liveliness::TopicInfo info,
     TopicStats stats);
 };
 using TopicDataPtr = std::shared_ptr<TopicData>;
@@ -94,12 +93,10 @@ public:
     rmw_names_and_types_t * topic_names_and_types) const;
 
   rmw_ret_t count_publishers(
-    const rmw_node_t * node,
     const char * topic_name,
     size_t * count) const;
 
   rmw_ret_t count_subscriptions(
-    const rmw_node_t * node,
     const char * topic_name,
     size_t * count) const;
 

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -122,8 +122,11 @@ private:
   namespace_2:
     node_n:
   */
+
+  using NodeMap = std::unordered_map<std::string, GraphNodePtr>;
+  using NamespaceMap = std::unordered_map<std::string, NodeMap>;
   // Map namespace to a map of <node_name, GraphNodePtr>.
-  std::unordered_map<std::string, std::unordered_map<std::string, GraphNodePtr>> graph_ = {};
+  NamespaceMap graph_ = {};
 
   // Optimize topic lookups across the graph.
   GraphNode::TopicMap graph_topics_ = {};

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -41,7 +41,6 @@ struct TopicStats
   // Constructor which initializes counters to 0.
   TopicStats(std::size_t pub_count, std::size_t sub_count);
 };
-using TopicStatsPtr = std::unique_ptr<TopicStats>;
 using TopicInfo = liveliness::TopicInfo;
 
 ///=============================================================================
@@ -119,9 +118,8 @@ private:
   // Map namespace to a map of <node_name, GraphNodePtr>.
   std::unordered_map<std::string, std::unordered_map<std::string, GraphNodePtr>> graph_ = {};
 
-  // Optimize topic lookups across the graph by mapping "topic_name?topic_type" keys to their pub/sub counts.
-  // TODO(Yadunund): Consider storing a set of NodePtrs for each key.
-  std::unordered_map<std::string, TopicStatsPtr> graph_topics_ = {};
+  // Optimize topic lookups across the graph.
+  GraphNode::TopicMap graph_topics_ = {};
 
   mutable std::mutex graph_mutex_;
 };

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -1,0 +1,342 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "liveliness_utils.hpp"
+
+#include <sstream>
+
+#include "rcpputils/scope_exit.hpp"
+#include "rcutils/logging_macros.h"
+
+
+namespace liveliness
+{
+
+///=============================================================================
+NodeInfo::NodeInfo(
+  std::size_t domain_id,
+  std::string ns,
+  std::string name,
+  std::string enclave)
+: domain_id_(std::move(domain_id)),
+  ns_(std::move(ns)),
+  name_(std::move(name)),
+  enclave_(std::move(enclave))
+{
+  // Do nothing.
+}
+
+///=============================================================================
+TopicInfo::TopicInfo(
+  std::string name,
+  std::string type,
+  std::string qos)
+: name_(std::move(name)),
+  type_(std::move(type)),
+  qos_(std::move(qos))
+{
+  // Do nothing.
+}
+
+///=============================================================================
+namespace
+{
+
+/// The admin space used to prefix the liveliness tokens.
+static const std::string ADMIN_SPACE = "@ros2_lv";
+static const std::string NODE_STR = "NN";
+static const std::string PUB_STR = "MP";
+static const std::string SUB_STR = "MS";
+static const std::string SRV_STR = "SS";
+static const std::string CLI_STR = "SC";
+
+static const std::unordered_map<EntityType, std::string> entity_to_str = {
+  {EntityType::Node, NODE_STR},
+  {EntityType::Publisher, PUB_STR},
+  {EntityType::Subscription, SUB_STR},
+  {EntityType::Service, SRV_STR},
+  {EntityType::Client, CLI_STR}
+};
+
+static const std::unordered_map<std::string, EntityType> str_to_entity = {
+  {NODE_STR, EntityType::Node},
+  {PUB_STR, EntityType::Publisher},
+  {SUB_STR, EntityType::Subscription},
+  {SRV_STR, EntityType::Service},
+  {CLI_STR, EntityType::Client}
+};
+
+} // namespace
+
+///=============================================================================
+std::string subscription_token(size_t domain_id)
+{
+  std::string token = ADMIN_SPACE + "/" + std::to_string(domain_id) + "/**";
+  return token;
+}
+
+///=============================================================================
+Entity::Entity(
+  EntityType type,
+  NodeInfo node_info,
+  std::optional<TopicInfo> topic_info)
+: type_(std::move(type)),
+  node_info_(std::move(node_info)),
+  topic_info_(std::move(topic_info))
+{
+  /**
+   * Set the liveliness token for the particular entity.
+   *
+   * The liveliness token keyexprs are in the form:
+   *
+   * <ADMIN_SPACE>/<domainid>/<entity>/<namespace>/<nodename>
+   *
+   * Where:
+   *  <domainid> - A number set by the user to "partition" graphs.  Roughly equivalent to the domain ID in DDS.
+   *  <entity> - The type of entity.  This can be one of "NN" for a node, "MP" for a publisher, "MS" for a subscription, "SS" for a service server, or "SC" for a service client.
+   *  <namespace> - The ROS namespace for this entity.  If the namespace is absolute, this function will add in an _ for later parsing reasons.
+   *  <nodename> - The ROS node name for this entity.
+   *
+   * For entities with topic infomation, the liveliness token keyexpr have additional fields:
+   *
+   * <ADMIN_SPACE>/<domainid>/<entity>/<namespace>/<nodename>/<topic_name>/<topic_type>/<topic_qos>
+   */
+  std::stringstream token_ss;
+  const auto & ns = node_info_.ns_;
+  token_ss << ADMIN_SPACE << "/" << node_info_.domain_id_ << "/" << entity_to_str.at(type_) << ns;
+  // An empty namespace from rcl will contain "/" but zenoh does not allow keys with "//".
+  // Hence we add an "_" to denote an empty namespace such that splitting the key
+  // will always result in 5 parts.
+  if (ns == "/") {
+    token_ss << "_/";
+  } else {
+    token_ss << "/";
+  }
+  // Finally append node name.
+  token_ss << node_info_.name_;
+  // If this entity has a topic info, append it to the token.
+  if (topic_info_.has_value()) {
+    const auto & topic_info = this->topic_info_.value();
+    // Note: We don't append a leading "/" as we expect the ROS topic name to start with a "/".
+    token_ss << topic_info.name_ + "/" + topic_info.type_ + "/" + topic_info.qos_;
+  }
+
+  this->keyexpr_ = token_ss.str();
+}
+
+///=============================================================================
+std::optional<Entity> Entity::make(
+  EntityType type,
+  NodeInfo node_info,
+  std::optional<TopicInfo> topic_info)
+{
+  if (entity_to_str.find(type) == entity_to_str.end()) {
+    RCUTILS_SET_ERROR_MSG("Invalid entity type.");
+    return std::nullopt;
+  }
+  if (node_info.ns_.empty() || node_info.name_.empty()) {
+    RCUTILS_SET_ERROR_MSG("Invalid node_info for entity.");
+    return std::nullopt;
+  }
+  if (type != EntityType::Node && !topic_info.has_value()) {
+    RCUTILS_SET_ERROR_MSG("Invalid topic_info for entity.");
+    return std::nullopt;
+  }
+
+  Entity entity{std::move(type), std::move(node_info), std::move(topic_info)};
+  return std::move(entity);
+}
+
+///=============================================================================
+std::optional<Entity> Entity::make(const std::string & keyexpr)
+{
+
+  std::vector<std::string> parts = split_keyexpr(keyexpr);
+  // At minimum, a token will contain 5 parts (ADMIN_SPACE, domain_id, entity_str, namespace, node_name).
+  // Basic validation.
+  if (parts.size() < 5) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Received invalid liveliness token");
+    return std::nullopt;
+  }
+  for (const std::string & p : parts) {
+    if (p.empty()) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_zenoh_cpp",
+        "Received invalid liveliness token");
+      return std::nullopt;
+    }
+  }
+
+  if (parts[0] != ADMIN_SPACE) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Received liveliness token with invalid admin space.");
+    return std::nullopt;
+  }
+
+  // Get the entity, ie NN, MP, MS, SS, SC.
+  std::string & entity_str = parts[2];
+  const auto entity_it = str_to_entity.find(entity_str);
+  if (entity_it == str_to_entity.end()) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Received liveliness token with invalid entity.");
+    return std::nullopt;
+  }
+
+  EntityType entity_type = entity_it->second;
+  std::size_t domain_id = std::stoul(parts[1]);
+  std::string ns = parts[3] == "_" ? "/" : "/" + std::move(parts[3]);
+  std::string node_name = std::move(parts[4]);
+  std::optional<TopicInfo> topic_info = std::nullopt;
+
+  // Populate topic_info if we have a token for an entity other than a node.
+  if (entity_type != EntityType::Node) {
+    if (parts.size() < 8) {
+      RCUTILS_LOG_ERROR_NAMED(
+        "rmw_zenoh_cpp",
+        "Received liveliness token for non-node entity without required parameters.");
+      return std::nullopt;
+    }
+    topic_info = TopicInfo{
+      "/" + std::move(parts[5]),
+      std::move(parts[6]),
+      std::move(parts[7])};
+  }
+
+  return Entity{
+    std::move(entity_type),
+    NodeInfo{std::move(domain_id), std::move(ns), std::move(node_name), ""},
+    std::move(topic_info)};
+}
+
+///=============================================================================
+const EntityType & Entity::type() const
+{
+  return this->type_;
+}
+
+///=============================================================================
+const NodeInfo & Entity::node_info() const
+{
+  return this->node_info_;
+}
+
+///=============================================================================
+const std::optional<TopicInfo> & Entity::topic_info() const
+{
+  return this->topic_info_;
+}
+
+///=============================================================================
+const std::string & Entity::keyexpr() const
+{
+  return this->keyexpr_;
+}
+
+///=============================================================================
+bool PublishToken::put(
+  z_owned_session_t * session,
+  const std::string & token)
+{
+  if (!z_session_check(session)) {
+    RCUTILS_SET_ERROR_MSG("The zenoh session is invalid.");
+    return false;
+  }
+
+  // TODO(Yadunund): z_keyexpr_new creates a copy so find a way to avoid it.
+  z_owned_keyexpr_t keyexpr = z_keyexpr_new(token.c_str());
+  auto drop_keyexpr = rcpputils::make_scope_exit(
+    [&keyexpr]() {
+      z_drop(z_move(keyexpr));
+    });
+  if (!z_keyexpr_check(&keyexpr)) {
+    RCUTILS_SET_ERROR_MSG("invalid keyexpression generation for liveliness publication.");
+    return false;
+  }
+  RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp", "Sending PUT on %s", token.c_str());
+  z_put_options_t options = z_put_options_default();
+  options.encoding = z_encoding(Z_ENCODING_PREFIX_EMPTY, NULL);
+  if (z_put(z_loan(*session), z_keyexpr(token.c_str()), nullptr, 0, &options) < 0) {
+    RCUTILS_SET_ERROR_MSG("unable to publish liveliness for node creation");
+    return false;
+  }
+
+  return true;
+}
+
+///=============================================================================
+bool PublishToken::del(
+  z_owned_session_t * session,
+  const std::string & token)
+{
+  if (!z_session_check(session)) {
+    RCUTILS_SET_ERROR_MSG("The zenoh session is invalid.");
+    return false;
+  }
+
+  // TODO(Yadunund): z_keyexpr_new creates a copy so find a way to avoid it.
+  z_owned_keyexpr_t keyexpr = z_keyexpr_new(token.c_str());
+  auto drop_keyexpr = rcpputils::make_scope_exit(
+    [&keyexpr]() {
+      z_drop(z_move(keyexpr));
+    });
+  if (!z_keyexpr_check(&keyexpr)) {
+    RCUTILS_SET_ERROR_MSG("invalid key-expression generation for liveliness publication.");
+    return false;
+  }
+  RCUTILS_LOG_WARN_NAMED("rmw_zenoh_cpp", "Sending DELETE on %s", token.c_str());
+  const z_delete_options_t options = z_delete_options_default();
+  if (z_delete(z_loan(*session), z_loan(keyexpr), &options) < 0) {
+    RCUTILS_SET_ERROR_MSG("failed to delete liveliness key");
+    return false;
+  }
+
+  return true;
+}
+
+///=============================================================================
+std::vector<std::string> split_keyexpr(
+  const std::string & keyexpr,
+  const char delim)
+{
+  std::vector<std::size_t> delim_idx = {};
+  // Insert -1 for starting position to make the split easier when using substr.
+  delim_idx.push_back(-1);
+  std::size_t idx = 0;
+  for (auto it = keyexpr.begin(); it != keyexpr.end(); ++it) {
+    if (*it == delim) {
+      delim_idx.push_back(idx);
+    }
+    ++idx;
+  }
+  std::vector<std::string> result = {};
+  try {
+    for (std::size_t i = 1; i < delim_idx.size(); ++i) {
+      const auto & prev_idx = delim_idx.at(i - 1);
+      const auto & idx = delim_idx.at(i);
+      result.push_back(keyexpr.substr(prev_idx + 1, idx - prev_idx - 1));
+    }
+  } catch (const std::exception & e) {
+    printf("%s\n", e.what());
+    return {};
+  }
+  // Finally add the last substr.
+  result.push_back(keyexpr.substr(delim_idx.back() + 1));
+  return result;
+}
+
+} // namespace liveliness

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -175,7 +175,7 @@ std::vector<std::string> split_keyexpr(
   // Insert -1 for starting position to make the split easier when using substr.
   delim_idx.push_back(-1);
   std::size_t idx = 0;
-  for (auto it = keyexpr.begin(); it != keyexpr.end(); ++it) {
+  for (std::string::const_iterator it = keyexpr.begin(); it != keyexpr.end(); ++it) {
     if (*it == delim) {
       delim_idx.push_back(idx);
     }
@@ -184,8 +184,8 @@ std::vector<std::string> split_keyexpr(
   std::vector<std::string> result = {};
   try {
     for (std::size_t i = 1; i < delim_idx.size(); ++i) {
-      const auto & prev_idx = delim_idx.at(i - 1);
-      const auto & idx = delim_idx.at(i);
+      const size_t prev_idx = delim_idx[i - 1];
+      const size_t idx = delim_idx[i];
       result.push_back(keyexpr.substr(prev_idx + 1, idx - prev_idx - 1));
     }
   } catch (const std::exception & e) {

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -266,7 +266,7 @@ std::optional<Entity> Entity::make(const std::string & keyexpr)
 }
 
 ///=============================================================================
-const EntityType & Entity::type() const
+EntityType Entity::type() const
 {
   return this->type_;
 }
@@ -287,13 +287,13 @@ std::string Entity::node_enclave() const
 }
 
 ///=============================================================================
-const std::optional<TopicInfo> & Entity::topic_info() const
+std::optional<TopicInfo> Entity::topic_info() const
 {
   return this->topic_info_;
 }
 
 ///=============================================================================
-const std::string & Entity::keyexpr() const
+std::string Entity::keyexpr() const
 {
   return this->keyexpr_;
 }

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -14,7 +14,12 @@
 
 #include "liveliness_utils.hpp"
 
+#include <optional>
 #include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "rcpputils/scope_exit.hpp"
@@ -55,12 +60,12 @@ namespace
 {
 
 /// The admin space used to prefix the liveliness tokens.
-static const std::string ADMIN_SPACE = "@ros2_lv";
-static const std::string NODE_STR = "NN";
-static const std::string PUB_STR = "MP";
-static const std::string SUB_STR = "MS";
-static const std::string SRV_STR = "SS";
-static const std::string CLI_STR = "SC";
+static const char ADMIN_SPACE[] = "@ros2_lv";
+static const char NODE_STR[] = "NN";
+static const char PUB_STR[] = "MP";
+static const char SUB_STR[] = "MS";
+static const char SRV_STR[] = "SS";
+static const char CLI_STR[] = "SC";
 
 static const std::unordered_map<EntityType, std::string> entity_to_str = {
   {EntityType::Node, NODE_STR},
@@ -78,12 +83,12 @@ static const std::unordered_map<std::string, EntityType> str_to_entity = {
   {CLI_STR, EntityType::Client}
 };
 
-} // namespace
+}  // namespace
 
 ///=============================================================================
 std::string subscription_token(size_t domain_id)
 {
-  std::string token = ADMIN_SPACE + "/" + std::to_string(domain_id) + "/**";
+  std::string token = std::string(ADMIN_SPACE) + "/" + std::to_string(domain_id) + "/**";
   return token;
 }
 
@@ -156,7 +161,7 @@ std::optional<Entity> Entity::make(
   }
 
   Entity entity{std::move(type), std::move(node_info), std::move(topic_info)};
-  return std::move(entity);
+  return entity;
 }
 
 namespace
@@ -192,14 +197,14 @@ std::vector<std::string> split_keyexpr(
   return result;
 }
 
-} // namespace
+}  // namespace
 
 ///=============================================================================
 std::optional<Entity> Entity::make(const std::string & keyexpr)
 {
-
   std::vector<std::string> parts = split_keyexpr(keyexpr);
-  // At minimum, a token will contain 5 parts (ADMIN_SPACE, domain_id, entity_str, namespace, node_name).
+  // A token will contain at least 5 parts:
+  // (ADMIN_SPACE, domain_id, entity_str, namespace, node_name).
   // Basic validation.
   if (parts.size() < 5) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -344,4 +349,4 @@ bool PublishToken::del(
   return true;
 }
 
-} // namespace liveliness
+}  // namespace liveliness

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -119,7 +119,7 @@ Entity::Entity(
    * <ADMIN_SPACE>/<domainid>/<entity>/<namespace>/<nodename>/<topic_name>/<topic_type>/<topic_qos>
    */
   std::stringstream token_ss;
-  const auto & ns = node_info_.ns_;
+  const std::string & ns = node_info_.ns_;
   token_ss << ADMIN_SPACE << "/" << node_info_.domain_id_ << "/" << entity_to_str.at(type_) << ns;
   // An empty namespace from rcl will contain "/" but zenoh does not allow keys with "//".
   // Hence we add an "_" to denote an empty namespace such that splitting the key
@@ -230,7 +230,8 @@ std::optional<Entity> Entity::make(const std::string & keyexpr)
 
   // Get the entity, ie NN, MP, MS, SS, SC.
   std::string & entity_str = parts[2];
-  const auto entity_it = str_to_entity.find(entity_str);
+  std::unordered_map<std::string, EntityType>::const_iterator entity_it =
+    str_to_entity.find(entity_str);
   if (entity_it == str_to_entity.end()) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
@@ -270,10 +271,19 @@ const EntityType & Entity::type() const
   return this->type_;
 }
 
-///=============================================================================
-const NodeInfo & Entity::node_info() const
+std::string Entity::node_namespace() const
 {
-  return this->node_info_;
+  return this->node_info_.ns_;
+}
+
+std::string Entity::node_name() const
+{
+  return this->node_info_.name_;
+}
+
+std::string Entity::node_enclave() const
+{
+  return this->node_info_.enclave_;
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -126,12 +126,6 @@ public:
     const std::string & token);
 };
 
-///=============================================================================
-/// Split a liveliness token's expression into parts based on a delimiter.
-std::vector<std::string> split_keyexpr(
-  const std::string & keyexpr,
-  const char delim = '/');
-
 } // namespace liveliness
 
 #endif  // DETAIL__LIVELINESS_UTILS_HPP_

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -1,0 +1,137 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DETAIL__LIVELINESS_UTILS_HPP_
+#define DETAIL__LIVELINESS_UTILS_HPP_
+
+#include <zenoh.h>
+
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+
+namespace liveliness
+{
+
+///=============================================================================
+struct NodeInfo
+{
+
+  std::size_t domain_id_;
+  std::string ns_;
+  std::string name_;
+  std::string enclave_;
+
+  NodeInfo(
+    std::size_t domain_id,
+    std::string ns,
+    std::string name,
+    std::string enclave);
+};
+
+///=============================================================================
+struct TopicInfo
+{
+  std::string name_;
+  std::string type_;
+  std::string qos_;
+
+  TopicInfo(
+    std::string name,
+    std::string type,
+    std::string qos);
+};
+
+///=============================================================================
+/// Retuns the keyexpr for liveliness subscription.
+std::string subscription_token(size_t domain_id);
+
+///=============================================================================
+enum class EntityType : uint8_t
+{
+  Invalid = 0,
+  Node,
+  Publisher,
+  Subscription,
+  Service,
+  Client
+};
+
+///=============================================================================
+// An struct to bundle results of parsing a token.
+// TODO(Yadunund): Consider using variadic templates to pass args instead of
+// relying on optional fields.
+class Entity
+{
+public:
+  /// Make an Entity from datatypes. This will return nullopt if the required
+  /// fields are not present for the EntityType.
+  // TODO(Yadunund): Find a way to better bundle the type and the associated data.
+  static std::optional<Entity> make(
+    EntityType type,
+    NodeInfo node_info,
+    std::optional<TopicInfo> topic_info = std::nullopt);
+
+  /// Make an Entity from a liveliness keyexpr.
+  static std::optional<Entity> make(const std::string & keyexpr);
+
+  /// Get the entity type.
+  const EntityType & type() const;
+
+  /// Get the node_info.
+  const NodeInfo & node_info() const;
+
+  /// Get the topic_info.
+  const std::optional<TopicInfo> & topic_info() const;
+
+  /// Get the liveliness keyexpr for this entity.
+  const std::string & keyexpr() const;
+
+private:
+  Entity(
+    EntityType type,
+    NodeInfo node_info,
+    std::optional<TopicInfo> topic_info);
+
+  EntityType type_;
+  NodeInfo node_info_;
+  std::optional<TopicInfo> topic_info_;
+  std::string keyexpr_;
+};
+
+///=============================================================================
+/// Helper utilities to put/delete tokens until liveliness is supported in the
+/// zenoh-c bindings.
+class PublishToken
+{
+public:
+  static bool put(
+    z_owned_session_t * session,
+    const std::string & token);
+
+  static bool del(
+    z_owned_session_t * session,
+    const std::string & token);
+};
+
+///=============================================================================
+/// Split a liveliness token's expression into parts based on a delimiter.
+std::vector<std::string> split_keyexpr(
+  const std::string & keyexpr,
+  const char delim = '/');
+
+} // namespace liveliness
+
+#endif  // DETAIL__LIVELINESS_UTILS_HPP_

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -19,7 +19,7 @@
 
 #include <optional>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 
 namespace liveliness
@@ -28,7 +28,6 @@ namespace liveliness
 ///=============================================================================
 struct NodeInfo
 {
-
   std::size_t domain_id_;
   std::string ns_;
   std::string name_;
@@ -126,6 +125,6 @@ public:
     const std::string & token);
 };
 
-} // namespace liveliness
+}  // namespace liveliness
 
 #endif  // DETAIL__LIVELINESS_UTILS_HPP_

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -89,8 +89,11 @@ public:
   /// Get the entity type.
   const EntityType & type() const;
 
-  /// Get the node_info.
-  const NodeInfo & node_info() const;
+  std::string node_namespace() const;
+
+  std::string node_name() const;
+
+  std::string node_enclave() const;
 
   /// Get the topic_info.
   const std::optional<TopicInfo> & topic_info() const;

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -87,7 +87,7 @@ public:
   static std::optional<Entity> make(const std::string & keyexpr);
 
   /// Get the entity type.
-  const EntityType & type() const;
+  EntityType type() const;
 
   std::string node_namespace() const;
 
@@ -96,10 +96,10 @@ public:
   std::string node_enclave() const;
 
   /// Get the topic_info.
-  const std::optional<TopicInfo> & topic_info() const;
+  std::optional<TopicInfo> topic_info() const;
 
   /// Get the liveliness keyexpr for this entity.
-  const std::string & keyexpr() const;
+  std::string keyexpr() const;
 
 private:
   Entity(

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -18,6 +18,7 @@
 
 #include "detail/guard_condition.hpp"
 #include "detail/identifier.hpp"
+#include "detail/liveliness_utils.hpp"
 #include "detail/rmw_data_types.hpp"
 #include "detail/zenoh_config.hpp"
 #include "detail/zenoh_router_check.hpp"
@@ -246,7 +247,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     });
 
   // Setup liveliness subscriptions for discovery.
-  const std::string liveliness_str = GenerateToken::liveliness(context->actual_domain_id);
+  const std::string liveliness_str = liveliness::subscription_token(context->actual_domain_id);
 
   // Query router/liveliness participants to get graph information before this session was started.
   RCUTILS_LOG_WARN_NAMED(

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -251,7 +251,8 @@ rmw_destroy_node(rmw_node_t * node)
   // Publish to the graph that a node has ridden off into the sunset
   // const bool del_result = PublishToken::del(
   //   &node->context->impl->session,
-  //   liveliness::GenerateToken::node(node->context->actual_domain_id, node->namespace_, node->name)
+  //   liveliness::GenerateToken::node(node->context->actual_domain_id, node->namespace_,
+  //     node->name)
   // );
   // if (!del_result) {
   //   return RMW_RET_ERROR;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2153,10 +2153,27 @@ rmw_count_publishers(
   const char * topic_name,
   size_t * count)
 {
-  static_cast<void>(node);
-  static_cast<void>(topic_name);
-  static_cast<void>(count);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
+  int validation_result = RMW_TOPIC_VALID;
+  rmw_ret_t ret = rmw_validate_full_topic_name(topic_name, &validation_result, nullptr);
+  if (RMW_RET_OK != ret) {
+    return ret;
+  }
+  if (RMW_TOPIC_VALID != validation_result) {
+    const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("topic_name argument is invalid: %s", reason);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
+
+  return node->context->impl->graph_cache.count_publishers(
+    node, topic_name, count);
 }
 
 //==============================================================================
@@ -2167,10 +2184,27 @@ rmw_count_subscribers(
   const char * topic_name,
   size_t * count)
 {
-  static_cast<void>(node);
-  static_cast<void>(topic_name);
-  static_cast<void>(count);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(topic_name, RMW_RET_INVALID_ARGUMENT);
+  int validation_result = RMW_TOPIC_VALID;
+  rmw_ret_t ret = rmw_validate_full_topic_name(topic_name, &validation_result, nullptr);
+  if (RMW_RET_OK != ret) {
+    return ret;
+  }
+  if (RMW_TOPIC_VALID != validation_result) {
+    const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("topic_name argument is invalid: %s", reason);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
+
+  return node->context->impl->graph_cache.count_subscriptions(
+    node, topic_name, count);
 }
 
 //==============================================================================

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1270,7 +1270,7 @@ rmw_create_subscription(
 
   // Publish to the graph that a new subscription is in town
   const auto liveliness_entity = liveliness::Entity::make(
-    liveliness::EntityType::Publisher,
+    liveliness::EntityType::Subscription,
     liveliness::NodeInfo{node->context->actual_domain_id, node->namespace_, node->name, ""},
     liveliness::TopicInfo{rmw_subscription->topic_name,
       sub_data->type_support->get_name(), "reliable"}
@@ -2173,8 +2173,7 @@ rmw_count_publishers(
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->graph_cache.count_publishers(
-    node, topic_name, count);
+  return node->context->impl->graph_cache.count_publishers(topic_name, count);
 }
 
 //==============================================================================
@@ -2204,8 +2203,7 @@ rmw_count_subscribers(
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->graph_cache.count_subscriptions(
-    node, topic_name, count);
+  return node->context->impl->graph_cache.count_subscriptions(topic_name, count);
 }
 
 //==============================================================================


### PR DESCRIPTION
This PR
- Updates the `GraphCache` implementation to support multiple types over the same topic name.
- Previously we were not keeping track of multiple pub/subs in the same node that publish over the same topic and let alone with different topic types. This PR addresses both these problems as well.
- It also reduces code duplication when adding/removing pub/subs by relying on lambdas that are reused for both pub/subs.
- Adds data structures and methods (see `liveliness_utils.hpp`) to manage token generation and conversion to C++ types. No longer have any magic string literal comparisons or custom key generation for unordered_maps.