### PR TITLE
Set pub cache queryable as complete

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -561,6 +561,7 @@ rmw_create_publisher(
   if (publisher_data->adapted_qos_profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
     ze_publication_cache_options_t pub_cache_opts = ze_publication_cache_options_default();
     pub_cache_opts.history = publisher_data->adapted_qos_profile.depth;
+    pub_cache_opts.queryable_complete = true;
     publisher_data->pub_cache = ze_declare_publication_cache(
       z_loan(context_impl->session),
       z_loan(keyexpr),
@@ -1289,11 +1290,8 @@ rmw_create_subscription(
 
   if (sub_data->adapted_qos_profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
     ze_querying_subscriber_options_t sub_options = ze_querying_subscriber_options_default();
-    // TODO(Yadunund): We need the query_target to be ALL_COMPLETE but the PubCache created
-    // does not setup a queryable that is complete. Once zettascale exposes that API,
-    // uncomment below.
-    // sub_options.query_target = Z_QUERY_TARGET_ALL_COMPLETE;
-    sub_options.query_target = Z_QUERY_TARGET_ALL;
+    // Target all complete publication caches which are queryables.
+    sub_options.query_target = Z_QUERY_TARGET_ALL_COMPLETE;
     // We set consolidation to none as we need to receive transient local messages
     // from a number of publishers. Eg: To receive TF data published over /tf_static
     // by various publishers.

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -24,9 +24,10 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # when expanded.
 set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp zenoh/shared-memory")
 
+# Set VCS_VERSION to include changes from https://github.com/eclipse-zenoh/zenoh-c/pull/243.
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 0.10.1-rc
+  VCS_VERSION de57b3fed5b1c3f4a83a2c0c0cb6a642c09a6210
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
 )


### PR DESCRIPTION
Vendor `zenoh-c` with https://github.com/eclipse-zenoh/zenoh-c/pull/243 changes and update code in `rmw_zenoh_cpp` to set publication cache's queryable as complete.
