### PR TITLE
Remove the router config for threads.

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -184,16 +184,6 @@
           /// The initial exponential backoff time in nanoseconds to allow the batching to eventually progress.
           /// Higher values lead to a more aggressive batching but it will introduce additional latency.
           backoff: 100,
-          // Number of threads dedicated to transmission
-          // By default, the number of threads is calculated as follows: 1 + ((#cores - 1) / 4)
-          // We limit the number of threads that the zenoh session can spin to 1.
-          // Without this limit, applications with multiple zenoh sessions can
-          // encounter system resource errors when trying to create new threads.
-          // Once zenoh migrates to relying on tokio for its async runtime,
-          // see https://github.com/eclipse-zenoh/zenoh/pull/566, we can consider
-          // removing these flags since with tokio, zenoh can better manage the threads it spins
-          // with the help of thread pools.
-          threads: 1,
         },
       },
       /// Configure the zenoh RX parameters of a link


### PR DESCRIPTION
It doesn't seem to work; the router throws an error:

JSON error: unknown field `threads`, expected `size` or `backoff` at commons/zenoh-config/src/lib.rs:601.', zenohd/src/main.rs:176:42

This partially undoes #95.  @Yadunund FYI, I'm just going to go ahead and merge this one since the router doesn't work at all right now.