### PR TITLE
Indefinite timeout for queries

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2234,6 +2234,11 @@ rmw_send_request(
   opts.attachment = z_bytes_map_as_attachment(&map);
 
   opts.target = Z_QUERY_TARGET_ALL_COMPLETE;
+  // The default timeout for a z_get query is 10 seconds and if a response is not received within
+  // this window, the queryable will return an invalid reply. However, it is common for actions,
+  // which are implemented using services, to take an extended duration to complete.Hence, we set
+  // the timeout_ms to the largest supported value to account for most realistic scenarios.
+  opts.timeout_ms = std::numeric_limits<uint64_t>::max();
   // Latest consolidation guarantees unicity of replies for the same key expression,
   // which optimizes bandwidth. The default is "None", which imples replies may come in any order
   // and any number.


### PR DESCRIPTION
This PR explicitly sets the `timeout_ms` get option to the max limit to account for long running actions whose implementations rely on services.