### PR TITLE
Implement method to get endpoints info

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -29,6 +29,7 @@
 #include "rcutils/types.h"
 
 #include "rmw/rmw.h"
+#include "rmw/get_topic_endpoint_info.h"
 #include "rmw/names_and_types.h"
 
 
@@ -107,6 +108,13 @@ public:
     const char * node_namespace,
     bool no_demangle,
     rmw_names_and_types_t * names_and_types) const;
+
+  rmw_ret_t get_entities_info_by_topic(
+    liveliness::EntityType entity_type,
+    rcutils_allocator_t * allocator,
+    const char * topic_name,
+    bool no_demangle,
+    rmw_topic_endpoint_info_array_t * endpoints_info) const;
 
 private:
   /*

--- a/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 
+#include "detail/identifier.hpp"
+#include "detail/liveliness_utils.hpp"
+#include "detail/rmw_data_types.hpp"
+
 #include "rmw/get_topic_endpoint_info.h"
+#include "rmw/impl/cpp/macros.hpp"
 
 extern "C"
 {
@@ -27,12 +32,20 @@ rmw_get_publishers_info_by_topic(
   bool no_mangle,
   rmw_topic_endpoint_info_array_t * publishers_info)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(topic_name);
-  static_cast<void>(no_mangle);
-  static_cast<void>(publishers_info);
-  return RMW_RET_OK;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  return node->context->impl->graph_cache.get_entities_info_by_topic(
+    liveliness::EntityType::Publisher,
+    allocator,
+    topic_name,
+    no_mangle,
+    publishers_info);
 }
 
 ///==============================================================================
@@ -45,11 +58,19 @@ rmw_get_subscriptions_info_by_topic(
   bool no_mangle,
   rmw_topic_endpoint_info_array_t * subscriptions_info)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(topic_name);
-  static_cast<void>(no_mangle);
-  static_cast<void>(subscriptions_info);
-  return RMW_RET_OK;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  return node->context->impl->graph_cache.get_entities_info_by_topic(
+    liveliness::EntityType::Subscription,
+    allocator,
+    topic_name,
+    no_mangle,
+    subscriptions_info);
 }
 }  // extern "C"


### PR DESCRIPTION
Implementing this method should allow `ros2 topic info -v` to return verbose results.

To test, 

```bash
# terminal 1
ros2 run rmw_zenoh_cpp init_rmw_zenoh_router 
```

```bash
# terminal 2
ros2 run demo_nodes_cpp talker
```

```bash
#terminal 3
ros2 topic info /chatter -v

# expected output
Publisher count: 1

size var: 1, size in array: 1
Node name: talker
Node namespace: /
Topic type: std_msgs/msg/String
Topic type hash: INVALID
Endpoint type: PUBLISHER
GID: 00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00
QoS profile:
  Reliability: SYSTEM_DEFAULT
  History (Depth): SYSTEM_DEFAULT
  Durability: SYSTEM_DEFAULT
  Lifespan: 0 nanoseconds
  Deadline: 0 nanoseconds
  Liveliness: SYSTEM_DEFAULT
  Liveliness lease duration: 0 nanoseconds

```