### PR TITLE
Run CI on all matrix jobs despite failure

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         docker_image: ['ros:iron-ros-base', 'ros:rolling-ros-base']
     container:


### PR DESCRIPTION
So that iron jobs run even if rolling fails due to interim docker issue