### PR TITLE
Adds base support for services.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -216,7 +216,8 @@ void GraphCache::parse_put(const std::string & keyexpr)
     } else {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
-        "Unable to add a new node /%s with id %s an existing namespace %s in the graph. Report this bug.",
+        "Unable to add a new node /%s with id %s an "
+        "existing namespace %s in the graph. Report this bug.",
         entity.node_name().c_str(),
         entity.id().c_str(),
         entity.node_namespace().c_str());

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -81,13 +81,6 @@ void sub_data_handler(
   }
 }
 
-
-//==============================================================================
-std::size_t rmw_service_data_t::get_new_uid()
-{
-  return client_count++;
-}
-
 //==============================================================================
 void service_data_handler(const z_query_t * query, void * data)
 {
@@ -115,10 +108,7 @@ void service_data_handler(const z_query_t * query, void * data)
   // Get the query parameters and payload
   {
     std::lock_guard<std::mutex> lock(service_data->query_queue_mutex);
-    const std::size_t client_id = service_data->get_new_uid();
-    service_data->id_query_map.emplace(
-      std::make_pair(client_id, z_query_clone(query)));
-    service_data->to_take.push_back(client_id);
+    service_data->query_queue.push_back(z_query_clone(query));
   }
   {
     // Since we added new data, trigger the guard condition if it is available

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -78,15 +78,6 @@ void sub_data_handler(
   z_drop(z_move(keystr));
 }
 
-saved_queryable_data::saved_queryable_data(z_owned_query_t query)
-: query(query)
-{}
-
-saved_queryable_data::~saved_queryable_data()
-{
-  z_query_drop(&query);
-}
-
 
 unsigned int rmw_service_data_t::get_new_uid()
 {
@@ -109,6 +100,7 @@ void service_data_handler(const z_query_t * query, void * service_data)
       "service for %s",
       z_loan(keystr)
     );
+    z_drop(z_move(keystr));
     return;
   }
 
@@ -118,7 +110,7 @@ void service_data_handler(const z_query_t * query, void * service_data)
 
     const unsigned int client_id = rmw_service_data->get_new_uid();
     rmw_service_data->id_query_map.emplace(
-      std::make_pair(client_id, std::make_unique<saved_queryable_data>(z_query_clone(query))));
+      std::make_pair(client_id, std::make_unique<z_owned_query_t>(z_query_clone(query))));
     rmw_service_data->to_take.push_back(client_id);
 
 

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -139,10 +139,17 @@ void client_data_handler(z_owned_reply_t * reply, void * client_data)
     "[client_data_handler] triggered for %s",
     rmw_client_data->service_name
   );
-  if (!z_reply_check(reply)) {
+  if (!z_check(*reply)) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "z_check returned False"
+    );
+    return;
+  }
+  if (!z_reply_check(reply)) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "z_reply_check returned False"
     );
     return;
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -22,6 +22,13 @@
 #include "rmw_data_types.hpp"
 
 ///==============================================================================
+
+saved_msg_data::saved_msg_data(zc_owned_payload_t p, uint64_t recv_ts, const uint8_t pub_gid[16])
+: payload(p), recv_timestamp(recv_ts)
+{
+  memcpy(publisher_gid, pub_gid, 16);
+}
+
 void sub_data_handler(
   const z_sample_t * sample,
   void * data)
@@ -69,6 +76,21 @@ void sub_data_handler(
   }
 
   z_drop(z_move(keystr));
+}
+
+saved_queryable_data::saved_queryable_data(z_owned_query_t query)
+: query(query)
+{}
+
+saved_queryable_data::~saved_queryable_data()
+{
+  z_query_drop(&query);
+}
+
+
+unsigned int rmw_service_data_t::get_new_uid()
+{
+  return client_count++;
 }
 
 void service_data_handler(const z_query_t * query, void * service_data)

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -70,3 +70,98 @@ void sub_data_handler(
 
   z_drop(z_move(keystr));
 }
