### PR TITLE
Handle duplicate node names by including zenoh session id in liveliness tokens

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -207,13 +207,12 @@ void GraphCache::parse_put(const std::string & keyexpr)
     NodeMap::iterator insertion_it =
       ns_it->second.insert(std::make_pair(entity.node_name(), make_graph_node(entity)));
     if (insertion_it != ns_it->second.end()) {
-      RCUTILS_LOG_WARN_NAMED(
+      RCUTILS_LOG_INFO_NAMED(
         "rmw_zenoh_cpp",
         "Added a new node /%s with id %s to an existing namespace %s in the graph.",
         entity.node_name().c_str(),
         entity.id().c_str(),
         entity.node_namespace().c_str());
-      return;
     } else {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
@@ -221,12 +220,11 @@ void GraphCache::parse_put(const std::string & keyexpr)
         entity.node_name().c_str(),
         entity.id().c_str(),
         entity.node_namespace().c_str());
-      return;
     }
-  } else {
-    // The entity represents a node that already exists in the graph.
-    // Update topic info if required below.
+    return;
   }
+  // Otherwise, the entity represents a node that already exists in the graph.
+  // Update topic info if required below.
 
   // Handles additions to an existing node in the graph.
   if (entity.type() == EntityType::Node) {

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -56,16 +56,6 @@ TopicData::TopicData(
 {}
 
 ///=============================================================================
-// bool operator==(const GraphNodePtr & lhs, const GraphNodePtr & rhs) {
-//   return lhs->id_ == rhs->id_ && lhs->ns_ == rhs->ns_ && lhs->name_ == rhs->name_;
-// }
-
-///=============================================================================
-// bool GraphCache::NodeComparator::operator()(const GraphNodePtr & lhs, const GraphNodePtr & rhs) const {
-//   return std::hash<std::string>{}(lhs->id_) < std::hash<std::string>{}(rhs->id_);
-// }
-
-///=============================================================================
 void GraphCache::parse_put(const std::string & keyexpr)
 {
   std::optional<liveliness::Entity> valid_entity = liveliness::Entity::make(keyexpr);

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -58,6 +58,7 @@ using TopicDataPtr = std::shared_ptr<TopicData>;
 // TODO(Yadunund): Expand to services and clients.
 struct GraphNode
 {
+  std::string id_;
   std::string ns_;
   std::string name_;
   // TODO(Yadunund): Should enclave be the parent to the namespace key and not within a Node?
@@ -71,6 +72,9 @@ struct GraphNode
   TopicMap subs_ = {};
 };
 using GraphNodePtr = std::shared_ptr<GraphNode>;
+// Two nodes are the same if their id, name and namespaces are identical.
+// TODO(Yadunund): Once zenoh API gives us globally unique IDs for entities, rely on only the id.
+// bool operator==(const GraphNodePtr & lhs, const GraphNodePtr & rhs);
 
 ///=============================================================================
 class GraphCache final
@@ -131,7 +135,14 @@ private:
     node_n:
   */
 
-  using NodeMap = std::unordered_map<std::string, GraphNodePtr>;
+  // // A comparator for sorting nodes that have the same name based on their
+  // // zenoh session ids.
+  // struct NodeComparator {
+  //   bool operator()(const GraphNodePtr & lhs, const GraphNodePtr & rhs) const;
+  // };
+
+  // We rely on a multimap to store nodes with duplicate names.
+  using NodeMap = std::multimap<std::string, GraphNodePtr>;
   using NamespaceMap = std::unordered_map<std::string, NodeMap>;
   // Map namespace to a map of <node_name, GraphNodePtr>.
   NamespaceMap graph_ = {};

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -72,9 +72,6 @@ struct GraphNode
   TopicMap subs_ = {};
 };
 using GraphNodePtr = std::shared_ptr<GraphNode>;
-// Two nodes are the same if their id, name and namespaces are identical.
-// TODO(Yadunund): Once zenoh API gives us globally unique IDs for entities, rely on only the id.
-// bool operator==(const GraphNodePtr & lhs, const GraphNodePtr & rhs);
 
 ///=============================================================================
 class GraphCache final
@@ -134,12 +131,6 @@ private:
   namespace_2:
     node_n:
   */
-
-  // // A comparator for sorting nodes that have the same name based on their
-  // // zenoh session ids.
-  // struct NodeComparator {
-  //   bool operator()(const GraphNodePtr & lhs, const GraphNodePtr & rhs) const;
-  // };
 
   // We rely on a multimap to store nodes with duplicate names.
   using NodeMap = std::multimap<std::string, GraphNodePtr>;

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -83,7 +83,7 @@ static const std::unordered_map<std::string, EntityType> str_to_entity = {
   {CLI_STR, EntityType::Client}
 };
 
-std::string convert(z_id_t id)
+std::string zid_to_str(z_id_t id)
 {
   std::stringstream ss;
   ss << std::hex;
@@ -180,7 +180,7 @@ std::optional<Entity> Entity::make(
     return std::nullopt;
   }
 
-  Entity entity{convert(id), std::move(type), std::move(node_info), std::move(topic_info)};
+  Entity entity{zid_to_str(id), std::move(type), std::move(node_info), std::move(topic_info)};
   return entity;
 }
 

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -83,14 +83,15 @@ static const std::unordered_map<std::string, EntityType> str_to_entity = {
   {CLI_STR, EntityType::Client}
 };
 
-std::string convert(z_id_t id) {
+std::string convert(z_id_t id)
+{
   std::stringstream ss;
   ss << std::hex;
   size_t i = 0;
   for (; i < (sizeof(id.id) - 1); i++) {
     ss << static_cast<int>(id.id[i]) << ".";
   }
-  ss << static_cast<int>(id.id[i]) << std::dec;
+  ss << static_cast<int>(id.id[i]);
   return ss.str();
 }
 
@@ -109,7 +110,8 @@ Entity::Entity(
   EntityType type,
   NodeInfo node_info,
   std::optional<TopicInfo> topic_info)
-: type_(std::move(type)),
+: id_(std::move(id)),
+  type_(std::move(type)),
   node_info_(std::move(node_info)),
   topic_info_(std::move(topic_info))
 {
@@ -132,7 +134,8 @@ Entity::Entity(
    */
   std::stringstream token_ss;
   const std::string & ns = node_info_.ns_;
-  token_ss << ADMIN_SPACE << "/" << node_info_.domain_id_ << "/" << id << "/" << entity_to_str.at(type_) << ns;
+  token_ss << ADMIN_SPACE << "/" << node_info_.domain_id_ << "/" << id_ << "/" << entity_to_str.at(
+    type_) << ns;
   // An empty namespace from rcl will contain "/" but zenoh does not allow keys with "//".
   // Hence we add an "_" to denote an empty namespace such that splitting the key
   // will always result in 5 parts.
@@ -254,7 +257,7 @@ std::optional<Entity> Entity::make(const std::string & keyexpr)
 
   EntityType entity_type = entity_it->second;
   std::size_t domain_id = std::stoul(parts[1]);
-  std::string& id = parts[2];
+  std::string & id = parts[2];
   std::string ns = parts[4] == "_" ? "/" : "/" + std::move(parts[4]);
   std::string node_name = std::move(parts[5]);
   std::optional<TopicInfo> topic_info = std::nullopt;
@@ -278,6 +281,12 @@ std::optional<Entity> Entity::make(const std::string & keyexpr)
     std::move(entity_type),
     NodeInfo{std::move(domain_id), std::move(ns), std::move(node_name), ""},
     std::move(topic_info)};
+}
+
+///=============================================================================
+std::string Entity::id() const
+{
+  return this->id_;
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -120,17 +120,21 @@ Entity::Entity(
    *
    * The liveliness token keyexprs are in the form:
    *
-   * <ADMIN_SPACE>/<domainid>/<entity>/<namespace>/<nodename>
+   * <ADMIN_SPACE>/<domainid>/<id>/<entity>/<namespace>/<nodename>
    *
    * Where:
    *  <domainid> - A number set by the user to "partition" graphs.  Roughly equivalent to the domain ID in DDS.
+   *  <id> - A unique ID to identify this entity. Currently the id is the zenoh session's id with elements concatenated into a string using '.' as separator.
    *  <entity> - The type of entity.  This can be one of "NN" for a node, "MP" for a publisher, "MS" for a subscription, "SS" for a service server, or "SC" for a service client.
    *  <namespace> - The ROS namespace for this entity.  If the namespace is absolute, this function will add in an _ for later parsing reasons.
    *  <nodename> - The ROS node name for this entity.
    *
    * For entities with topic infomation, the liveliness token keyexpr have additional fields:
    *
-   * <ADMIN_SPACE>/<domainid>/<entity>/<namespace>/<nodename>/<topic_name>/<topic_type>/<topic_qos>
+   * <ADMIN_SPACE>/<domainid>/<id>/<entity>/<namespace>/<nodename>/<topic_name>/<topic_type>/<topic_qos>
+   *  <topic_name> - The ROS topic name for this entity.
+   *  <topic_type> - The type for the topic.
+   *  <topic_qos> - The qos for the topic.
    */
   std::stringstream token_ss;
   const std::string & ns = node_info_.ns_;

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -111,6 +111,7 @@ private:
     NodeInfo node_info,
     std::optional<TopicInfo> topic_info);
 
+  std::string id_;
   EntityType type_;
   NodeInfo node_info_;
   std::optional<TopicInfo> topic_info_;

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -79,12 +79,15 @@ public:
   /// fields are not present for the EntityType.
   // TODO(Yadunund): Find a way to better bundle the type and the associated data.
   static std::optional<Entity> make(
+    z_id_t id,
     EntityType type,
     NodeInfo node_info,
     std::optional<TopicInfo> topic_info = std::nullopt);
 
   /// Make an Entity from a liveliness keyexpr.
   static std::optional<Entity> make(const std::string & keyexpr);
+
+  std::string id() const;
 
   /// Get the entity type.
   EntityType type() const;
@@ -103,6 +106,7 @@ public:
 
 private:
   Entity(
+    std::string id,
     EntityType type,
     NodeInfo node_info,
     std::optional<TopicInfo> topic_info);

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -196,6 +196,7 @@ rmw_create_node(
   // Initialize liveliness token for the node to advertise that a new node is in town.
   rmw_node_data_t * node_data = static_cast<rmw_node_data_t *>(node->data);
   const auto liveliness_entity = liveliness::Entity::make(
+    z_info_zid(z_loan(context->impl->session)),
     liveliness::EntityType::Node,
     liveliness::NodeInfo{context->actual_domain_id, namespace_, name, ""});
   if (!liveliness_entity.has_value()) {
@@ -578,6 +579,7 @@ rmw_create_publisher(
   //   return nullptr;
   // }
   const auto liveliness_entity = liveliness::Entity::make(
+    z_info_zid(z_loan(node->context->impl->session)),
     liveliness::EntityType::Publisher,
     liveliness::NodeInfo{node->context->actual_domain_id, node->namespace_, node->name, ""},
     liveliness::TopicInfo{rmw_publisher->topic_name,
@@ -1270,6 +1272,7 @@ rmw_create_subscription(
 
   // Publish to the graph that a new subscription is in town
   const auto liveliness_entity = liveliness::Entity::make(
+    z_info_zid(z_loan(node->context->impl->session)),
     liveliness::EntityType::Subscription,
     liveliness::NodeInfo{node->context->actual_domain_id, node->namespace_, node->name, ""},
     liveliness::TopicInfo{rmw_subscription->topic_name,


### PR DESCRIPTION
This PR addresses #84.

It so does so by including the zenoh session id in the liveliness token.
The token is updated to:
`<ADMIN_SPACE>/<domainid>/<id>/<entity>/<namespace>/<nodename>` where `<id>` is meant to be a unique ID to identify this entity. However, until the zenoh API exposes the globally unique IDs for each participant/entity, this id is currently set to the zenoh session's id with elements concatenated into a string using '.' as separator.

The `NodeMap` data structure is updated to an `std::multimap` to allow storing multiple nodes with the same name in the same namespace. Codebase is updated accoridngly.

Now after running two instances of `/talker`, running the command `ros2 node list` should correctly list two separate `/talker` nodes.
Note: Make sure to kill all ros2 nodes and daemons before trying this.

```bash
yadunund@ubuntu-22-04:~/ws_rmw$ ros2 node list
WARNING: Be aware that there are nodes in the graph that share an exact name, which can have unintended side effects.
/talker
/talker
```