### PR TITLE
Fix a number of small issues in rmw_zenoh_cpp

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -459,6 +459,9 @@ void GraphCache::parse_del(const std::string & keyexpr)
     }
     ns_it->second.erase(node_it);
     total_nodes_in_graph_ -= 1;
+    if (ns_it->second.size() == 0) {
+      graph_.erase(entity.node_namespace());
+    }
     return;
   }
 

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -205,6 +205,7 @@ void GraphCache::parse_put(const std::string & keyexpr)
     NodeMap node_map = {
       {entity.node_name(), make_graph_node(entity, *this)}};
     graph_.emplace(std::make_pair(entity.node_namespace(), std::move(node_map)));
+    total_nodes_in_graph_ += 1;
     return;
   }
 
@@ -226,6 +227,7 @@ void GraphCache::parse_put(const std::string & keyexpr)
     // name but unique id.
     NodeMap::iterator insertion_it =
       ns_it->second.insert(std::make_pair(entity.node_name(), make_graph_node(entity, *this)));
+    total_nodes_in_graph_ += 1;
     if (insertion_it == ns_it->second.end()) {
       RCUTILS_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
@@ -456,6 +458,7 @@ void GraphCache::parse_del(const std::string & keyexpr)
       remove_topics(graph_node->clients_, EntityType::Client, *this);
     }
     ns_it->second.erase(node_it);
+    total_nodes_in_graph_ -= 1;
     return;
   }
 
@@ -494,13 +497,8 @@ rmw_ret_t GraphCache::get_node_names(
   RCUTILS_CHECK_ALLOCATOR_WITH_MSG(
     allocator, "get_node_names allocator is not valid", return RMW_RET_INVALID_ARGUMENT);
 
-  size_t nodes_number = 0;
-  for (const std::pair<const std::string, NodeMap> & it : graph_) {
-    nodes_number += it.second.size();
-  }
-
   rcutils_ret_t rcutils_ret =
-    rcutils_string_array_init(node_names, nodes_number, allocator);
+    rcutils_string_array_init(node_names, total_nodes_in_graph_, allocator);
   if (rcutils_ret != RCUTILS_RET_OK) {
     return RMW_RET_BAD_ALLOC;
   }
@@ -515,7 +513,7 @@ rmw_ret_t GraphCache::get_node_names(
     });
 
   rcutils_ret =
-    rcutils_string_array_init(node_namespaces, nodes_number, allocator);
+    rcutils_string_array_init(node_namespaces, total_nodes_in_graph_, allocator);
   if (rcutils_ret != RCUTILS_RET_OK) {
     return RMW_RET_BAD_ALLOC;
   }
