### PR TITLE
[Fix PR #70] Instantiate new topic data for cache

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -115,7 +115,13 @@ void GraphCache::parse_put(const std::string & keyexpr)
       GraphNode::TopicMap::iterator cache_topic_it = graph_topics_.find(topic_info.name_);
       if (cache_topic_it == graph_topics_.end()) {
         // First time this topic name is added to the graph.
-        graph_topics_[topic_info.name_] = std::move(topic_data_map);
+        std::shared_ptr<TopicData> topic_data_ptr = std::make_shared<TopicData>(
+          topic_info,
+          TopicStats{pub_count, sub_count}
+        );
+        graph_topics_[topic_info.name_] = GraphNode::TopicDataMap{
+          {topic_info.type_, topic_data_ptr}
+        };
       } else {
         // If a TopicData entry for the same type exists in the topic map, update pub/sub counts
         // or else create an new TopicData.


### PR DESCRIPTION
Undo https://github.com/ros2/rmw_zenoh/commit/357f6588fab1f2f9192e7be418d9f1c3b4956da5 as part of https://github.com/ros2/rmw_zenoh/pull/70#discussion_r1409789588. We need to instantiate a new `TopicDataPtr` as the `topic_map_data` tracks the pub/sub count for a specific node so using the same shared_ptr would lead to incorrect tracking in `graph_topics_` which keeps track of the count across the entire graph. 