### PR TITLE
Allow connections between routers

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -24,7 +24,7 @@
   /// peers, or client can use to establish a zenoh session.
   listen: {
     endpoints: [
-      "tcp/localhost:7447"
+      "tcp/[::]:7447"
     ],
   },
   /// Configure the scouting mechanisms and their behaviours


### PR DESCRIPTION
Fix the default router config to listen on all connections established to the `7447` port. 


Will add documentation on how to connect two routers, as part of the fix for https://github.com/ros2/rmw_zenoh/issues/102