+
+void service_data_handler(const z_query_t * query, void * service_data)
+{
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_cpp",
+    "[service_data_handler] triggered"
+  );
+  z_owned_str_t keystr = z_keyexpr_to_string(z_query_keyexpr(query));
+
+  auto rmw_service_data = static_cast<rmw_service_data_t *>(service_data);
+  if (rmw_service_data == nullptr) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to obtain rmw_service_data_t from data for "
+      "service for %s",
+      z_loan(keystr)
+    );
+    return;
+  }
+
+  // Get the query parameters and payload
+  {
+    std::lock_guard<std::mutex> lock(rmw_service_data->query_queue_mutex);
+
+    const unsigned int client_id = rmw_service_data->get_new_uid();
+    rmw_service_data->id_query_map.emplace(
+      std::make_pair(client_id, std::make_unique<saved_queryable_data>(z_query_clone(query))));
+    rmw_service_data->to_take.push_back(client_id);
+
+
+    // Since we added new data, trigger the guard condition if it is available
+    std::lock_guard<std::mutex> internal_lock(rmw_service_data->internal_mutex);
+    if (rmw_service_data->condition != nullptr) {
+      rmw_service_data->condition->notify_one();
+    }
+  }
+
+  z_drop(z_move(keystr));
+}
+
+void client_data_handler(z_owned_reply_t * reply, void * client_data)
+{
+  auto rmw_client_data = static_cast<rmw_client_data_t *>(client_data);
+  if (rmw_client_data == nullptr) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to obtain rmw_client_data_t "
+    );
+    return;
+  }
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_cpp",
+    "[client_data_handler] triggered for %s",
+    rmw_client_data->service_name
+  );
+  if (!z_reply_check(reply)) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "z_check returned False"
+    );
+    return;
+  }
+  if (!z_reply_is_ok(reply)) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "z_reply_is_ok returned False"
+    );
+    return;
+  }
+
+  z_sample_t sample = z_reply_ok(reply);
+
+  z_owned_str_t keystr = z_keyexpr_to_string(sample.keyexpr);
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rmw_zenoh_cpp",
+    "[client_data_handler] keyexpr of sample: %s",
+    z_loan(keystr)
+  );
+
+  {
+    std::lock_guard<std::mutex> msg_lock(rmw_client_data->message_mutex);
+    rmw_client_data->message = std::make_unique<saved_msg_data>(
+      zc_sample_payload_rcinc(&sample), sample.timestamp.time, sample.timestamp.id.id);
+  }
+  {
+    std::lock_guard<std::mutex> internal_lock(rmw_client_data->internal_mutex);
+    if (rmw_client_data->condition != nullptr) {
+      rmw_client_data->condition->notify_one();
+    }
+  }
+
+  z_reply_drop(reply);
+  z_drop(z_move(keystr));
+}

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -99,11 +99,7 @@ void sub_data_handler(const z_sample_t * sample, void * sub_data);
 
 struct saved_msg_data
 {
-  explicit saved_msg_data(zc_owned_payload_t p, uint64_t recv_ts, const uint8_t pub_gid[16])
-  : payload(p), recv_timestamp(recv_ts)
-  {
-    memcpy(publisher_gid, pub_gid, 16);
-  }
+  explicit saved_msg_data(zc_owned_payload_t p, uint64_t recv_ts, const uint8_t pub_gid[16]);
 
   zc_owned_payload_t payload;
   uint64_t recv_timestamp;
@@ -144,22 +140,17 @@ void client_data_handler(z_owned_reply_t * reply, void * client_data);
 
 struct saved_queryable_data
 {
-  explicit saved_queryable_data(z_owned_query_t query)
-  : query(query)
-  {
-  }
+  explicit saved_queryable_data(z_owned_query_t query);
+  ~saved_queryable_data();
 
-  const z_owned_query_t query;
+  z_owned_query_t query;
 };
 
 ///==============================================================================
 
 struct rmw_service_data_t
 {
-  unsigned int get_new_uid()
-  {
-    return client_count++;
-  }
+  unsigned int get_new_uid();
 
   const char * zn_queryable_key;
   z_owned_queryable_t zn_queryable;

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -156,7 +156,7 @@ struct rmw_service_data_t
   rmw_context_t * context;
 
   // Map to store the query id and the query.
-  // The query handler is saved as it is needed to answer the query later on.
+  // The query handle is saved as it is needed to answer the query later on.
   std::unordered_map<std::size_t, z_owned_query_t> id_query_map;
   // The query id's of the queries that need to be processed.
   std::deque<std::size_t> to_take;

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -137,14 +137,13 @@ void service_data_handler(const z_query_t * query, void * service_data);
 
 void client_data_handler(z_owned_reply_t * reply, void * client_data);
 
-
 ///==============================================================================
 
 struct rmw_service_data_t
 {
-  unsigned int get_new_uid();
+  std::size_t get_new_uid();
 
-  const char * keyexpr;
+  z_owned_keyexpr_t keyexpr;
   z_owned_queryable_t qable;
 
   const void * request_type_support_impl;
@@ -157,27 +156,27 @@ struct rmw_service_data_t
 
   // Map to store the query id and the query.
   // The query handler is saved as it is needed to answer the query later on.
-  std::unordered_map<unsigned int, std::unique_ptr<z_owned_query_t>> id_query_map;
+  std::unordered_map<std::size_t, z_owned_query_t> id_query_map;
   // The query id's of the queries that need to be processed.
-  std::deque<unsigned int> to_take;
+  std::deque<std::size_t> to_take;
   std::mutex query_queue_mutex;
 
   std::mutex internal_mutex;
   std::condition_variable * condition{nullptr};
 
-  unsigned int client_count{};
+  std::size_t client_count = 0;
 };
 
 ///==============================================================================
 
 struct rmw_client_data_t
 {
-  const char * service_name;
+  z_owned_keyexpr_t keyexpr;
 
   z_owned_closure_reply_t zn_closure_reply;
 
   std::mutex message_mutex;
-  std::unique_ptr<saved_msg_data> message;
+  std::vector<z_owned_reply_t> replies;
 
   const void * request_type_support_impl;
   const void * response_type_support_impl;

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -138,22 +138,14 @@ void service_data_handler(const z_query_t * query, void * service_data);
 void client_data_handler(z_owned_reply_t * reply, void * client_data);
 
 
-struct saved_queryable_data
-{
-  explicit saved_queryable_data(z_owned_query_t query);
-  ~saved_queryable_data();
-
-  z_owned_query_t query;
-};
-
 ///==============================================================================
 
 struct rmw_service_data_t
 {
   unsigned int get_new_uid();
 
-  const char * zn_queryable_key;
-  z_owned_queryable_t zn_queryable;
+  const char * keyexpr;
+  z_owned_queryable_t qable;
 
   const void * request_type_support_impl;
   const void * response_type_support_impl;
@@ -165,7 +157,7 @@ struct rmw_service_data_t
 
   // Map to store the query id and the query.
   // The query handler is saved as it is needed to answer the query later on.
-  std::unordered_map<unsigned int, std::unique_ptr<saved_queryable_data>> id_query_map;
+  std::unordered_map<unsigned int, std::unique_ptr<z_owned_query_t>> id_query_map;
   // The query id's of the queries that need to be processed.
   std::deque<unsigned int> to_take;
   std::mutex query_queue_mutex;

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -25,6 +25,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "rcutils/allocator.h"
 

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -174,11 +174,7 @@ struct rmw_client_data_t
 {
   const char * service_name;
 
-  // TODO(francocipollone): Remove this. For some reason if I remove this(not being even used) it
-  //                        ends up panicking when calling the service. Something is missing.
-  z_owned_reply_channel_t zn_reply_channel;
   z_owned_closure_reply_t zn_closure_reply;
-
 
   std::mutex message_mutex;
   std::unique_ptr<saved_msg_data> message;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2080,7 +2080,8 @@ static int64_t get_sequence_num_from_attachment(const z_attachment_t * const att
     return -1;
   } else if (errno != 0) {
     // Some other error occurred, which may include overflow or underflow
-    RMW_SET_ERROR_MSG("An undefined error occurred while getting the sequence number, this may be an overflow");
+    RMW_SET_ERROR_MSG(
+      "An undefined error occurred while getting the sequence number, this may be an overflow");
     return -1;
   }
 
@@ -2505,7 +2506,9 @@ rmw_take_request(
   // Add this query to the map, so that rmw_send_response can quickly look it up later
   {
     std::lock_guard<std::mutex> lock(service_data->sequence_to_query_map_mutex);
-    if (service_data->sequence_to_query_map.find(sequence_number) != service_data->sequence_to_query_map.end()) {
+    if (service_data->sequence_to_query_map.find(sequence_number) !=
+      service_data->sequence_to_query_map.end())
+    {
       RMW_SET_ERROR_MSG("duplicate sequence number in the map");
       return RMW_RET_ERROR;
     }

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -82,6 +82,9 @@ z_owned_keyexpr_t ros_topic_name_to_zenoh_key(
   domain_ss << domain_id;
   char * stripped_topic_name = rcutils_strndup(
     &topic_name[start_offset], end_offset - start_offset, *allocator);
+  if (stripped_topic_name == nullptr) {
+    return z_keyexpr_null();
+  }
   z_owned_keyexpr_t keyexpr = z_keyexpr_join(
     z_keyexpr(domain_ss.str().c_str()), z_keyexpr(stripped_topic_name));
   allocator->deallocate(stripped_topic_name, allocator->state);

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2193,9 +2193,6 @@ rmw_create_service(
     return nullptr;
   }
 
-  // TODO(francocipollone): Verify if this is the right way to get the
-  //                        type support as the architecture for the service here
-  //                        is different to the one used in DDS (with fastcdr).
   auto service_members = static_cast<const service_type_support_callbacks_t *>(type_support->data);
   auto request_members = static_cast<const message_type_support_callbacks_t *>(
     service_members->request_members_->data);

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1723,7 +1723,8 @@ rmw_create_client(
   }
 
   // client data
-  rmw_client_t * rmw_client = static_cast<rmw_client_t *>(allocator->allocate(
+  rmw_client_t * rmw_client = static_cast<rmw_client_t *>(allocator->zero_allocate(
+      1,
       sizeof(rmw_client_t),
       allocator->state));
   RMW_CHECK_FOR_NULL_WITH_MSG(
@@ -2150,7 +2151,8 @@ rmw_create_service(
   // SERVICE DATA ==============================================================
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
-  rmw_service_t * rmw_service = static_cast<rmw_service_t *>(allocator->allocate(
+  rmw_service_t * rmw_service = static_cast<rmw_service_t *>(allocator->zero_allocate(
+      1,
       sizeof(rmw_service_t),
       allocator->state));
   RMW_CHECK_FOR_NULL_WITH_MSG(

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -382,6 +382,33 @@ static const rosidl_message_type_support_t * find_type_support(
 }
 
 //==============================================================================
+static const rosidl_service_type_support_t * find_service_type_support(
+  const rosidl_service_type_support_t * type_supports)
+{
+  const rosidl_service_type_support_t * type_support = get_service_typesupport_handle(
+    type_supports, RMW_ZENOH_CPP_TYPESUPPORT_C);
+  if (!type_support) {
+    rcutils_error_string_t prev_error_string = rcutils_get_error_string();
+    rcutils_reset_error();
+    type_support = get_service_typesupport_handle(
+      type_supports, RMW_ZENOH_CPP_TYPESUPPORT_CPP);
+    if (!type_support) {
+      rcutils_error_string_t error_string = rcutils_get_error_string();
+      rcutils_reset_error();
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Type support not from this implementation. Got:\n"
+        "    %s\n"
+        "    %s\n"
+        "while fetching it",
+        prev_error_string.str, error_string.str);
+      return nullptr;
+    }
+  }
+
+  return type_support;
+}
+
+//==============================================================================
 /// Create a publisher and return a handle to that publisher.
 rmw_publisher_t *
 rmw_create_publisher(
@@ -1628,15 +1655,199 @@ rmw_return_loaned_message_from_subscription(
 rmw_client_t *
 rmw_create_client(
   const rmw_node_t * node,
-  const rosidl_service_type_support_t * type_support,
+  const rosidl_service_type_support_t * type_supports,
   const char * service_name,
   const rmw_qos_profile_t * qos_profile)
 {
-  static_cast<void>(node);
-  static_cast<void>(type_support);
-  static_cast<void>(service_name);
-  static_cast<void>(qos_profile);
-  return nullptr;
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_common_cpp",
+    "[rmw_create_client] %s with queue of depth %ld",
+    service_name,
+    qos_profile->depth);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
+
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return nullptr);
+
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, nullptr);
+  if (strlen(service_name) == 0) {
+    RMW_SET_ERROR_MSG("service name is empty string");
+    return nullptr;
+  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(qos_profile, nullptr);
+  RMW_CHECK_ARGUMENT_FOR_NULL(type_supports, nullptr);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    node->context,
+    "expected initialized context",
+    return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    node->context->impl,
+    "expected initialized context impl",
+    return nullptr);
+  rmw_context_impl_s * context_impl = static_cast<rmw_context_impl_s *>(
+    node->context->impl);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context_impl,
+    "unable to get rmw_context_impl_s",
+    return nullptr);
+  if (!z_check(context_impl->session)) {
+    RMW_SET_ERROR_MSG("zenoh session is invalid");
+    return nullptr;
+  }
+
+  rcutils_allocator_t * allocator = &node->context->options.allocator;
+
+  // Validate service name
+  int validation_result;
+
+  if (rmw_validate_full_topic_name(service_name, &validation_result, nullptr) != RMW_RET_OK) {
+    RMW_SET_ERROR_MSG("rmw_validate_full_topic_name failed");
+    return nullptr;
+  }
+
+  if (validation_result != RMW_TOPIC_VALID && !qos_profile->avoid_ros_namespace_conventions) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("service name is malformed: %s", service_name);
+    return nullptr;
+  }
+
+  // client data
+  rmw_client_t * rmw_client = static_cast<rmw_client_t *>(allocator->allocate(
+      sizeof(rmw_client_t),
+      allocator->state));
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    rmw_client,
+    "failed to allocate memory for the client",
+    return nullptr);
+
+  auto free_rmw_client = rcpputils::make_scope_exit(
+    [rmw_client, allocator]() {
+      allocator->deallocate(rmw_client, allocator->state);
+    });
+
+  auto client_data = static_cast<rmw_client_data_t *>(
+    allocator->allocate(sizeof(rmw_client_data_t), allocator->state));
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client_data,
+    "failed to allocate memory for client data",
+    return nullptr);
+  auto free_client_data = rcpputils::make_scope_exit(
+    [client_data, allocator]() {
+      allocator->deallocate(client_data, allocator->state);
+    });
+
+
+  // Obtain the type support
+  const rosidl_service_type_support_t * type_support = find_service_type_support(type_supports);
+  if (type_support == nullptr) {
+    // error was already set by find_type_support
+    return nullptr;
+  }
+
+  auto service_members = static_cast<const service_type_support_callbacks_t *>(type_support->data);
+  auto request_members = static_cast<const message_type_support_callbacks_t *>(
+    service_members->request_members_->data);
+  auto response_members = static_cast<const message_type_support_callbacks_t *>(
+    service_members->response_members_->data);
+
+  client_data->context = node->context;
+  client_data->typesupport_identifier = type_support->typesupport_identifier;
+  client_data->request_type_support_impl = request_members;
+  client_data->response_type_support_impl = response_members;
+
+  // Request type support
+  client_data->request_type_support = static_cast<RequestTypeSupport *>(
+    allocator->allocate(sizeof(RequestTypeSupport), allocator->state));
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client_data->request_type_support,
+    "Failed to allocate RequestTypeSupport",
+    return nullptr);
+  auto free_request_type_support = rcpputils::make_scope_exit(
+    [client_data, allocator]() {
+      allocator->deallocate(client_data->request_type_support, allocator->state);
+    });
+
+  RMW_TRY_PLACEMENT_NEW(
+    client_data->request_type_support,
+    client_data->request_type_support,
+    return nullptr,
+    RequestTypeSupport, service_members);
+  auto destruct_request_type_support = rcpputils::make_scope_exit(
+    [client_data]() {
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        client_data->request_type_support->~RequestTypeSupport(),
+        RequestTypeSupport);
+    });
+
+  // Response type support
+  client_data->response_type_support = static_cast<ResponseTypeSupport *>(
+    allocator->allocate(sizeof(ResponseTypeSupport), allocator->state));
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client_data->response_type_support,
+    "Failed to allocate ResponseTypeSupport",
+    return nullptr);
+  auto free_response_type_support = rcpputils::make_scope_exit(
+    [client_data, allocator]() {
+      allocator->deallocate(client_data->response_type_support, allocator->state);
+    });
+
+  RMW_TRY_PLACEMENT_NEW(
+    client_data->response_type_support,
+    client_data->response_type_support,
+    return nullptr,
+    ResponseTypeSupport, service_members);
+  auto destruct_response_type_support = rcpputils::make_scope_exit(
+    [client_data]() {
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        client_data->response_type_support->~ResponseTypeSupport(),
+        ResponseTypeSupport);
+    });
+
+  // Populate the rmw_client.
+  rmw_client->data = client_data;
+  rmw_client->implementation_identifier = rmw_zenoh_identifier;
+
+  rmw_client->service_name = rcutils_strdup(service_name, *allocator);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    rmw_client->service_name,
+    "failed to allocate client name",
+    return nullptr);
+
+  auto free_service_name = rcpputils::make_scope_exit(
+    [rmw_client, allocator]() {
+      allocator->deallocate(const_cast<char *>(rmw_client->service_name), allocator->state);
+    });
+
+  // Zenoh implementation for the client
+
+  // TODO(francocipollone): Replace ros_topic_name_to_zenoh_key by service related function.
+  //                        If this is enough simply rename the method.
+  z_owned_keyexpr_t keyexpr = ros_topic_name_to_zenoh_key(
+    rmw_client->service_name, node->context->actual_domain_id, allocator);
+  auto always_free_ros_keyexpr = rcpputils::make_scope_exit(
+    [&keyexpr]() {
+      z_keyexpr_drop(z_move(keyexpr));
+    });
+  if (!z_keyexpr_check(&keyexpr)) {
+    RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
+    return nullptr;
+  }
+
+  free_rmw_client.cancel();
+  free_client_data.cancel();
+  free_request_type_support.cancel();
+  destruct_request_type_support.cancel();
+  free_response_type_support.cancel();
+  destruct_response_type_support.cancel();
+  free_service_name.cancel();
+
+  return rmw_client;
 }
 
 //==============================================================================
@@ -1644,9 +1855,35 @@ rmw_create_client(
 rmw_ret_t
 rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
-  static_cast<void>(node);
-  static_cast<void>(client);
-  return RMW_RET_UNSUPPORTED;
+  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_destroy_client] %s", client->service_name);
+
+  // ASSERTIONS ================================================================
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  rcutils_allocator_t * allocator = &node->context->options.allocator;
+
+  auto client_data = static_cast<rmw_client_data_t *>(client->data);
+
+  // CLEANUP ===================================================================
+  allocator->deallocate(client_data->request_type_support, allocator->state);
+  allocator->deallocate(client_data->response_type_support, allocator->state);
+  allocator->deallocate(client->data, allocator->state);
+
+  allocator->deallocate(const_cast<char *>(client->service_name), allocator->state);
+  allocator->deallocate(client, allocator->state);
+
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -1657,10 +1894,93 @@ rmw_send_request(
   const void * ros_request,
   int64_t * sequence_id)
 {
-  static_cast<void>(client);
-  static_cast<void>(ros_request);
-  static_cast<void>(sequence_id);
-  return RMW_RET_UNSUPPORTED;
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_cpp", "[rmw_send_request]");
+
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(ros_request, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(sequence_id, RMW_RET_INVALID_ARGUMENT);
+
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client->data,
+    "client implementation pointer is null",
+    RMW_RET_INVALID_ARGUMENT);
+
+  auto * client_data = static_cast<rmw_client_data_t *>(client->data);
+
+  rmw_context_impl_s * context_impl = static_cast<rmw_context_impl_s *>(
+    client_data->context->impl);
+
+  // Serialize data
+
+  rcutils_allocator_t * allocator = &(client_data->context->options.allocator);
+
+  size_t max_data_length = (
+    client_data->request_type_support->get_estimated_serialized_size(
+      ros_request, client_data->request_type_support_impl));
+
+  // Init serialized message byte array
+  char * request_bytes = static_cast<char *>(allocator->allocate(
+      max_data_length,
+      allocator->state));
+  if (!request_bytes) {
+    RMW_SET_ERROR_MSG("failed allocate request message bytes");
+    allocator->deallocate(request_bytes, allocator->state);
+    return RMW_RET_ERROR;
+  }
+
+  // Object that manages the raw buffer
+  eprosima::fastcdr::FastBuffer fastbuffer(request_bytes, max_data_length);
+
+  // Object that serializes the data
+  eprosima::fastcdr::Cdr ser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
+  if (!client_data->request_type_support->serialize_ros_message(
+      ros_request,
+      ser,
+      client_data->request_type_support_impl))
+  {
+    allocator->deallocate(request_bytes, allocator->state);
+    return RMW_RET_ERROR;
+  }
+
+  size_t data_length = ser.getSerializedDataLength();
+
+  // TODO(francocipollone): Do I really need the sequency number here?
+  *sequence_id = 0;
+
+
+  // Send request
+  z_get_options_t opts = z_get_options_default();
+  opts.value.payload = z_bytes_t{data_length, reinterpret_cast<const uint8_t *>(request_bytes)};
+  opts.value.encoding = z_encoding(Z_ENCODING_PREFIX_EMPTY, NULL);
+
+
+  z_owned_keyexpr_t keyexpr = ros_topic_name_to_zenoh_key(
+    client->service_name, client_data->context->actual_domain_id, allocator);
+  auto always_free_ros_keyexpr = rcpputils::make_scope_exit(
+    [&keyexpr]() {
+      z_keyexpr_drop(z_move(keyexpr));
+    });
+  if (!z_keyexpr_check(&keyexpr)) {
+    RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
+    return RMW_RET_ERROR;
+  }
+
+  client_data->service_name = client->service_name;
+  client_data->zn_closure_reply = z_closure(client_data_handler, nullptr, client_data);
+
+  z_get(z_loan(context_impl->session), z_loan(keyexpr), "", &client_data->zn_closure_reply, &opts);
+
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -1672,11 +1992,67 @@ rmw_take_response(
   void * ros_response,
   bool * taken)
 {
-  static_cast<void>(client);
-  static_cast<void>(request_header);
-  static_cast<void>(ros_response);
-  static_cast<void>(taken);
-  return RMW_RET_UNSUPPORTED;
+  *taken = false;
+  RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_response]");
+
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(ros_response, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
+
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    client,
+    client->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client->service_name, "client has no service name", RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+
+
+  auto client_data = static_cast<rmw_client_data_t *>(client->data);
+
+  std::unique_ptr<saved_msg_data> msg_data = nullptr;
+
+  {
+    std::lock_guard<std::mutex> lock(client_data->message_mutex);
+    if (client_data->message == nullptr) {
+      // TODO(francocipollone): Verify behavior.
+      RCUTILS_LOG_ERROR_NAMED("rmw_zenoh_cpp", "[rmw_take_response] Response message is empty");
+      return RMW_RET_ERROR;
+    }
+
+    msg_data = std::move(client_data->message);
+    client_data->message.release();
+  }
+
+  // Object that manages the raw buffer
+  eprosima::fastcdr::FastBuffer fastbuffer(
+    reinterpret_cast<char *>(const_cast<uint8_t *>(msg_data->payload.payload.start)),
+    msg_data->payload.payload.len);
+
+  // Object that serializes the data
+  eprosima::fastcdr::Cdr deser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
+  if (!client_data->response_type_support->deserialize_ros_message(
+      deser,
+      ros_response,
+      client_data->response_type_support_impl))
+  {
+    RMW_SET_ERROR_MSG("could not deserialize ROS response");
+    return RMW_RET_ERROR;
+  }
+
+  *taken = true;
+  zc_payload_drop(&(msg_data->payload));
+
+  // TODO(francocipollone): Verify request_header information.
+  request_header->request_id.sequence_number = 0;
+
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -1686,9 +2062,10 @@ rmw_client_request_publisher_get_actual_qos(
   const rmw_client_t * client,
   rmw_qos_profile_t * qos)
 {
+  // TODO(francocipollone): Fix.
   static_cast<void>(client);
   static_cast<void>(qos);
-  return RMW_RET_UNSUPPORTED;
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -1698,9 +2075,10 @@ rmw_client_response_subscription_get_actual_qos(
   const rmw_client_t * client,
   rmw_qos_profile_t * qos)
 {
+  // TODO(francocipollone): Fix.
   static_cast<void>(client);
   static_cast<void>(qos);
-  return RMW_RET_UNSUPPORTED;
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -1712,8 +2090,12 @@ rmw_create_service(
   const char * service_name,
   const rmw_qos_profile_t * qos_profiles)
 {
-  // Interim implementation to suppress type_description service that spins up
-  // with a node by default.
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_cpp",
+    "[rmw_create_service] %s",
+    service_name);
+
+  // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, nullptr);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node,
@@ -1729,6 +2111,7 @@ rmw_create_service(
   RMW_CHECK_ARGUMENT_FOR_NULL(qos_profiles, nullptr);
   if (!qos_profiles->avoid_ros_namespace_conventions) {
     int validation_result = RMW_TOPIC_VALID;
+    // TODO(francocipollone): Verify if this is the right way to validate the service name.
     rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
     if (RMW_RET_OK != ret) {
       return nullptr;
@@ -1739,20 +2122,199 @@ rmw_create_service(
       return nullptr;
     }
   }
-  // rmw_qos_profile_t adapted_qos_profile =
-  //   rmw_dds_common::qos_profile_update_best_available_for_services(*qos_profile);
-  // if (!is_valid_qos(adapted_qos_profile)) {
-  //   RMW_SET_ERROR_MSG("create_service() called with invalid QoS");
-  //   return nullptr;
-  // }
 
-  rmw_service_t * service = rmw_service_allocate();
-  if (!service) {
-    RMW_SET_ERROR_MSG("failed to allocate rmw_service_t");
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    node->context,
+    "expected initialized context",
+    return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    node->context->impl,
+    "expected initialized context impl",
+    return nullptr);
+  rmw_context_impl_s * context_impl = static_cast<rmw_context_impl_s *>(
+    node->context->impl);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context_impl,
+    "unable to get rmw_context_impl_s",
+    return nullptr);
+  if (!z_check(context_impl->session)) {
+    RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
   }
 
-  return service;
+  // SERVICE DATA ==============================================================
+  rcutils_allocator_t * allocator = &node->context->options.allocator;
+
+  rmw_service_t * rmw_service = static_cast<rmw_service_t *>(allocator->allocate(
+      sizeof(rmw_service_t),
+      allocator->state));
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    rmw_service,
+    "failed to allocate memory for the service",
+    return nullptr);
+
+  auto free_rmw_service = rcpputils::make_scope_exit(
+    [rmw_service, allocator]() {
+      allocator->deallocate(rmw_service, allocator->state);
+    });
+
+  auto service_data = static_cast<rmw_service_data_t *>(
+    allocator->allocate(sizeof(rmw_service_data_t), allocator->state));
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service_data,
+    "failed to allocate memory for service data",
+    return nullptr);
+  auto free_service_data = rcpputils::make_scope_exit(
+    [service_data, allocator]() {
+      allocator->deallocate(service_data, allocator->state);
+    });
+
+  RMW_TRY_PLACEMENT_NEW(service_data, service_data, return nullptr, rmw_service_data_t);
+  auto destruct_service_data = rcpputils::make_scope_exit(
+    [service_data]() {
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        service_data->~rmw_service_data_t(),
+        rmw_service_data_t);
+    });
+
+  // Get the RMW type support.
+  const rosidl_service_type_support_t * type_support = find_service_type_support(type_supports);
+  if (type_support == nullptr) {
+    // error was already set by find_type_support
+    return nullptr;
+  }
+
+  // TODO(francocipollone): Verify if this is the right way to get the
+  //                        type support as the architecture for the service here
+  //                        is different to the one used in DDS (with fastcdr).
+  auto service_members = static_cast<const service_type_support_callbacks_t *>(type_support->data);
+  auto request_members = static_cast<const message_type_support_callbacks_t *>(
+    service_members->request_members_->data);
+  auto response_members = static_cast<const message_type_support_callbacks_t *>(
+    service_members->response_members_->data);
+
+  service_data->context = node->context;
+  service_data->typesupport_identifier = type_support->typesupport_identifier;
+  service_data->request_type_support_impl = request_members;
+  service_data->response_type_support_impl = response_members;
+
+  // Request type support
+  service_data->request_type_support = static_cast<RequestTypeSupport *>(
+    allocator->allocate(sizeof(RequestTypeSupport), allocator->state));
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service_data->request_type_support,
+    "Failed to allocate RequestTypeSupport",
+    return nullptr);
+  auto free_request_type_support = rcpputils::make_scope_exit(
+    [service_data, allocator]() {
+      allocator->deallocate(service_data->request_type_support, allocator->state);
+    });
+
+  RMW_TRY_PLACEMENT_NEW(
+    service_data->request_type_support,
+    service_data->request_type_support,
+    return nullptr,
+    RequestTypeSupport, service_members);
+  auto destruct_request_type_support = rcpputils::make_scope_exit(
+    [service_data]() {
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        service_data->request_type_support->~RequestTypeSupport(),
+        RequestTypeSupport);
+    });
+
+  // Response type support
+  service_data->response_type_support = static_cast<ResponseTypeSupport *>(
+    allocator->allocate(sizeof(ResponseTypeSupport), allocator->state));
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service_data->response_type_support,
+    "Failed to allocate ResponseTypeSupport",
+    return nullptr);
+  auto free_response_type_support = rcpputils::make_scope_exit(
+    [service_data, allocator]() {
+      allocator->deallocate(service_data->response_type_support, allocator->state);
+    });
+
+  RMW_TRY_PLACEMENT_NEW(
+    service_data->response_type_support,
+    service_data->response_type_support,
+    return nullptr,
+    ResponseTypeSupport, service_members);
+  auto destruct_response_type_support = rcpputils::make_scope_exit(
+    [service_data]() {
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        service_data->response_type_support->~ResponseTypeSupport(),
+        ResponseTypeSupport);
+    });
+
+  // Populate the rmw_service.
+  rmw_service->data = service_data;
+  rmw_service->implementation_identifier = rmw_zenoh_identifier;
+
+  rmw_service->service_name = rcutils_strdup(service_name, *allocator);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    rmw_service->service_name,
+    "failed to allocate service name",
+    return nullptr);
+
+  auto free_service_name = rcpputils::make_scope_exit(
+    [rmw_service, allocator]() {
+      allocator->deallocate(const_cast<char *>(rmw_service->service_name), allocator->state);
+    });
+
+
+  // Zenoh implementation for the service
+
+  // TODO(francocipollone): Replace ros_topic_name_to_zenoh_key by service related function.
+  //                        If this is enough simply rename the method.
+  z_owned_keyexpr_t keyexpr = ros_topic_name_to_zenoh_key(
+    rmw_service->service_name, node->context->actual_domain_id, allocator);
+  auto always_free_ros_keyexpr = rcpputils::make_scope_exit(
+    [&keyexpr]() {
+      z_keyexpr_drop(z_move(keyexpr));
+    });
+  if (!z_keyexpr_check(&keyexpr)) {
+    RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
+    return nullptr;
+  }
+
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_cpp", "[rmw_create_service] keyexpr: %s",
+    z_loan(z_keyexpr_to_string(z_loan(keyexpr))));
+
+  z_owned_closure_query_t callback = z_closure(service_data_handler, nullptr, service_data);
+
+  service_data->zn_queryable = z_declare_queryable(
+    z_loan(context_impl->session),
+    z_loan(keyexpr),
+    z_move(callback),
+    nullptr);
+
+  if (!z_check(service_data->zn_queryable)) {
+    RMW_SET_ERROR_MSG("unable to create zenoh queryable");
+    return nullptr;
+  }
+
+  auto undeclare_z_queryable = rcpputils::make_scope_exit(
+    [service_data]() {
+      z_undeclare_queryable(z_move(service_data->zn_queryable));
+    });
+
+
+  // TODO(francocipollone): Update graph cache.
+
+  free_rmw_service.cancel();
+  free_service_data.cancel();
+  free_service_name.cancel();
+  destruct_service_data.cancel();
+  destruct_request_type_support.cancel();
+  destruct_response_type_support.cancel();
+  free_request_type_support.cancel();
+  free_response_type_support.cancel();
+  undeclare_z_queryable.cancel();
+  return rmw_service;
 }
 
 //==============================================================================
