### PR TITLE
Fix handling of SIGINT by router executable

### DIFF
--- a/rmw_zenoh_cpp/apps/init_rmw_zenoh_router.cpp
+++ b/rmw_zenoh_cpp/apps/init_rmw_zenoh_router.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <stdlib.h>
+#include <sys/wait.h>
 
 #include <iostream>
 #include <string>
@@ -33,9 +34,15 @@ int Main(int, char **)
   // Execute zenohd command
   const std::string zenohd_cmd = "zenohd -c " + zenoh_router_config_path;
   const int ret = system(zenohd_cmd.c_str());
-  if (ret != 0) {
-    std::cerr << "Failed to run zenoh router: " << zenohd_cmd << std::endl;
+  if (ret < 0) {
+    std::cerr << "Error running zenoh router via command: " << zenohd_cmd << std::endl;
     return ret;
+  } else {
+    if (WIFEXITED(ret)) {
+      std::cout << "Zenoh router exited normally." << std::endl;
+    } else {
+      std::cout << "Zenoh router exited abnormally with error code [" << ret << "]" << std::endl;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
Aim to address https://github.com/ros2/rmw_zenoh/issues/78

According to the [manual page()](https://linux.die.net/man/3/system), `system` will return `-1` on error.

However right now, killing the process via SIGINT (CTRL+C) returns with error code `2`. Investigating...
```bash
[2024-01-23T14:48:43Z INFO  zenohd] Starting required plugin "rest"
[2024-01-23T14:48:43Z INFO  zenohd] Successfully started plugin rest from "/usr/lib/libzenoh_plugin_rest.so"
[2024-01-23T14:48:43Z INFO  zenohd] Finished loading plugins
^C
Thread 1 "zenohd" received signal SIGINT, Interrupt.
syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
38	../sysdeps/unix/sysv/linux/x86_64/syscall.S: No such file or directory.
(gdb) bt
#0  syscall () at ../sysdeps/unix/sysv/linux/x86_64/syscall.S:38
#1  0x00005555557a6762 in parking::Inner::park ()
#2  0x0000555555696c43 in zenohd::main ()
#3  0x000055555561eaf3 in std::sys_common::backtrace::__rust_begin_short_backtrace ()
#4  0x00005555556b23a7 in main ()
(gdb) print $eax
$1 = -512

```