### PR TITLE
Update GraphCache for services & clients along with remaining graph introspection methods

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -963,7 +963,6 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
   return RMW_RET_OK;
 }
 
-
 ///=============================================================================
 rmw_ret_t GraphCache::service_server_is_available(
   const char * service_name,

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -963,3 +963,23 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
   cleanup_endpoints_info.cancel();
   return RMW_RET_OK;
 }
+
+
+///=============================================================================
+rmw_ret_t GraphCache::service_server_is_available(
+  const char * service_name,
+  const char * service_type,
+  bool * is_available)
+{
+  *is_available = false;
+  std::lock_guard<std::mutex> lock(graph_mutex_);
+  GraphNode::TopicMap::iterator service_it = graph_services_.find(service_name);
+  if (service_it != graph_services_.end()){
+    GraphNode::TopicDataMap::iterator type_it = service_it->second.find(service_type);
+    if (type_it != service_it->second.end()){
+      *is_available = true;
+    }
+  }
+
+  return RMW_RET_OK;
+}

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -755,6 +755,40 @@ rmw_ret_t GraphCache::count_subscriptions(
 }
 
 ///=============================================================================
+rmw_ret_t GraphCache::count_services(
+  const char * service_name,
+  size_t * count) const
+{
+  *count = 0;
+  std::lock_guard<std::mutex> lock(graph_mutex_);
+  if (graph_services_.count(service_name) != 0) {
+    for (const std::pair<const std::string, TopicDataPtr> & it : graph_services_.at(service_name)) {
+      // Iterate through all the types and increment count.
+      *count += it.second->stats_.sub_count_;
+    }
+  }
+
+  return RMW_RET_OK;
+}
+
+///=============================================================================
+rmw_ret_t GraphCache::count_clients(
+  const char * service_name,
+  size_t * count) const
+{
+  *count = 0;
+  std::lock_guard<std::mutex> lock(graph_mutex_);
+  if (graph_services_.count(service_name) != 0) {
+    for (const std::pair<const std::string, TopicDataPtr> & it : graph_services_.at(service_name)) {
+      // Iterate through all the types and increment count.
+      *count += it.second->stats_.pub_count_;
+    }
+  }
+
+  return RMW_RET_OK;
+}
+
+///=============================================================================
 rmw_ret_t GraphCache::get_entity_names_and_types_by_node(
   liveliness::EntityType entity_type,
   rcutils_allocator_t * allocator,

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -73,7 +73,8 @@ void GraphCache::parse_put(const std::string & keyexpr)
       if (entity.type() != EntityType::Publisher &&
         entity.type() != EntityType::Subscription &&
         entity.type() != EntityType::Service &&
-        entity.type() != EntityType::Client) {
+        entity.type() != EntityType::Client)
+      {
         RCUTILS_LOG_WARN_NAMED(
           "rmw_zenoh_cpp",
           "add_topic_data() for invalid EntityType. Report this.");
@@ -92,29 +93,27 @@ void GraphCache::parse_put(const std::string & keyexpr)
       const liveliness::TopicInfo topic_info = entity.topic_info().value();
       std::string entity_desc = "";
       GraphNode::TopicMap & topic_map =
-        [&]() -> GraphNode::TopicMap&
+        [&]() -> GraphNode::TopicMap &
         {
           if (entity.type() == EntityType::Publisher) {
             entity_desc = "publisher";
             return graph_node.pubs_;
-          }
-          else if (entity.type() == EntityType::Subscription) {
+          } else if (entity.type() == EntityType::Subscription) {
             entity_desc = "subscription";
             return graph_node.subs_;
-          }
-          else if (entity.type() == EntityType::Service) {
+          } else if (entity.type() == EntityType::Service) {
             entity_desc = "service";
             return graph_node.services_;
 
-          }
-          else {
+          } else {
             entity_desc = "client";
             return graph_node.clients_;
           }
         }();
       // For the sake of reusing data structures and lookup functions, we treat publishers and clients are equivalent.
       // Similarly, subscriptions and services are equivalent.
-      const std::size_t pub_count = entity.type() == EntityType::Publisher || entity.type() == EntityType::Client ? 1 : 0;
+      const std::size_t pub_count = entity.type() == EntityType::Publisher ||
+        entity.type() == EntityType::Client ? 1 : 0;
       const std::size_t sub_count = !pub_count;
 
       TopicDataPtr graph_topic_data = std::make_shared<TopicData>(
@@ -331,7 +330,8 @@ void GraphCache::parse_del(const std::string & keyexpr)
       if (entity.type() != EntityType::Publisher &&
         entity.type() != EntityType::Subscription &&
         entity.type() != EntityType::Service &&
-        entity.type() != EntityType::Client) {
+        entity.type() != EntityType::Client)
+      {
         RCUTILS_LOG_WARN_NAMED(
           "rmw_zenoh_cpp",
           "remove_topic_data() for invalid EntityType. Report this.");
@@ -349,29 +349,27 @@ void GraphCache::parse_del(const std::string & keyexpr)
       const liveliness::TopicInfo topic_info = entity.topic_info().value();
       std::string entity_desc = "";
       GraphNode::TopicMap & topic_map =
-        [&]() -> GraphNode::TopicMap&
+        [&]() -> GraphNode::TopicMap &
         {
           if (entity.type() == EntityType::Publisher) {
             entity_desc = "publisher";
             return graph_node.pubs_;
-          }
-          else if (entity.type() == EntityType::Subscription) {
+          } else if (entity.type() == EntityType::Subscription) {
             entity_desc = "subscription";
             return graph_node.subs_;
-          }
-          else if (entity.type() == EntityType::Service) {
+          } else if (entity.type() == EntityType::Service) {
             entity_desc = "service";
             return graph_node.services_;
 
-          }
-          else {
+          } else {
             entity_desc = "client";
             return graph_node.clients_;
           }
         }();
       // For the sake of reusing data structures and lookup functions, we treat publishers and clients are equivalent.
       // Similarly, subscriptions and services are equivalent.
-      const std::size_t pub_count = entity.type() == EntityType::Publisher || entity.type() == EntityType::Client ? 1 : 0;
+      const std::size_t pub_count = entity.type() == EntityType::Publisher ||
+        entity.type() == EntityType::Client ? 1 : 0;
       const std::size_t sub_count = !pub_count;
 
       GraphNode::TopicMap::iterator topic_it = topic_map.find(topic_info.name_);
@@ -463,7 +461,8 @@ void GraphCache::parse_del(const std::string & keyexpr)
       );
       auto remove_topics =
         [&](const GraphNode::TopicMap & topic_map, const EntityType & entity_type) -> void {
-          std::size_t pub_count = entity_type == EntityType::Publisher || entity_type == EntityType::Client ? 1 : 0;
+          std::size_t pub_count = entity_type == EntityType::Publisher ||
+            entity_type == EntityType::Client ? 1 : 0;
           std::size_t sub_count = !pub_count;
           for (auto topic_it = topic_map.begin(); topic_it != topic_map.end(); ++topic_it) {
             for (auto type_it = topic_it->second.begin(); type_it != topic_it->second.end();
@@ -974,9 +973,9 @@ rmw_ret_t GraphCache::service_server_is_available(
   *is_available = false;
   std::lock_guard<std::mutex> lock(graph_mutex_);
   GraphNode::TopicMap::iterator service_it = graph_services_.find(service_name);
-  if (service_it != graph_services_.end()){
+  if (service_it != graph_services_.end()) {
     GraphNode::TopicDataMap::iterator type_it = service_it->second.find(service_type);
-    if (type_it != service_it->second.end()){
+    if (type_it != service_it->second.end()) {
       *is_available = true;
     }
   }

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -800,6 +800,10 @@ rmw_ret_t GraphCache::get_entity_names_and_types_by_node(
     return fill_names_and_types(node_it->second->pubs_, allocator, names_and_types);
   } else if (entity_type == EntityType::Subscription) {
     return fill_names_and_types(node_it->second->subs_, allocator, names_and_types);
+  } else if (entity_type == EntityType::Service) {
+    return fill_names_and_types(node_it->second->services_, allocator, names_and_types);
+  } else if (entity_type == EntityType::Client) {
+    return fill_names_and_types(node_it->second->clients_, allocator, names_and_types);
   } else {
     return RMW_RET_OK;
   }
@@ -849,7 +853,6 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
       }
     }
   }
-
 
   rmw_ret_t ret = rmw_topic_endpoint_info_array_init_with_size(
     endpoints_info,

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -709,6 +709,18 @@ rmw_ret_t GraphCache::get_topic_names_and_types(
 }
 
 ///=============================================================================
+rmw_ret_t GraphCache::get_service_names_and_types(
+  rcutils_allocator_t * allocator,
+  rmw_names_and_types_t * service_names_and_types) const
+{
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
+    allocator, "get_node_names allocator is not valid", return RMW_RET_INVALID_ARGUMENT);
+
+  std::lock_guard<std::mutex> lock(graph_mutex_);
+  return fill_names_and_types(graph_services_, allocator, service_names_and_types);
+}
+
+///=============================================================================
 rmw_ret_t GraphCache::count_publishers(
   const char * topic_name,
   size_t * count) const

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -106,6 +106,10 @@ public:
     bool no_demangle,
     rmw_names_and_types_t * topic_names_and_types) const;
 
+  rmw_ret_t get_service_names_and_types(
+    rcutils_allocator_t * allocator,
+    rmw_names_and_types_t * service_names_and_types) const;
+
   rmw_ret_t count_publishers(
     const char * topic_name,
     size_t * count) const;

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -118,6 +118,14 @@ public:
     const char * topic_name,
     size_t * count) const;
 
+  rmw_ret_t count_services(
+    const char * service_name,
+    size_t * count) const;
+
+  rmw_ret_t count_clients(
+    const char * service_name,
+    size_t * count) const;
+
   rmw_ret_t get_entity_names_and_types_by_node(
     liveliness::EntityType entity_type,
     rcutils_allocator_t * allocator,

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -141,6 +141,11 @@ public:
     bool no_demangle,
     rmw_topic_endpoint_info_array_t * endpoints_info) const;
 
+  rmw_ret_t service_server_is_available(
+    const char * service_name,
+    const char * service_type,
+    bool * is_available);
+
 private:
   /*
   namespace_1:

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -34,9 +34,14 @@
 
 
 ///=============================================================================
+// TODO(Yadunund): Since we reuse pub_count_ and sub_count_ for pub/sub and
+// service/client consider more general names for these fields.
 struct TopicStats
 {
+  // The count of publishers or clients.
   std::size_t pub_count_;
+
+  // The count of subscriptions or services.
   std::size_t sub_count_;
 
   // Constructor which initializes counters to 0.
@@ -69,8 +74,15 @@ struct GraphNode
   using TopicDataMap = std::unordered_map<std::string, TopicDataPtr>;
   // Map topic name to TopicDataMap
   using TopicMap = std::unordered_map<std::string, TopicDataMap>;
+
+  // Entries for pub/sub.
   TopicMap pubs_ = {};
   TopicMap subs_ = {};
+
+  // Entires for service/client.
+  TopicMap clients_ = {};
+  TopicMap services_ = {};
+
 };
 using GraphNodePtr = std::shared_ptr<GraphNode>;
 
@@ -146,8 +158,10 @@ private:
   // Map namespace to a map of <node_name, GraphNodePtr>.
   NamespaceMap graph_ = {};
 
-  // Optimize topic lookups across the graph.
+  // Optimize pub/sub lookups across the graph.
   GraphNode::TopicMap graph_topics_ = {};
+  // Optimize service/client lookups across the graph.
+  GraphNode::TopicMap graph_services_ = {};
 
   mutable std::mutex graph_mutex_;
 };

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -255,7 +255,7 @@ std::optional<Entity> Entity::make(const std::string & keyexpr)
   if (entity_it == str_to_entity.end()) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Received liveliness token with invalid entity.");
+      "Received liveliness token with invalid entity %s.", entity_str.c_str());
     return std::nullopt;
   }
 

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -155,7 +155,8 @@ Entity::Entity(
   if (topic_info_.has_value()) {
     const auto & topic_info = this->topic_info_.value();
     // Note: We don't append a leading "/" as we expect the ROS topic name to start with a "/".
-    token_ss << "/" + mangle_name(topic_info.name_) + "/" + topic_info.type_ + "/" + topic_info.qos_;
+    token_ss <<
+      "/" + mangle_name(topic_info.name_) + "/" + topic_info.type_ + "/" + topic_info.qos_;
   }
 
   this->keyexpr_ = token_ss.str();
@@ -389,13 +390,13 @@ bool PublishToken::del(
 }
 
 ///=============================================================================
-std::string mangle_name(const std::string& input) {
+std::string mangle_name(const std::string & input)
+{
   std::string output = "";
   for (std::size_t i = 0; i < input.length(); ++i) {
     if (input[i] == '/') {
       output += SLASH_REPLACEMENT;
-    }
-    else {
+    } else {
       output += input[i];
     }
   }
@@ -403,13 +404,13 @@ std::string mangle_name(const std::string& input) {
 }
 
 ///=============================================================================
-std::string demangle_name(const std::string& input) {
+std::string demangle_name(const std::string & input)
+{
   std::string output = "";
   for (std::size_t i = 0; i < input.length(); ++i) {
     if (input[i] == SLASH_REPLACEMENT) {
       output += '/';
-    }
-    else {
+    } else {
       output += input[i];
     }
   }

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -133,6 +133,12 @@ public:
     const std::string & token);
 };
 
+/// Replace "/" instances with "§".
+std::string mangle_name(const std::string& input);
+
+/// Replace "§" instances with "/".
+std::string demangle_name(const std::string& input);
+
 }  // namespace liveliness
 
 #endif  // DETAIL__LIVELINESS_UTILS_HPP_

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -134,10 +134,10 @@ public:
 };
 
 /// Replace "/" instances with "§".
-std::string mangle_name(const std::string& input);
+std::string mangle_name(const std::string & input);
 
 /// Replace "§" instances with "/".
-std::string demangle_name(const std::string& input);
+std::string demangle_name(const std::string & input);
 
 }  // namespace liveliness
 

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -136,7 +136,7 @@ public:
 /// Replace "/" instances with "§".
 std::string mangle_name(const std::string & input);
 
-/// Replace "§" instances with "/".
+/// Replace "%" instances with "/".
 std::string demangle_name(const std::string & input);
 
 }  // namespace liveliness

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -133,7 +133,7 @@ public:
     const std::string & token);
 };
 
-/// Replace "/" instances with "§".
+/// Replace "/" instances with "%".
 std::string mangle_name(const std::string & input);
 
 /// Replace "%" instances with "/".

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -146,6 +146,9 @@ struct rmw_service_data_t
   z_owned_keyexpr_t keyexpr;
   z_owned_queryable_t qable;
 
+  // Liveliness token for the service.
+  zc_owned_liveliness_token_t token;
+
   const void * request_type_support_impl;
   const void * response_type_support_impl;
   const char * typesupport_identifier;
@@ -171,8 +174,10 @@ struct rmw_service_data_t
 struct rmw_client_data_t
 {
   z_owned_keyexpr_t keyexpr;
-
   z_owned_closure_reply_t zn_closure_reply;
+
+  // Liveliness token for the client.
+  zc_owned_liveliness_token_t token;
 
   std::mutex message_mutex;
   std::deque<z_owned_reply_t> replies;

--- a/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "detail/rmw_data_types.hpp"
 
+#include "rmw/error_handling.h"
 #include "rmw/get_service_names_and_types.h"
 
 extern "C"
@@ -25,9 +27,13 @@ rmw_get_service_names_and_types(
   rcutils_allocator_t * allocator,
   rmw_names_and_types_t * service_names_and_types)
 {
-  static_cast<void>(node);
-  static_cast<void>(allocator);
-  static_cast<void>(service_names_and_types);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(allocator, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_names_and_types, RMW_RET_INVALID_ARGUMENT);
+
+  return node->context->impl->graph_cache.get_service_names_and_types(
+    allocator, service_names_and_types);
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
@@ -14,12 +14,8 @@
 
 #include "detail/rmw_data_types.hpp"
 
-#include "rcutils/strdup.h"
-
 #include "rmw/error_handling.h"
 #include "rmw/get_topic_names_and_types.h"
-
-#include "rcpputils/scope_exit.hpp"
 
 extern "C"
 {

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -255,7 +255,11 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     "Sending Query '%s' to fetch discovery data...",
     liveliness_str.c_str()
   );
-  z_owned_reply_channel_t channel = zc_reply_fifo_new(16);
+  // Without setting the bound value to 0, the liveliness get call
+  // block execution where there are more than 3 nodes in the graph.
+  // From the zenoh-c documentation: If `bound` is different from 0, that channel will be bound and apply back-pressure when full.
+  // TODO(Yadunund): Investigate why this is the case and try switching to callbacks instead.
+  z_owned_reply_channel_t channel = zc_reply_fifo_new(0);
   zc_liveliness_get(
     z_loan(context->impl->session), z_keyexpr(liveliness_str.c_str()),
     z_move(channel.send), NULL);

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -255,10 +255,11 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     "Sending Query '%s' to fetch discovery data...",
     liveliness_str.c_str()
   );
-  // Without setting the bound value to 0, the liveliness get call
-  // block execution where there are more than 3 nodes in the graph.
-  // From the zenoh-c documentation: If `bound` is different from 0, that channel will be bound and apply back-pressure when full.
-  // TODO(Yadunund): Investigate why this is the case and try switching to callbacks instead.
+  // We create a blocking channel that is unbounded, ie. `bound` = 0, to receive
+  // replies for the zc_liveliness_get() call. This is necessary as if the `bound`
+  // is too low, the channel may starve the zenoh executor of its threads which
+  // would lead to deadlocks when trying to receive replies and block the
+  // execution here.
   z_owned_reply_channel_t channel = zc_reply_fifo_new(0);
   zc_liveliness_get(
     z_loan(context->impl->session), z_keyexpr(liveliness_str.c_str()),

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1858,13 +1858,12 @@ rmw_create_client(
   size_t suffix_substring_position = service_type.find("Request_");
   if (std::string::npos != suffix_substring_position) {
     service_type = service_type.substr(0, suffix_substring_position);
-  }
-  else {
+  } else {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unexpected type %s for client %s. Report this bug",
       service_type.c_str(), rmw_client->service_name);
-      return nullptr;
+    return nullptr;
   }
   const auto liveliness_entity = liveliness::Entity::make(
     z_info_zid(z_loan(node->context->impl->session)),
@@ -2442,13 +2441,12 @@ rmw_create_service(
   size_t suffix_substring_position = service_type.find("Response_");
   if (std::string::npos != suffix_substring_position) {
     service_type = service_type.substr(0, suffix_substring_position);
-  }
-  else {
+  } else {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unexpected type %s for service %s. Report this bug",
       service_type.c_str(), rmw_service->service_name);
-      return nullptr;
+    return nullptr;
   }
   const auto liveliness_entity = liveliness::Entity::make(
     z_info_zid(z_loan(node->context->impl->session)),
@@ -3312,7 +3310,8 @@ rmw_service_server_is_available(
 
   rmw_client_data_t * client_data = static_cast<rmw_client_data_t *>(client->data);
   if (client_data == nullptr) {
-    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("Unable to retreive client_data from client for service %s", client->service_name);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Unable to retreive client_data from client for service %s", client->service_name);
     return RMW_RET_INVALID_ARGUMENT;
   }
 
@@ -3320,13 +3319,12 @@ rmw_service_server_is_available(
   size_t suffix_substring_position = service_type.find("Request_");
   if (std::string::npos != suffix_substring_position) {
     service_type = service_type.substr(0, suffix_substring_position);
-  }
-  else {
+  } else {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unexpected type %s for client %s. Report this bug",
       service_type.c_str(), client->service_name);
-      return RMW_RET_INVALID_ARGUMENT;
+    return RMW_RET_INVALID_ARGUMENT;
   }
 
   return node->context->impl->graph_cache.service_server_is_available(

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3208,10 +3208,26 @@ rmw_count_clients(
   const char * service_name,
   size_t * count)
 {
-  static_cast<void>(node);
-  static_cast<void>(service_name);
-  static_cast<void>(count);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, RMW_RET_INVALID_ARGUMENT);
+  int validation_result = RMW_TOPIC_VALID;
+  rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
+  if (RMW_RET_OK != ret) {
+    return ret;
+  }
+  if (RMW_TOPIC_VALID != validation_result) {
+    const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("topic_name argument is invalid: %s", reason);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
+
+  return node->context->impl->graph_cache.count_clients(service_name, count);
 }
 
 //==============================================================================
@@ -3222,10 +3238,26 @@ rmw_count_services(
   const char * service_name,
   size_t * count)
 {
-  static_cast<void>(node);
-  static_cast<void>(service_name);
-  static_cast<void>(count);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    node,
+    node->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(service_name, RMW_RET_INVALID_ARGUMENT);
+  int validation_result = RMW_TOPIC_VALID;
+  rmw_ret_t ret = rmw_validate_full_topic_name(service_name, &validation_result, nullptr);
+  if (RMW_RET_OK != ret) {
+    return ret;
+  }
+  if (RMW_TOPIC_VALID != validation_result) {
+    const char * reason = rmw_full_topic_name_validation_result_string(validation_result);
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("topic_name argument is invalid: %s", reason);
+    return RMW_RET_INVALID_ARGUMENT;
+  }
+  RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
+
+  return node->context->impl->graph_cache.count_services(service_name, count);
 }
 
 //==============================================================================


### PR DESCRIPTION
~This PR builds on top of #86  but with changes from https://github.com/ros2/rmw_zenoh/pull/87. Reviewing might be easier if we merge #87 in and rebase #86.~

Changes introduced:
* Liveliness tokens are put/deleted for service and client entities and GraphCache is updated with this information.
* Implement all remaining graph introspection functions.
* Fixes liveliness tokens when node or topic names have `/` in the middle. Eg `/add_two_ints_server/get_type_description`. Previously such names would get appended to the liveliness token without any substitution which could cause the parsing and reconstruction of `liveliness::Entity` to have incorrect values for types and qos. Now a `SLASH_REPLACEMENT` char is introduced and such names and mangled and demangled to correctly transmit and reconstruct graph information.

To Test:

```bash
# terminal 1
  ros2 run demo_nodes_cpp add_two_ints_server
```

```bash
# terminal 2
ros2 service list

# result
/add_two_ints_server/set_parameters
/add_two_ints_server/set_parameters_atomically
/add_two_ints
/add_two_ints_server/get_type_description
/add_two_ints_server/get_parameter_types
/add_two_ints_server/list_parameters
/add_two_ints_server/get_parameters
/add_two_ints_server/describe_parameters

```

```bash
ros2 node info /add_two_ints

# result 
/add_two_ints_server
  Subscribers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Publishers:
    /rosout: rcl_interfaces/msg/Log
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Service Servers:
    /add_two_ints_server/get_type_description: type_description_interfaces/srv/GetTypeDescription
    /add_two_ints: example_interfaces/srv/AddTwoInts
    /add_two_ints_server/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /add_two_ints_server/list_parameters: rcl_interfaces/srv/ListParameters
    /add_two_ints_server/get_parameters: rcl_interfaces/srv/GetParameters
    /add_two_ints_server/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /add_two_ints_server/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
    /add_two_ints_server/set_parameters: rcl_interfaces/srv/SetParameters
  Service Clients:

  Action Servers:

  Action Clients:
  ```
  
  ## Known issue (currently being investigated)
  ~Starting 3 or more nodes causes the liveliness get query at node initialization to hang indefinitely.~
  * Fixed by https://github.com/ros2/rmw_zenoh/pull/90/commits/689d10231665e6e13277b0ab6b189cfb98158997