@@ -1766,6 +2328,8 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
     return RMW_RET_ERROR;
   }
   rmw_service_free(service);
+
+  // TODO(francocipollone): Update graph cache.
   return RMW_RET_OK;
 }
 
@@ -1778,11 +2342,84 @@ rmw_take_request(
   void * ros_request,
   bool * taken)
 {
-  static_cast<void>(service);
-  static_cast<void>(request_header);
-  static_cast<void>(ros_request);
-  static_cast<void>(taken);
-  return RMW_RET_UNSUPPORTED;
+  *taken = false;
+  RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_request]");
+
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(ros_request, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
+
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service->service_name, "service has no service name", RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+
+
+  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
+
+  std::unique_lock<std::mutex> lock(service_data->query_queue_mutex);
+
+  if (service_data->id_query_map.empty()) {
+    // TODO(francocipollone): Verify behavior.
+    RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_request] Take id_query_map is empty");
+    return RMW_RET_OK;
+  }
+
+  const unsigned int query_id = service_data->to_take.back();
+  const auto query_ret = service_data->id_query_map.find(query_id);
+  if (query_ret == service_data->id_query_map.end()) {
+    RMW_SET_ERROR_MSG("Query id not found in id_query_map");
+    return RMW_RET_ERROR;
+  }
+  const saved_queryable_data * query = (*query_ret).second.get();
+  const z_owned_query_t * owned_query_ptr = &query->query;
+  // TODO(francocipollone): Remove the query id from the to_take collection
+  service_data->to_take.pop_back();
+  service_data->query_queue_mutex.unlock();
+
+  // DESERIALIZE MESSAGE ========================================================
+  if (!z_query_check(owned_query_ptr)) {
+    RMW_SET_ERROR_MSG("onwed_query_t contains gravestone, can't deserialize message");
+    return RMW_RET_ERROR;
+  }
+  const z_query_t z_loaned_query = z_query_loan(owned_query_ptr);
+  z_value_t payload_value = z_query_value(&z_loaned_query);
+
+  // Object that manages the raw buffer
+  eprosima::fastcdr::FastBuffer fastbuffer(
+    reinterpret_cast<char *>(const_cast<uint8_t *>(payload_value.payload.start)),
+    payload_value.payload.len);
+
+  // Object that serializes the data
+  eprosima::fastcdr::Cdr deser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
+  if (!service_data->request_type_support->deserialize_ros_message(
+      deser,
+      ros_request,
+      service_data->request_type_support_impl))
+  {
+    RMW_SET_ERROR_MSG("could not deserialize ROS message");
+    return RMW_RET_ERROR;
+  }
+
+  RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_request] deserialized message");
+
+
+  // Fill in the request header.
+  request_header->request_id.sequence_number = query_id;
+
+
+  *taken = true;
+
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -1793,10 +2430,82 @@ rmw_send_response(
   rmw_request_id_t * request_header,
   void * ros_response)
 {
-  static_cast<void>(service);
-  static_cast<void>(request_header);
-  static_cast<void>(ros_response);
-  return RMW_RET_UNSUPPORTED;
+  RCUTILS_LOG_INFO_NAMED(
+    "rmw_zenoh_cpp", "[rmw_send_response]");
+
+  RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(request_header, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(ros_response, RMW_RET_INVALID_ARGUMENT);
+
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    service,
+    service->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service->data,
+    "service implementation pointer is null",
+    RMW_RET_INVALID_ARGUMENT);
+
+  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
+
+  rcutils_allocator_t * allocator = &(service_data->context->options.allocator);
+
+  size_t max_data_length = (
+    service_data->response_type_support->get_estimated_serialized_size(
+      ros_response, service_data->response_type_support_impl));
+
+  // Init serialized message byte array
+  char * response_bytes = static_cast<char *>(allocator->allocate(
+      max_data_length,
+      allocator->state));
+  if (!response_bytes) {
+    RMW_SET_ERROR_MSG("failed allocate response message bytes");
+    allocator->deallocate(response_bytes, allocator->state);
+    return RMW_RET_ERROR;
+  }
+
+  // Object that manages the raw buffer
+  eprosima::fastcdr::FastBuffer fastbuffer(response_bytes, max_data_length);
+
+  // Object that serializes the data
+  eprosima::fastcdr::Cdr ser(
+    fastbuffer,
+    eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+    eprosima::fastcdr::Cdr::DDS_CDR);
+  if (!service_data->response_type_support->serialize_ros_message(
+      ros_response,
+      ser,
+      service_data->response_type_support_impl))
+  {
+    allocator->deallocate(response_bytes, allocator->state);
+    return RMW_RET_ERROR;
+  }
+
+  size_t data_length = ser.getSerializedDataLength();
+
+  size_t meta_length = sizeof(request_header->sequence_number);
+  memcpy(
+    &response_bytes[data_length],
+    reinterpret_cast<char *>(&request_header->sequence_number),
+    meta_length);
+
+  // Create the queryable payload
+  service_data->query_queue_mutex.lock();
+  auto query = service_data->id_query_map[request_header->sequence_number]
+    ->query;
+  service_data->query_queue_mutex.unlock();
+
+  z_query_reply_options_t options = z_query_reply_options_default();
+  options.encoding = z_encoding(Z_ENCODING_PREFIX_EMPTY, NULL);
+  const z_query_t loaned_query = z_loan(query);
+  const z_query_t * query_ptr = &loaned_query;
+  z_query_reply(
+    query_ptr, z_query_keyexpr(query_ptr), reinterpret_cast<const uint8_t *>(
+      response_bytes), data_length + meta_length, &options);
+
+  return RMW_RET_OK;
 }
 
 //==============================================================================
