### PR TITLE
Added docker file and docker compose to dockerize rolling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM osrf/ros:rolling-desktop
+SHELL ["/bin/bash", "-c"]
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN apt update
+COPY . /app/src/rmw_zenoh
+WORKDIR /app
+RUN rosdep install --from-paths src --ignore-src --rosdistro rolling -y
+RUN source /opt/ros/rolling/setup.bash && source "$HOME/.cargo/env" && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
+
+SHELL ["/bin/bash", "-c"]
+ENTRYPOINT ["/app/src/rmw_zenoh/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.2'
+services:
+  router:
+    build:
+      context: .
+    image: zenoh:latest
+    stdin_open: true
+    tty: true
+    container_name: router_container
+    command: router
+    volumes:
+    - /dev/shm:/dev/shm
+    network_mode: host
+
+
+  talker:
+    build:
+      context: .
+    image: zenoh:latest
+    stdin_open: true
+    tty: true
+    container_name: talker_container
+    command: talker
+    volumes:
+    - /dev/shm:/dev/shm
+    network_mode: host
+    depends_on:
+    - router
+    
+  listener:
+    build:
+      context: .
+    image: zenoh:latest
+    stdin_open: true
+    tty: true
+    container_name: listener_container
+    command: listener
+    volumes:
+    - /dev/shm:/dev/shm
+    network_mode: host
+    depends_on:
+    - router
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source ./install/setup.bash
+
+if [ $1 = "router" ]
+then
+    ros2 run rmw_zenoh_cpp rmw_zenohd
+fi
+
+if [ $1 = "talker" ]
+then
+    export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+    ros2 run demo_nodes_cpp talker
+fi
+
+if [ $1 = "listener" ]
+then
+    export RMW_IMPLEMENTATION=rmw_zenoh_cpp
+    ros2 run demo_nodes_cpp listener
+fi
+


### PR DESCRIPTION
I am working on issue #111, but I am unable to test it because my system only has ROS Humble, and the build is failing in that ROS version. Therefore, for testing purposes, I have dockerized the code for ROS Rolling. Let me know if this is helpful, and then I will update the README file with the Docker steps.

The output look like:-
![Screenshot from 2024-03-08 19-15-10](https://github.com/ros2/rmw_zenoh/assets/36565630/dc306fa1-352d-406a-ba98-7b105a42f35d)
