### PR TITLE
Implement __rmw_take_serialized.

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1634,6 +1634,7 @@ rmw_take_sequence(
   return RMW_RET_UNSUPPORTED;
 }
 
+//==============================================================================
 static rmw_ret_t __rmw_take_serialized(
   const rmw_subscription_t * subscription,
   rmw_serialized_message_t * serialized_message,
@@ -1669,13 +1670,16 @@ static rmw_ret_t __rmw_take_serialized(
   }
 
   if (serialized_message->buffer_capacity < msg_data->payload.payload.len) {
-    rmw_ret_t ret = rmw_serialized_message_resize(serialized_message, msg_data->payload.payload.len);
+    rmw_ret_t ret =
+      rmw_serialized_message_resize(serialized_message, msg_data->payload.payload.len);
     if (ret != RMW_RET_OK) {
       return ret;  // Error message already set
     }
   }
   serialized_message->buffer_length = msg_data->payload.payload.len;
-  memcpy(serialized_message->buffer, msg_data->payload.payload.start, msg_data->payload.payload.len);
+  memcpy(
+    serialized_message->buffer, msg_data->payload.payload.start,
+    msg_data->payload.payload.len);
 
   *taken = true;
 


### PR DESCRIPTION
This allows us to implement rmw_take_serialized_message and rmw_take_serialize_message_with_info, both of which are required for rosbag2.

Note that this implementation copies some parts of __rmw_take. Given the different types involved (void * ros_message vs. rmw_serialize_message_t *), I didn't see a readable way to reduce this duplication.

Tested by running `ros2 bag record -a`.  Before this PR, that would throw many errors, while after this PR it works as expected and can play back data.