@@ -2054,6 +2763,29 @@ rmw_wait(
     }
   }
 
+
+  if (services) {
+    // Go through each of the services and attach the wait set condition variable to them.
+    // That way they can wake it up if they are triggered while we are waiting.
+    for (size_t i = 0; i < services->service_count; ++i) {
+      auto serv_data = static_cast<rmw_service_data_t *>(services->services[i]);
+      if (serv_data != nullptr) {
+        serv_data->condition = &wait_set_data->condition_variable;
+      }
+    }
+  }
+
+  if (clients) {
+    // Go through each of the clients and attach the wait set condition variable to them.
+    // That way they can wake it up if they are triggered while we are waiting.
+    for (size_t i = 0; i < clients->client_count; ++i) {
+      auto client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
+      if (client_data != nullptr) {
+        client_data->condition = &wait_set_data->condition_variable;
+      }
+    }
+  }
+
   std::unique_lock<std::mutex> lock(wait_set_data->condition_mutex);
 
   // According to the RMW documentation, if wait_timeout is NULL that means
@@ -2098,6 +2830,37 @@ rmw_wait(
       }
     }
   }
+
+  if (services) {
+    // Now detach the condition variable and mutex from each of the services
+    for (size_t i = 0; i < services->service_count; ++i) {
+      auto serv_data = static_cast<rmw_service_data_t *>(services->services[i]);
+      if (serv_data != nullptr) {
+        serv_data->condition = nullptr;
+        if (serv_data->to_take.empty()) {
+          // Setting to nullptr lets rcl know that this service is not ready
+          services->services[i] = nullptr;
+        }
+      }
+    }
+  }
+
+  if (clients) {
+    // Now detach the condition variable and mutex from each of the clients
+    for (size_t i = 0; i < clients->client_count; ++i) {
+      auto client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
+      if (client_data != nullptr) {
+        client_data->condition = nullptr;
+        // According to the documentation for rmw_wait in rmw.h, entries in the
+        // array that have *not* been triggered should be set to NULL
+        if (client_data->message == nullptr) {
+          // Setting to nullptr lets rcl know that this client is not ready
+          clients->clients[i] = nullptr;
+        }
+      }
+    }
+  }
+
 
   return RMW_RET_OK;
 }
