### PR TITLE
Limit threads per zenoh session

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -186,7 +186,14 @@
           backoff: 100,
           // Number of threads dedicated to transmission
           // By default, the number of threads is calculated as follows: 1 + ((#cores - 1) / 4)
-          // threads: 4,
+          // We limit the number of threads that the zenoh session can spin to 1.
+          // Without this limit, applications with multiple zenoh sessions can
+          // encounter system resource errors when trying to create new threads.
+          // Once zenoh migrates to relying on tokio for its async runtime,
+          // see https://github.com/eclipse-zenoh/zenoh/pull/566, we can consider
+          // removing these flags since with tokio, zenoh can better manage the threads it spins
+          // with the help of thread pools.
+          threads: 1,
         },
       },
       /// Configure the zenoh RX parameters of a link

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -187,6 +187,13 @@
         },
         // Number of threads dedicated to transmission
         // By default, the number of threads is calculated as follows: 1 + ((#cores - 1) / 4)
+        // We limit the number of threads that the zenoh session can spin to 1.
+        // Without this limit, applications with multiple zenoh sessions can
+        // encounter system resource errors when trying to create new threads.
+        // Once zenoh migrates to relying on tokio for its async runtime,
+        // see https://github.com/eclipse-zenoh/zenoh/pull/566, we can consider
+        // removing these flags since with tokio, zenoh can better manage the threads it spins
+        // with the help of thread pools.
         threads: 1,
       },
       /// Configure the zenoh RX parameters of a link

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -185,6 +185,9 @@
           /// Higher values lead to a more aggressive batching but it will introduce additional latency.
           backoff: 100,
         },
+        // Number of threads dedicated to transmission
+        // By default, the number of threads is calculated as follows: 1 + ((#cores - 1) / 4)
+        threads: 1,
       },
       /// Configure the zenoh RX parameters of a link
       rx: {

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -15,7 +15,8 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # the zenoh session can spin via the session config as well as the ASYNC_STD_THREAD_COUNT
 # environment variable. Without this limit, applications with multiple zenoh sessions can
 # encounter system resource errors when trying to create new threads.
-# Once zenoh migrates to relying on tokio for its async runtime, we can consider
+# Once zenoh migrates to relying on tokio for its async runtime,
+# see https://github.com/eclipse-zenoh/zenoh/pull/566, we can consider
 # removing these flags since with tokio, zenoh can better manage the threads it spins
 # with the help of thread pools.
 # Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -10,9 +10,24 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+# Disable default features and only enable tcp transport for zenoh. This reduces
+# build time but more importantly allows us to limit the number of threads that
+# the zenoh session can spin via the session config as well as the ASYNC_STD_THREAD_COUNT
+# environment variable. Without this limit, applications with multiple zenoh sessions can
+# encounter system resource errors when trying to create new threads.
+# Once zenoh migrates to relying on tokio for its async runtime, we can consider
+# removing these flags since with tokio, zenoh can better manage the threads it spins
+# with the help of thread pools.
+# Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
+# latter is a list separater in cmake and hence the string will be split into two
+# when expanded.
+set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp")
+
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 0.10.1-rc
+  CMAKE_ARGS
+    "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
 )
 
 # set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/install")


### PR DESCRIPTION
Fix #94 by passing `"--no-default-features;--features=zenoh/transport_tcp"` to the cargo command invoked when building `zenoh-c`. The default session config is also updated to limit the threads to 1.

Special thanks to @cottsay for advising on how to deal with the `;`s in cmake 

cc: @Mallets