@@ -541,7 +539,7 @@ rmw_ret_t GraphCache::get_node_names(
   std::shared_ptr<rcpputils::scope_exit<decltype(free_enclaves_lambda)>> free_enclaves{nullptr};
   if (enclaves) {
     rcutils_ret =
-      rcutils_string_array_init(enclaves, nodes_number, allocator);
+      rcutils_string_array_init(enclaves, total_nodes_in_graph_, allocator);
     if (RCUTILS_RET_OK != rcutils_ret) {
       return RMW_RET_BAD_ALLOC;
     }

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -180,6 +180,7 @@ private:
   using NamespaceMap = std::unordered_map<std::string, NodeMap>;
   // Map namespace to a map of <node_name, GraphNodePtr>.
   NamespaceMap graph_ = {};
+  size_t total_nodes_in_graph_{0};
 
   // Optimize pub/sub lookups across the graph.
   GraphNode::TopicMap graph_topics_ = {};

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -433,67 +433,6 @@ std::string Entity::keyexpr() const
 }
 
 ///=============================================================================
-bool PublishToken::put(
-  z_owned_session_t * session,
-  const std::string & token)
-{
-  if (!z_session_check(session)) {
-    RCUTILS_SET_ERROR_MSG("The zenoh session is invalid.");
-    return false;
-  }
-
-  // TODO(Yadunund): z_keyexpr_new creates a copy so find a way to avoid it.
-  z_owned_keyexpr_t keyexpr = z_keyexpr_new(token.c_str());
-  auto drop_keyexpr = rcpputils::make_scope_exit(
-    [&keyexpr]() {
-      z_drop(z_move(keyexpr));
-    });
-  if (!z_keyexpr_check(&keyexpr)) {
-    RCUTILS_SET_ERROR_MSG("invalid keyexpression generation for liveliness publication.");
-    return false;
-  }
-
-  z_put_options_t options = z_put_options_default();
-  options.encoding = z_encoding(Z_ENCODING_PREFIX_EMPTY, NULL);
-  if (z_put(z_loan(*session), z_keyexpr(token.c_str()), nullptr, 0, &options) < 0) {
-    RCUTILS_SET_ERROR_MSG("unable to publish liveliness for node creation");
-    return false;
-  }
-
-  return true;
-}
-
-///=============================================================================
-bool PublishToken::del(
-  z_owned_session_t * session,
-  const std::string & token)
-{
-  if (!z_session_check(session)) {
-    RCUTILS_SET_ERROR_MSG("The zenoh session is invalid.");
-    return false;
-  }
-
-  // TODO(Yadunund): z_keyexpr_new creates a copy so find a way to avoid it.
-  z_owned_keyexpr_t keyexpr = z_keyexpr_new(token.c_str());
-  auto drop_keyexpr = rcpputils::make_scope_exit(
-    [&keyexpr]() {
-      z_drop(z_move(keyexpr));
-    });
-  if (!z_keyexpr_check(&keyexpr)) {
-    RCUTILS_SET_ERROR_MSG("invalid key-expression generation for liveliness publication.");
-    return false;
-  }
-
-  const z_delete_options_t options = z_delete_options_default();
-  if (z_delete(z_loan(*session), z_loan(keyexpr), &options) < 0) {
-    RCUTILS_SET_ERROR_MSG("failed to delete liveliness key");
-    return false;
-  }
-
-  return true;
-}
-
-///=============================================================================
 std::string mangle_name(const std::string & input)
 {
   std::string output = "";

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -119,21 +119,6 @@ private:
   std::string keyexpr_;
 };
 
-///=============================================================================
-/// Helper utilities to put/delete tokens until liveliness is supported in the
-/// zenoh-c bindings.
-class PublishToken
-{
-public:
-  static bool put(
-    z_owned_session_t * session,
-    const std::string & token);
-
-  static bool del(
-    z_owned_session_t * session,
-    const std::string & token);
-};
-
 /// Replace "/" instances with "%".
 std::string mangle_name(const std::string & input);
 

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -31,6 +31,11 @@ saved_msg_data::saved_msg_data(zc_owned_payload_t p, uint64_t recv_ts, const uin
   memcpy(publisher_gid, pub_gid, 16);
 }
 
+saved_msg_data::~saved_msg_data()
+{
+  z_drop(z_move(payload));
+}
+
 void rmw_subscription_data_t::attach_condition(std::condition_variable * condition_variable)
 {
   std::lock_guard<std::mutex> lock(condition_mutex_);
@@ -92,7 +97,6 @@ void rmw_subscription_data_t::add_new_message(
     // queue if it is non-empty.
     if (!message_queue_.empty()) {
       std::unique_ptr<saved_msg_data> old = std::move(message_queue_.front());
-      z_drop(z_move(old->payload));
       message_queue_.pop_front();
     }
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -111,6 +111,8 @@ struct saved_msg_data
 {
   explicit saved_msg_data(zc_owned_payload_t p, uint64_t recv_ts, const uint8_t pub_gid[16]);
 
+  ~saved_msg_data();
+
   zc_owned_payload_t payload;
   uint64_t recv_timestamp;
   uint8_t publisher_gid[16];

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -25,7 +25,6 @@
 #include <new>
 #include <optional>
 #include <random>
-#include <sstream>
 #include <string>
 #include <utility>
 
@@ -82,6 +81,8 @@ namespace
 z_owned_keyexpr_t ros_topic_name_to_zenoh_key(
   const char * const topic_name, size_t domain_id, rcutils_allocator_t * allocator)
 {
+  std::string d = std::to_string(domain_id);
+
   size_t start_offset = 0;
   size_t topic_name_len = strlen(topic_name);
   size_t end_offset = topic_name_len;
@@ -97,18 +98,17 @@ z_owned_keyexpr_t ros_topic_name_to_zenoh_key(
     }
   }
 
-  std::stringstream domain_ss;
-  domain_ss << domain_id;
   char * stripped_topic_name = rcutils_strndup(
     &topic_name[start_offset], end_offset - start_offset, *allocator);
   if (stripped_topic_name == nullptr) {
     return z_keyexpr_null();
   }
-  z_owned_keyexpr_t keyexpr = z_keyexpr_join(
-    z_keyexpr(domain_ss.str().c_str()), z_keyexpr(stripped_topic_name));
+
+  z_owned_keyexpr_t ret = z_keyexpr_join(z_keyexpr(d.c_str()), z_keyexpr(stripped_topic_name));
+
   allocator->deallocate(stripped_topic_name, allocator->state);
 
-  return keyexpr;
+  return ret;
 }
 
 //==============================================================================

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1578,7 +1578,6 @@ static rmw_ret_t __rmw_take(
   }
 
   *taken = true;
-  z_drop(&msg_data->payload);
 
   // TODO(clalancette): fill in source_timestamp
   message_info->source_timestamp = 0;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3504,10 +3504,23 @@ rmw_get_gid_for_client(const rmw_client_t * client, rmw_gid_t * gid)
 rmw_ret_t
 rmw_compare_gids_equal(const rmw_gid_t * gid1, const rmw_gid_t * gid2, bool * result)
 {
-  static_cast<void>(gid1);
-  static_cast<void>(gid2);
-  static_cast<void>(result);
-  return RMW_RET_UNSUPPORTED;
+  RMW_CHECK_ARGUMENT_FOR_NULL(gid1, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    gid1,
+    gid1->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(gid2, RMW_RET_INVALID_ARGUMENT);
+  RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
+    gid2,
+    gid2->implementation_identifier,
+    rmw_zenoh_identifier,
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RMW_CHECK_ARGUMENT_FOR_NULL(result, RMW_RET_INVALID_ARGUMENT);
+
+  *result = memcmp(gid1->data, gid2->data, RMW_GID_STORAGE_SIZE) == 0;
+
+  return RMW_RET_OK;
 }
 
 //==============================================================================

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -285,8 +285,6 @@ rmw_create_node(
       allocator->deallocate(const_cast<char *>(node->namespace_), allocator->state);
     });
 
-  // TODO(yadunund): Register with storage system here and throw error if
-  // zenohd is not running.
   // Put metadata into node->data.
   node->data = allocator->zero_allocate(1, sizeof(rmw_node_data_t), allocator->state);
   RMW_CHECK_FOR_NULL_WITH_MSG(
@@ -576,7 +574,6 @@ rmw_create_publisher(
   rmw_publisher->data = publisher_data;
   rmw_publisher->implementation_identifier = rmw_zenoh_identifier;
   rmw_publisher->options = *publisher_options;
-  // TODO(yadunund): Update this.
   rmw_publisher->can_loan_messages = false;
 
   size_t topic_len = strlen(topic_name);

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -317,11 +317,8 @@ rmw_create_node(
     NULL
   );
   auto free_token = rcpputils::make_scope_exit(
-    [node]() {
-      if (node->data != nullptr) {
-        rmw_node_data_t * node_data = static_cast<rmw_node_data_t *>(node->data);
-        z_drop(z_move(node_data->token));
-      }
+    [node_data]() {
+      z_drop(z_move(node_data->token));
     });
   if (!z_check(node_data->token)) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -330,11 +327,11 @@ rmw_create_node(
     return nullptr;
   }
 
+  free_token.cancel();
   free_node_data.cancel();
   free_namespace.cancel();
   free_name.cancel();
   free_node.cancel();
-  free_token.cancel();
   return node;
 }
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -259,17 +259,11 @@ rmw_create_node(
       allocator->deallocate(node, allocator->state);
     });
 
-  size_t name_len = strlen(name);
-  // We specifically don't use rcutils_strdup() here because we want to avoid iterating over the
-  // name again looking for the \0 (we already did that above).
-  char * new_string = static_cast<char *>(allocator->allocate(name_len + 1, allocator->state));
+  node->name = rcutils_strdup(name, *allocator);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    new_string,
+    node->name,
     "unable to allocate memory for node name",
     return nullptr);
-  memcpy(new_string, name, name_len);
-  new_string[name_len] = '\0';
-  node->name = new_string;
   auto free_name = rcpputils::make_scope_exit(
     [node, allocator]() {
       allocator->deallocate(const_cast<char *>(node->name), allocator->state);
@@ -551,17 +545,11 @@ rmw_create_publisher(
   rmw_publisher->options = *publisher_options;
   rmw_publisher->can_loan_messages = false;
 
-  size_t topic_len = strlen(topic_name);
-  // We specifically don't use rcutils_strdup() here because we want to avoid iterating over the
-  // name again looking for the \0 (we already did that above).
-  char * new_string = static_cast<char *>(allocator->allocate(topic_len + 1, allocator->state));
+  rmw_publisher->topic_name = rcutils_strdup(topic_name, *allocator);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    new_string,
+    rmw_publisher->topic_name,
     "Failed to allocate topic name",
     return nullptr);
-  memcpy(new_string, topic_name, topic_len);
-  new_string[topic_len] = '\0';
-  rmw_publisher->topic_name = new_string;
   auto free_topic_name = rcpputils::make_scope_exit(
     [rmw_publisher, allocator]() {
       allocator->deallocate(const_cast<char *>(rmw_publisher->topic_name), allocator->state);
@@ -1270,17 +1258,11 @@ rmw_create_subscription(
   rmw_subscription->implementation_identifier = rmw_zenoh_identifier;
   rmw_subscription->data = sub_data;
 
-  size_t topic_len = strlen(topic_name);
-  // We specifically don't use rcutils_strdup() here because we want to avoid iterating over the
-  // name again looking for the \0 (we already did that above).
-  char * new_string = static_cast<char *>(allocator->allocate(topic_len + 1, allocator->state));
+  rmw_subscription->topic_name = rcutils_strdup(topic_name, *allocator);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    new_string,
+    rmw_subscription->topic_name,
     "Failed to allocate topic name",
     return nullptr);
-  memcpy(new_string, topic_name, topic_len);
-  new_string[topic_len] = '\0';
-  rmw_subscription->topic_name = new_string;
   auto free_topic_name = rcpputils::make_scope_exit(
     [rmw_subscription, allocator]() {
       allocator->deallocate(const_cast<char *>(rmw_subscription->topic_name), allocator->state);

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -299,16 +299,6 @@ rmw_create_node(
   node->implementation_identifier = rmw_zenoh_identifier;
   node->context = context;
 
-  // Uncomment and rely on #if #endif blocks to enable this feature when building with
-  // zenoh-pico since liveliness is only available in zenoh-c.
-  // Publish to the graph that a new node is in town
-  // const bool pub_result = PublishToken::put(
-  //   &node->context->impl->session,
-  //   liveliness::GenerateToken::node(context->actual_domain_id, namespace_, name)
-  // );
-  // if (!pub_result) {
-  //   return nullptr;
-  // }
   // Initialize liveliness token for the node to advertise that a new node is in town.
   rmw_node_data_t * node_data = static_cast<rmw_node_data_t *>(node->data);
   const auto liveliness_entity = liveliness::Entity::make(
@@ -362,18 +352,6 @@ rmw_destroy_node(rmw_node_t * node)
     node->implementation_identifier,
     rmw_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-
-  // Uncomment and rely on #if #endif blocks to enable this feature when building with
-  // zenoh-pico since liveliness is only available in zenoh-c.
-  // Publish to the graph that a node has ridden off into the sunset
-  // const bool del_result = PublishToken::del(
-  //   &node->context->impl->session,
-  //   liveliness::GenerateToken::node(node->context->actual_domain_id, node->namespace_,
-  //     node->name)
-  // );
-  // if (!del_result) {
-  //   return RMW_RET_ERROR;
-  // }
 
   // Undeclare liveliness token for the node to advertise that the node has ridden
   // off into the sunset.
@@ -647,23 +625,6 @@ rmw_create_publisher(
       z_undeclare_publisher(z_move(publisher_data->pub));
     });
 
-  // Uncomment and rely on #if #endif blocks to enable this feature when building with
-  // zenoh-pico since liveliness is only available in zenoh-c.
-  // Publish to the graph that a new publisher is in town
-  // TODO(Yadunund): Publish liveliness for the new publisher.
-  // const bool pub_result = PublishToken::put(
-  //   &node->context->impl->session,
-  //   liveliness::GenerateToken::publisher(
-  //     node->context->actual_domain_id,
-  //     node->namespace_,
-  //     node->name,
-  //     rmw_publisher->topic_name,
-  //     publisher_data->type_support->get_name(),
-  //     "reliable")
-  // );
-  // if (!pub_result) {
-  //   return nullptr;
-  // }
   const auto liveliness_entity = liveliness::Entity::make(
     z_info_zid(z_loan(node->context->impl->session)),
     liveliness::EntityType::Publisher,
@@ -733,24 +694,6 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
 
   auto publisher_data = static_cast<rmw_publisher_data_t *>(publisher->data);
   if (publisher_data != nullptr) {
-    // Uncomment and rely on #if #endif blocks to enable this feature when building with
-    // zenoh-pico since liveliness is only available in zenoh-c.
-    // Publish to the graph that a publisher has ridden off into the sunset
-    // const bool del_result = PublishToken::del(
-    //   &node->context->impl->session,
-    //   liveliness::GenerateToken::publisher(
-    //     node->context->actual_domain_id,
-    //     node->namespace_,
-    //     node->name,
-    //     publisher->topic_name,
-    //     publisher_data->type_support->get_name(),
-    //     "reliable"
-    //   )
-    // );
-    // if (!del_result) {
-    //   // TODO(Yadunund): Should this really return an error?
-    //   return RMW_RET_ERROR;
-    // }
     z_drop(z_move(publisher_data->token));
     if (publisher_data->pub_cache.has_value()) {
       z_drop(z_move(publisher_data->pub_cache.value()));


### PR DESCRIPTION
This PR is a smorgasbord of small fixes around the tree.  It is probably easiest to look at the individual patches, but in short:

* Add a small optimization where we keep a running total of the number of nodes in the graph.  This speeds up `get_nodes_names` for large graphs, since we don't have to iterate over the namespaces anymore.
* While doing the above, I noticed that we never removed namespaces once they were added.  I added a patch so that if there are no nodes left in the namespace after this one is removed, we also remove the namespace.
* I removed a few old TODO comments.
* I removed the PublishToken implementation.  While it is somewhat nice to have, it is a bit messy and I think we are going to have to do something more substantial when we try to support zenoh-pico.  And this code is still in the git history.
* Remove some hand-coded `rcutils_strdup` implementations.  The original reason for that hand-coding is gone, so we can just use `rcutils_strdup` now.
* Speed up `ros_topic_name_to_zenoh_key`.  In particular, `std::to_string` is much faster than `std::stringstream`, so use that.
* Use RAII for saved_msg_data.  That way we don't have to remember to `z_drop` the sample.
* Implement `rmw_compare_gids_equal`, which just gets us one step closer to having a complete implementation.