### PR TITLE
add `rosdep install` to Setup instruction for resolving dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,11 @@ Build `rmw_zenoh_cpp`
 mkdir ~/ws_rmw_zenoh/src -p && cd ~/ws_rmw_zenoh/src
 git clone https://github.com/ros2/rmw_zenoh.git
 cd ~/ws_rmw_zenoh
+rosdep install --from-paths src --ignore-src --rosdistro <DISTRO> -y # replace <DISTRO> with ROS 2 distro of choice
 source /opt/ros/<DISTRO>/setup.bash # replace <DISTRO> with ROS 2 distro of choice
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 ```
-
-> Note: When the stderr `CMake Error at CMakeLists.txt:11 (find_package):` occurs, you need to install ament_cmake_vendor_package by `sudo apt install ros-<DISTRO>-ament-cmake-vendor-package`.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 
 ```
 
+> Note: When the stderr `CMake Error at CMakeLists.txt:11 (find_package):` occurs, you need to install ament_cmake_vendor_package by `sudo apt install ros-<DISTRO>-ament-cmake-vendor-package`.
+
 ## Test
 
 Make sure to source the built workspace using the commands below prior to running any other commands.


### PR DESCRIPTION
When I tried to use this awesome repository, I found `ament-cmake-vendor-package` is needed to build this package.
I tested this behavior by using both `iron` and `rolling` images on [Docker Official Image for ros](https://hub.docker.com/_/ros/), but it seems that this package is not installed by default.

```
% docker run -it ros:rolling              
# sudo apt update && sudo apt install curl
# curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
# source "$HOME/.cargo/env"
# mkdir -p ws/src && cd ws/src/
# git clone https://github.com/ros2/rmw_zenoh
# cd ..
# colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
Starting >>> zenoh_c_vendor
--- stderr: zenoh_c_vendor                         
CMake Error at CMakeLists.txt:11 (find_package):
  By not providing "Findament_cmake_vendor_package.cmake" in
  CMAKE_MODULE_PATH this project has asked CMake to find a package
  configuration file provided by "ament_cmake_vendor_package", but CMake did
  not find one.

  Could not find a package configuration file provided by
  "ament_cmake_vendor_package" with any of the following names:

    ament_cmake_vendor_packageConfig.cmake
    ament_cmake_vendor_package-config.cmake

  Add the installation prefix of "ament_cmake_vendor_package" to
  CMAKE_PREFIX_PATH or set "ament_cmake_vendor_package_DIR" to a directory
  containing one of the above files.  If "ament_cmake_vendor_package"
  provides a separate development package or SDK, be sure it has been
  installed.


---
Failed   <<< zenoh_c_vendor [0.11s, exited with code 1]

Summary: 0 packages finished [0.41s]
  1 package failed: zenoh_c_vendor
  1 package had stderr output: zenoh_c_vendor
  1 package not processed

```

Of course, those familiar with ROS will quickly realize that they can just operate `apt install ros-<DISTRO>-ament-cmake-vendor-package` to fix this issue. But there are others who don't. I think it would be not good to waste time before trying out this wonderful package. Also, I understand that it is also possible that this operation may not be necessary in the future.
However, I want to suggest adding a note about this solution for now.