@@ -2274,10 +3037,12 @@ rmw_service_server_is_available(
   const rmw_client_t * client,
   bool * is_available)
 {
+  // TODO(francocipollone): Provide a proper implementation.
+  //                        We need graph cache information for this.
+  *is_available = true;
   static_cast<void>(node);
   static_cast<void>(client);
-  static_cast<void>(is_available);
-  return RMW_RET_UNSUPPORTED;
+  return RMW_RET_OK;
 }
 
 //==============================================================================

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -90,7 +90,7 @@ z_owned_keyexpr_t ros_topic_name_to_zenoh_key(
 }
 
 //==============================================================================
-const rosidl_message_type_support_t * find_type_support(
+const rosidl_message_type_support_t * find_message_type_support(
   const rosidl_message_type_support_t * type_supports)
 {
   const rosidl_message_type_support_t * type_support = get_message_typesupport_handle(
@@ -466,9 +466,9 @@ rmw_create_publisher(
   }
 
   // Get the RMW type support.
-  const rosidl_message_type_support_t * type_support = find_type_support(type_supports);
+  const rosidl_message_type_support_t * type_support = find_message_type_support(type_supports);
   if (type_support == nullptr) {
-    // error was already set by find_type_support
+    // error was already set by find_message_type_support
     return nullptr;
   }
 
@@ -1032,9 +1032,9 @@ rmw_serialize(
   const rosidl_message_type_support_t * type_support,
   rmw_serialized_message_t * serialized_message)
 {
-  const rosidl_message_type_support_t * ts = find_type_support(type_support);
+  const rosidl_message_type_support_t * ts = find_message_type_support(type_support);
   if (ts == nullptr) {
-    // error was already set by find_type_support
+    // error was already set by find_message_type_support
     return RMW_RET_ERROR;
   }
 
@@ -1067,9 +1067,9 @@ rmw_deserialize(
   const rosidl_message_type_support_t * type_support,
   void * ros_message)
 {
-  const rosidl_message_type_support_t * ts = find_type_support(type_support);
+  const rosidl_message_type_support_t * ts = find_message_type_support(type_support);
   if (ts == nullptr) {
-    // error was already set by find_type_support
+    // error was already set by find_message_type_support
     return RMW_RET_ERROR;
   }
 
@@ -1147,9 +1147,9 @@ rmw_create_subscription(
   //   return nullptr;
   // }
 
-  const rosidl_message_type_support_t * type_support = find_type_support(type_supports);
+  const rosidl_message_type_support_t * type_support = find_message_type_support(type_supports);
   if (type_support == nullptr) {
-    // error was already set by find_type_support
+    // error was already set by find_message_type_support
     return nullptr;
   }
 
@@ -1759,7 +1759,7 @@ rmw_create_client(
   // Obtain the type support
   const rosidl_service_type_support_t * type_support = find_service_type_support(type_supports);
   if (type_support == nullptr) {
-    // error was already set by find_type_support
+    // error was already set by find_service_type_support
     return nullptr;
   }
 
@@ -2186,7 +2186,7 @@ rmw_create_service(
   // Get the RMW type support.
   const rosidl_service_type_support_t * type_support = find_service_type_support(type_supports);
   if (type_support == nullptr) {
-    // error was already set by find_type_support
+    // error was already set by find_service_type_support
     return nullptr;
   }
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2474,9 +2474,12 @@ rmw_send_response(
       allocator->state));
   if (!response_bytes) {
     RMW_SET_ERROR_MSG("failed allocate response message bytes");
-    allocator->deallocate(response_bytes, allocator->state);
     return RMW_RET_ERROR;
   }
+  auto free_response_bytes = rcpputils::make_scope_exit(
+    [response_bytes, allocator]() {
+      allocator->deallocate(response_bytes, allocator->state);
+    });
 
   // Object that manages the raw buffer
   eprosima::fastcdr::FastBuffer fastbuffer(response_bytes, max_data_length);
@@ -2491,7 +2494,6 @@ rmw_send_response(
       ser,
       service_data->response_type_support_impl))
   {
-    allocator->deallocate(response_bytes, allocator->state);
     return RMW_RET_ERROR;
   }
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2532,6 +2532,7 @@ rmw_send_response(
     query_ptr, z_query_keyexpr(query_ptr), reinterpret_cast<const uint8_t *>(
       response_bytes), data_length + meta_length, &options);
 
+  z_drop(z_move(*owned_query_ptr));
   return RMW_RET_OK;
 }
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1954,9 +1954,12 @@ rmw_send_request(
       allocator->state));
   if (!request_bytes) {
     RMW_SET_ERROR_MSG("failed allocate request message bytes");
-    allocator->deallocate(request_bytes, allocator->state);
     return RMW_RET_ERROR;
   }
+  auto free_request_bytes = rcpputils::make_scope_exit(
+    [request_bytes, allocator]() {
+      allocator->deallocate(request_bytes, allocator->state);
+    });
 
   // Object that manages the raw buffer
   eprosima::fastcdr::FastBuffer fastbuffer(request_bytes, max_data_length);
@@ -1971,7 +1974,6 @@ rmw_send_request(
       ser,
       client_data->request_type_support_impl))
   {
-    allocator->deallocate(request_bytes, allocator->state);
     return RMW_RET_ERROR;
   }
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1739,6 +1739,13 @@ rmw_create_client(
       allocator->deallocate(client_data, allocator->state);
     });
 
+  RMW_TRY_PLACEMENT_NEW(client_data, client_data, return nullptr, rmw_client_data_t);
+  auto destruct_client_data = rcpputils::make_scope_exit(
+    [client_data]() {
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        client_data->~rmw_client_data_t(),
+        rmw_client_data_t);
+    });
 
   // Obtain the type support
   const rosidl_service_type_support_t * type_support = find_service_type_support(type_supports);
@@ -1809,43 +1816,39 @@ rmw_create_client(
     });
 
   // Populate the rmw_client.
