### PR TITLE
Attach sequence number and publisher GID to serialized messages

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1046,7 +1046,7 @@ rmw_publish_serialized_message(
 
   uint64_t sequence_number = publisher_data->get_next_sequence_number();
 
-  z_owned_bytes_map_t map = 
+  z_owned_bytes_map_t map =
     create_map_and_set_sequence_num(sequence_number, publisher_data->pub_gid);
 
   if (!z_check(map)) {


### PR DESCRIPTION
Fixes #130 by attaching the GID and sequence number to the message in `rmw_publish_serialized_message` mirroring `rmw_publish`. Tested by building locally and publishing messages from SQLite3 bag and subscribing with `ros2 topic hz`