### PR TITLE
Enables CI when pushing rolling branch.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,8 @@ name: build
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ rolling ]
+  workflow_dispatch:
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
I wanted to double-check check CI is passing after last zenoh-c commit and found this minor bug.

### Summary

 - Trigger CI when commit is pushed to default branch (rolling)
 - Enables workflow_dispatch
 