-  rmw_client->data = client_data;
   rmw_client->implementation_identifier = rmw_zenoh_identifier;
-
   rmw_client->service_name = rcutils_strdup(service_name, *allocator);
-
   RMW_CHECK_FOR_NULL_WITH_MSG(
     rmw_client->service_name,
     "failed to allocate client name",
     return nullptr);
-
   auto free_service_name = rcpputils::make_scope_exit(
     [rmw_client, allocator]() {
       allocator->deallocate(const_cast<char *>(rmw_client->service_name), allocator->state);
     });
 
-  // Zenoh implementation for the client
-
-  // TODO(francocipollone): Replace ros_topic_name_to_zenoh_key by service related function.
-  //                        If this is enough simply rename the method.
-  z_owned_keyexpr_t keyexpr = ros_topic_name_to_zenoh_key(
+  client_data->keyexpr = ros_topic_name_to_zenoh_key(
     rmw_client->service_name, node->context->actual_domain_id, allocator);
-  auto always_free_ros_keyexpr = rcpputils::make_scope_exit(
-    [&keyexpr]() {
-      z_keyexpr_drop(z_move(keyexpr));
+  auto free_ros_keyexpr = rcpputils::make_scope_exit(
+    [client_data]() {
+      z_keyexpr_drop(z_move(client_data->keyexpr));
     });
-  if (!z_keyexpr_check(&keyexpr)) {
+  if (!z_keyexpr_check(&client_data->keyexpr)) {
     RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
     return nullptr;
   }
+
+  rmw_client->data = client_data;
 
   free_rmw_client.cancel();
   free_client_data.cancel();
   free_request_type_support.cancel();
   destruct_request_type_support.cancel();
   free_response_type_support.cancel();
+  destruct_client_data.cancel();
   destruct_response_type_support.cancel();
   free_service_name.cancel();
+  free_ros_keyexpr.cancel();
 
   return rmw_client;
 }
@@ -1855,11 +1858,10 @@ rmw_create_client(
 rmw_ret_t
 rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 {
-  RCUTILS_LOG_DEBUG_NAMED("rmw_zenoh_cpp", "[rmw_destroy_client] %s", client->service_name);
-
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client->data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node,
     node->implementation_identifier,
@@ -1873,14 +1875,19 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
 
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
-  auto client_data = static_cast<rmw_client_data_t *>(client->data);
+  rmw_client_data_t * client_data = static_cast<rmw_client_data_t *>(client->data);
   RMW_CHECK_FOR_NULL_WITH_MSG(
     client_data,
-    "client implementation pointer is null",
+    "client implementation pointer is null.",
     return RMW_RET_INVALID_ARGUMENT);
 
   // CLEANUP ===================================================================
   z_drop(z_move(client_data->zn_closure_reply));
+  z_drop(z_move(client_data->keyexpr));
+  for (z_owned_reply_t & reply : client_data->replies) {
+    z_reply_drop(&reply);
+  }
+  client_data->replies.clear();
 
   allocator->deallocate(client_data->request_type_support, allocator->state);
   allocator->deallocate(client_data->response_type_support, allocator->state);
@@ -1889,8 +1896,6 @@ rmw_destroy_client(rmw_node_t * node, rmw_client_t * client)
   allocator->deallocate(const_cast<char *>(client->service_name), allocator->state);
   allocator->deallocate(client, allocator->state);
 
-  RCUTILS_LOG_DEBUG_NAMED(
-    "rmw_zenoh_cpp", "[rmw_destroy_client] %s FINISHED", client->service_name);
   return RMW_RET_OK;
 }
 
@@ -1904,23 +1909,21 @@ rmw_send_request(
 {
   RCUTILS_LOG_INFO_NAMED(
     "rmw_zenoh_cpp", "[rmw_send_request]");
-
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client->data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_request, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(sequence_id, RMW_RET_INVALID_ARGUMENT);
-
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     client,
     client->implementation_identifier,
     rmw_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
+  rmw_client_data_t * client_data = static_cast<rmw_client_data_t *>(client->data);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    client->data,
-    "client implementation pointer is null",
+    client_data,
+    "Unable to retrieve client_data from client.",
     RMW_RET_INVALID_ARGUMENT);
-
-  auto * client_data = static_cast<rmw_client_data_t *>(client->data);
 
   rmw_context_impl_s * context_impl = static_cast<rmw_context_impl_s *>(
     client_data->context->impl);
@@ -1967,24 +1970,13 @@ rmw_send_request(
 
   // Send request
   z_get_options_t opts = z_get_options_default();
+  opts.target = Z_QUERY_TARGET_ALL;
   opts.value.payload = z_bytes_t{data_length, reinterpret_cast<const uint8_t *>(request_bytes)};
   opts.value.encoding = z_encoding(Z_ENCODING_PREFIX_EMPTY, NULL);
-
-  z_owned_keyexpr_t keyexpr = ros_topic_name_to_zenoh_key(
-    client->service_name, client_data->context->actual_domain_id, allocator);
-  auto always_free_ros_keyexpr = rcpputils::make_scope_exit(
-    [&keyexpr]() {
-      z_keyexpr_drop(z_move(keyexpr));
-    });
-  if (!z_keyexpr_check(&keyexpr)) {
-    RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
-    return RMW_RET_ERROR;
-  }
-
-  client_data->service_name = client->service_name;
   client_data->zn_closure_reply = z_closure(client_data_handler, nullptr, client_data);
-
-  z_get(z_loan(context_impl->session), z_loan(keyexpr), "", &client_data->zn_closure_reply, &opts);
+  z_get(
+    z_loan(context_impl->session), z_loan(
+      client_data->keyexpr), "", &client_data->zn_closure_reply, &opts);
 
   return RMW_RET_OK;
 }
@@ -2002,41 +1994,36 @@ rmw_take_response(
   RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_response]");
 
   RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client->data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_response, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
-
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     client,
     client->implementation_identifier,
     rmw_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-
   RMW_CHECK_FOR_NULL_WITH_MSG(
     client->service_name, "client has no service name", RMW_RET_INVALID_ARGUMENT);
+
+  rmw_client_data_t * client_data = static_cast<rmw_client_data_t *>(client->data);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    client->data, "client implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
+    client->data, "Unable to retrieve client_data from client.", RMW_RET_INVALID_ARGUMENT);
 
+  z_owned_reply_t * latest_reply = nullptr;
 
-  auto client_data = static_cast<rmw_client_data_t *>(client->data);
-
-  std::unique_ptr<saved_msg_data> msg_data = nullptr;
-
-  {
-    std::lock_guard<std::mutex> lock(client_data->message_mutex);
-    if (client_data->message == nullptr) {
-      // TODO(francocipollone): Verify behavior.
-      RCUTILS_LOG_ERROR_NAMED("rmw_zenoh_cpp", "[rmw_take_response] Response message is empty");
-      return RMW_RET_ERROR;
-    }
-
-    msg_data = std::move(client_data->message);
-    client_data->message.release();
+  std::lock_guard<std::mutex> lock(client_data->message_mutex);
+  if (client_data->replies.empty()) {
+    // TODO(francocipollone): Verify behavior.
+    RCUTILS_LOG_ERROR_NAMED("rmw_zenoh_cpp", "[rmw_take_response] Response message is empty");
+    return RMW_RET_ERROR;
   }
+  latest_reply = &client_data->replies.back();
+  z_sample_t sample = z_reply_ok(latest_reply);
 
   // Object that manages the raw buffer
   eprosima::fastcdr::FastBuffer fastbuffer(
-    reinterpret_cast<char *>(const_cast<uint8_t *>(msg_data->payload.payload.start)),
-    msg_data->payload.payload.len);
+    reinterpret_cast<char *>(const_cast<uint8_t *>(sample.payload.start)),
+    sample.payload.len);
 
   // Object that serializes the data
   eprosima::fastcdr::Cdr deser(
@@ -2053,7 +2040,11 @@ rmw_take_response(
   }
 
   *taken = true;
-  zc_payload_drop(&(msg_data->payload));
+
+  for (z_owned_reply_t & reply : client_data->replies) {
+    z_reply_drop(&reply);
+  }
+  client_data->replies.clear();
 
   // TODO(francocipollone): Verify request_header information.
   request_header->request_id.sequence_number = 0;
@@ -2158,7 +2149,6 @@ rmw_create_service(
     rmw_service,
     "failed to allocate memory for the service",
     return nullptr);
-
   auto free_rmw_service = rcpputils::make_scope_exit(
     [rmw_service, allocator]() {
       allocator->deallocate(rmw_service, allocator->state);
@@ -2207,16 +2197,14 @@ rmw_create_service(
   // Request type support
   service_data->request_type_support = static_cast<RequestTypeSupport *>(
     allocator->allocate(sizeof(RequestTypeSupport), allocator->state));
-
   RMW_CHECK_FOR_NULL_WITH_MSG(
     service_data->request_type_support,
     "Failed to allocate RequestTypeSupport",
     return nullptr);
   auto free_request_type_support = rcpputils::make_scope_exit(
-    [service_data, allocator]() {
-      allocator->deallocate(service_data->request_type_support, allocator->state);
+    [request_type_support = service_data->request_type_support, allocator]() {
+      allocator->deallocate(request_type_support, allocator->state);
     });
-
   RMW_TRY_PLACEMENT_NEW(
     service_data->request_type_support,
     service_data->request_type_support,
@@ -2232,16 +2220,14 @@ rmw_create_service(
   // Response type support
   service_data->response_type_support = static_cast<ResponseTypeSupport *>(
     allocator->allocate(sizeof(ResponseTypeSupport), allocator->state));
-
   RMW_CHECK_FOR_NULL_WITH_MSG(
     service_data->response_type_support,
     "Failed to allocate ResponseTypeSupport",
     return nullptr);
   auto free_response_type_support = rcpputils::make_scope_exit(
-    [service_data, allocator]() {
-      allocator->deallocate(service_data->response_type_support, allocator->state);
+    [response_type_support = service_data->response_type_support, allocator]() {
+      allocator->deallocate(response_type_support, allocator->state);
     });
-
   RMW_TRY_PLACEMENT_NEW(
     service_data->response_type_support,
     service_data->response_type_support,
@@ -2255,46 +2241,34 @@ rmw_create_service(
     });
 
   // Populate the rmw_service.
-  rmw_service->data = service_data;
   rmw_service->implementation_identifier = rmw_zenoh_identifier;
-
   rmw_service->service_name = rcutils_strdup(service_name, *allocator);
-
   RMW_CHECK_FOR_NULL_WITH_MSG(
     rmw_service->service_name,
     "failed to allocate service name",
     return nullptr);
-
   auto free_service_name = rcpputils::make_scope_exit(
     [rmw_service, allocator]() {
       allocator->deallocate(const_cast<char *>(rmw_service->service_name), allocator->state);
     });
-
-  // Zenoh implementation for the service
-
-  // TODO(francocipollone): Replace ros_topic_name_to_zenoh_key by service related function.
-  //                        If this is enough simply rename the method.
-  z_owned_keyexpr_t keyexpr = ros_topic_name_to_zenoh_key(
+  service_data->keyexpr = ros_topic_name_to_zenoh_key(
     rmw_service->service_name, node->context->actual_domain_id, allocator);
-  auto always_free_ros_keyexpr = rcpputils::make_scope_exit(
-    [&keyexpr]() {
-      z_keyexpr_drop(z_move(keyexpr));
+  auto free_ros_keyexpr = rcpputils::make_scope_exit(
+    [service_data]() {
+      if (service_data) {
+        z_drop(z_move(service_data->keyexpr));
+      }
     });
-  if (!z_keyexpr_check(&keyexpr)) {
+  if (!z_check(z_loan(service_data->keyexpr))) {
     RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
     return nullptr;
   }
-  service_data->keyexpr = z_keyexpr_to_string(z_loan(keyexpr))._cstr;
-
-  RCUTILS_LOG_INFO_NAMED(
-    "rmw_zenoh_cpp", "[rmw_create_service] keyexpr: %s",
-    z_loan(z_keyexpr_to_string(z_loan(keyexpr))));
 
   z_owned_closure_query_t callback = z_closure(service_data_handler, nullptr, service_data);
 
   service_data->qable = z_declare_queryable(
     z_loan(context_impl->session),
-    z_loan(keyexpr),
+    z_loan(service_data->keyexpr),
     z_move(callback),
     nullptr);
 
@@ -2302,13 +2276,14 @@ rmw_create_service(
     RMW_SET_ERROR_MSG("unable to create zenoh queryable");
     return nullptr;
   }
-
   auto undeclare_z_queryable = rcpputils::make_scope_exit(
     [service_data]() {
       z_undeclare_queryable(z_move(service_data->qable));
     });
 
   // TODO(francocipollone): Update graph cache.
+
+  rmw_service->data = service_data;
 
   free_rmw_service.cancel();
   free_service_data.cancel();
@@ -2318,6 +2293,7 @@ rmw_create_service(
   destruct_response_type_support.cancel();
   free_request_type_support.cancel();
   free_response_type_support.cancel();
+  free_ros_keyexpr.cancel();
   undeclare_z_queryable.cancel();
   return rmw_service;
 }
@@ -2330,6 +2306,7 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
   // ASSERTIONS ================================================================
   RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service->data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node,
     node->implementation_identifier,
@@ -2343,13 +2320,14 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
 
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
-  auto service_data = static_cast<rmw_service_data_t *>(service->data);
+  rmw_service_data_t * service_data = static_cast<rmw_service_data_t *>(service->data);
   RMW_CHECK_FOR_NULL_WITH_MSG(
     service_data,
-    "service implementation pointer is null",
+    "Unable to retrieve service_data from service",
     return RMW_RET_INVALID_ARGUMENT);
 
   // CLEANUP ================================================================
+  z_drop(z_move(service_data->keyexpr));
   z_drop(z_move(service_data->qable));
   for (auto & id_query : service_data->id_query_map) {
     z_drop(z_move(id_query.second));
@@ -2359,7 +2337,8 @@ rmw_destroy_service(rmw_node_t * node, rmw_service_t * service)
   allocator->deallocate(service_data->response_type_support, allocator->state);
   allocator->deallocate(service->data, allocator->state);
 
-  rmw_service_free(service);
+  allocator->deallocate(const_cast<char *>(service->service_name), allocator->state);
+  allocator->deallocate(service, allocator->state);
 
   // TODO(francocipollone): Update graph cache.
   return RMW_RET_OK;
@@ -2378,6 +2357,7 @@ rmw_take_request(
   RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_request]");
 
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service->data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_request, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(taken, RMW_RET_INVALID_ARGUMENT);
 
@@ -2389,36 +2369,28 @@ rmw_take_request(
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
     service->service_name, "service has no service name", RMW_RET_INVALID_ARGUMENT);
-  RMW_CHECK_FOR_NULL_WITH_MSG(
-    service->data, "service implementation pointer is null", RMW_RET_INVALID_ARGUMENT);
 
-  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
+  rmw_service_data_t * service_data = static_cast<rmw_service_data_t *>(service->data);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    service->data, "Unable to retrieve service_data from service", RMW_RET_INVALID_ARGUMENT);
 
   std::unique_lock<std::mutex> lock(service_data->query_queue_mutex);
-
   if (service_data->id_query_map.empty()) {
     // TODO(francocipollone): Verify behavior.
     RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_request] Take id_query_map is empty");
     return RMW_RET_OK;
   }
-
-  const unsigned int query_id = service_data->to_take.back();
-  const auto query_ret = service_data->id_query_map.find(query_id);
-  if (query_ret == service_data->id_query_map.end()) {
+  const std::size_t query_id = service_data->to_take.back();
+  auto query_it = service_data->id_query_map.find(query_id);
+  if (query_it == service_data->id_query_map.end()) {
     RMW_SET_ERROR_MSG("Query id not found in id_query_map");
     return RMW_RET_ERROR;
   }
-  const z_owned_query_t * owned_query_ptr = (*query_ret).second.get();
-  // TODO(francocipollone): Remove the query id from the to_take collection
   service_data->to_take.pop_back();
   service_data->query_queue_mutex.unlock();
 
   // DESERIALIZE MESSAGE ========================================================
-  if (!z_query_check(owned_query_ptr)) {
-    RMW_SET_ERROR_MSG("onwed_query_t contains gravestone, can't deserialize message");
-    return RMW_RET_ERROR;
-  }
-  const z_query_t z_loaned_query = z_query_loan(owned_query_ptr);
+  const z_query_t z_loaned_query = z_query_loan(&query_it->second);
   z_value_t payload_value = z_query_value(&z_loaned_query);
 
   // Object that manages the raw buffer
@@ -2440,8 +2412,6 @@ rmw_take_request(
     return RMW_RET_ERROR;
   }
 
-  RCUTILS_LOG_INFO_NAMED("rmw_zenoh_cpp", "[rmw_take_request] deserialized message");
-
   // Fill in the request header.
   request_header->request_id.sequence_number = query_id;
 
@@ -2462,6 +2432,7 @@ rmw_send_response(
     "rmw_zenoh_cpp", "[rmw_send_response]");
 
   RMW_CHECK_ARGUMENT_FOR_NULL(service, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service->data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(request_header, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(ros_response, RMW_RET_INVALID_ARGUMENT);
 
@@ -2473,10 +2444,10 @@ rmw_send_response(
 
   RMW_CHECK_FOR_NULL_WITH_MSG(
     service->data,
-    "service implementation pointer is null",
+    "Unable to retrieve service_data from service",
     RMW_RET_INVALID_ARGUMENT);
 
-  auto * service_data = static_cast<rmw_service_data_t *>(service->data);
+  rmw_service_data_t * service_data = static_cast<rmw_service_data_t *>(service->data);
 
   rcutils_allocator_t * allocator = &(service_data->context->options.allocator);
 
@@ -2520,19 +2491,21 @@ rmw_send_response(
     meta_length);
 
   // Create the queryable payload
-  service_data->query_queue_mutex.lock();
-  auto owned_query_ptr = service_data->id_query_map[request_header->sequence_number].get();
-  service_data->query_queue_mutex.unlock();
-
+  std::lock_guard<std::mutex> lock(service_data->query_queue_mutex);
+  auto query_it = service_data->id_query_map.find(request_header->sequence_number);
+  if (query_it == service_data->id_query_map.end()) {
+    RMW_SET_ERROR_MSG("Unable to find taken request. Report this bug.");
+    return RMW_RET_ERROR;
+  }
+  const z_query_t z_loaned_query = z_query_loan(&query_it->second);
   z_query_reply_options_t options = z_query_reply_options_default();
   options.encoding = z_encoding(Z_ENCODING_PREFIX_EMPTY, NULL);
-  const z_query_t loaned_query = z_loan(*owned_query_ptr);
-  const z_query_t * query_ptr = &loaned_query;
   z_query_reply(
-    query_ptr, z_query_keyexpr(query_ptr), reinterpret_cast<const uint8_t *>(
+    &z_loaned_query, z_loan(service_data->keyexpr), reinterpret_cast<const uint8_t *>(
       response_bytes), data_length + meta_length, &options);
 
-  z_drop(z_move(*owned_query_ptr));
+  z_drop(z_move(query_it->second));
+  service_data->id_query_map.erase(query_it);
   return RMW_RET_OK;
 }
 
@@ -2807,7 +2780,7 @@ rmw_wait(
     // Go through each of the clients and attach the wait set condition variable to them.
     // That way they can wake it up if they are triggered while we are waiting.
     for (size_t i = 0; i < clients->client_count; ++i) {
-      auto client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
+      rmw_client_data_t * client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
       if (client_data != nullptr) {
         client_data->condition = &wait_set_data->condition_variable;
       }
@@ -2876,12 +2849,12 @@ rmw_wait(
   if (clients) {
     // Now detach the condition variable and mutex from each of the clients
     for (size_t i = 0; i < clients->client_count; ++i) {
-      auto client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
+      rmw_client_data_t * client_data = static_cast<rmw_client_data_t *>(clients->clients[i]);
       if (client_data != nullptr) {
         client_data->condition = nullptr;
         // According to the documentation for rmw_wait in rmw.h, entries in the
         // array that have *not* been triggered should be set to NULL
-        if (client_data->message == nullptr) {
+        if (client_data->replies.empty()) {
           // Setting to nullptr lets rcl know that this client is not ready
           clients->clients[i] = nullptr;
         }


### PR DESCRIPTION
### Summary
 - Provides support for services
 - Graph cache update is not tackled in this PR.

### Notes on the implementation
 - Queryables are being used for the service client interaction. (instead of topics as dds implementations) 
 - Main rmw methods to implement from the server side
   - rmw_create_service
   - rmw_take_request
   - rmw_send_response
 - Main rmw methods to implement from the clilent side:
   - rmw_create_client
   - rmw_send_request
   - rmw_take_response
 
      
### Pendings
 - [x] :exclamation: `z_query_value` is failing to obtain the message when using `z_owned_query` approach, even replicated in simpler script (Notified zettascale folks) :exclamation:(blocker)  
 - [ ] Define headers (request/response) and sequence id information.
 - [x] Verify waits added to the rmw_wait method.
 - [ ] Verify keyexpression for the service 
 - [x] Fix style
 - [ ] `rmw_service_server_is_available` method needs graph information. 
 - [ ] Update graph cache
