### PR TITLE
Implement `rmw_get_node_info_and_types` methods

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -100,6 +100,14 @@ public:
     const char * topic_name,
     size_t * count) const;
 
+  rmw_ret_t get_entity_names_and_types_by_node(
+    liveliness::EntityType entity_type,
+    rcutils_allocator_t * allocator,
+    const char * node_name,
+    const char * node_namespace,
+    bool no_demangle,
+    rmw_names_and_types_t * names_and_types) const;
+
 private:
   /*
   namespace_1:

--- a/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "detail/identifier.hpp"
+#include "detail/liveliness_utils.hpp"
+#include "detail/rmw_data_types.hpp"
 
 #include "rmw/get_node_info_and_types.h"
+#include "rmw/impl/cpp/macros.hpp"
 
 extern "C"
 {
@@ -28,13 +32,21 @@ rmw_get_subscriber_names_and_types_by_node(
   bool no_demangle,
   rmw_names_and_types_t * topic_names_and_types)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(node_name);
-  static_cast<void>(node_namespace);
-  static_cast<void>(no_demangle);
-  static_cast<void>(topic_names_and_types);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  return node->context->impl->graph_cache.get_entity_names_and_types_by_node(
+    liveliness::EntityType::Subscription,
+    allocator,
+    node_name,
+    node_namespace,
+    no_demangle,
+    topic_names_and_types);
 }
 
 ///==============================================================================
@@ -48,13 +60,21 @@ rmw_get_publisher_names_and_types_by_node(
   bool no_demangle,
   rmw_names_and_types_t * topic_names_and_types)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(node_name);
-  static_cast<void>(node_namespace);
-  static_cast<void>(no_demangle);
-  static_cast<void>(topic_names_and_types);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  return node->context->impl->graph_cache.get_entity_names_and_types_by_node(
+    liveliness::EntityType::Publisher,
+    allocator,
+    node_name,
+    node_namespace,
+    no_demangle,
+    topic_names_and_types);
 }
 
 ///==============================================================================
@@ -67,12 +87,21 @@ rmw_get_service_names_and_types_by_node(
   const char * node_namespace,
   rmw_names_and_types_t * service_names_and_types)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(node_name);
-  static_cast<void>(node_namespace);
-  static_cast<void>(service_names_and_types);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  return node->context->impl->graph_cache.get_entity_names_and_types_by_node(
+    liveliness::EntityType::Service,
+    allocator,
+    node_name,
+    node_namespace,
+    false,
+    service_names_and_types);
 }
 
 ///==============================================================================
@@ -85,11 +114,20 @@ rmw_get_client_names_and_types_by_node(
   const char * node_namespace,
   rmw_names_and_types_t * service_names_and_types)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(node_name);
-  static_cast<void>(node_namespace);
-  static_cast<void>(service_names_and_types);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  return node->context->impl->graph_cache.get_entity_names_and_types_by_node(
+    liveliness::EntityType::Client,
+    allocator,
+    node_name,
+    node_namespace,
+    false,
+    service_names_and_types);
 }
 }  // extern "C"


### PR DESCRIPTION
Build on top of #77 

Running any node, eg `talker` nodes and executing `ros2 node info /talker` should yield 

```bash
/talker
  Subscribers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Publishers:
    /rosout: rcl_interfaces/msg/Log
    /chatter: std_msgs/msg/String
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Service Servers:

  Service Clients:

  Action Servers:

  Action Clients:
```

