### PR TITLE
FastCDR version bump

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(zenohc REQUIRED)
 
 add_library(rmw_zenoh_cpp SHARED
   src/detail/attachment_helpers.cpp
+  src/detail/cdr.cpp
   src/detail/event.cpp
   src/detail/identifier.cpp
   src/detail/graph_cache.cpp

--- a/rmw_zenoh_cpp/src/detail/cdr.cpp
+++ b/rmw_zenoh_cpp/src/detail/cdr.cpp
@@ -1,0 +1,42 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fastcdr/Cdr.h"
+#include "fastcdr/FastBuffer.h"
+#include "fastcdr/config.h"
+
+#include "cdr.hpp"
+
+rmw_zenoh_cpp::Cdr::Cdr(eprosima::fastcdr::FastBuffer & fastbuffer)
+#if FASTCDR_VERSION_MAJOR == 1
+: cdr_(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR)
+#else
+: cdr_(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::DDS_CDR)
+#endif
+{
+}
+
+size_t rmw_zenoh_cpp::Cdr::get_serialized_data_length() const
+{
+#if FASTCDR_VERSION_MAJOR == 1
+  return cdr_.getSerializedDataLength();
+#else
+  return cdr_.get_serialized_data_length();
+#endif
+}
+
+eprosima::fastcdr::Cdr & rmw_zenoh_cpp::Cdr::get_cdr()
+{
+  return cdr_;
+}

--- a/rmw_zenoh_cpp/src/detail/cdr.hpp
+++ b/rmw_zenoh_cpp/src/detail/cdr.hpp
@@ -1,0 +1,39 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DETAIL__CDR_HPP_
+#define DETAIL__CDR_HPP_
+
+#include "fastcdr/Cdr.h"
+#include "fastcdr/FastBuffer.h"
+
+// A wrapper class to paper over the differences between Fast-CDR v1 and Fast-CDR v2
+namespace rmw_zenoh_cpp
+{
+class Cdr final
+{
+public:
+  explicit Cdr(eprosima::fastcdr::FastBuffer & fastbuffer);
+
+  eprosima::fastcdr::Cdr & get_cdr();
+
+  size_t get_serialized_data_length() const;
+
+private:
+  eprosima::fastcdr::Cdr cdr_;
+};
+
+}  // namespace rmw_zenoh_cpp
+
+#endif  // DETAIL__CDR_HPP_

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -319,8 +319,8 @@ std::shared_ptr<Entity> Entity::make(
   return std::make_shared<Entity>(
     Entity{
       zid_to_str(zid),
-      std::move(nid),
-      std::move(id),
+      nid,
+      id,
       std::move(type),
       std::move(node_info),
       std::move(topic_info)});

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <fastcdr/FastBuffer.h>
+#include <fastcdr/CdrEncoding.hpp>
 #include <fastcdr/Cdr.h>
 
 #include <zenoh.h>
@@ -915,7 +916,7 @@ rmw_publish(
   eprosima::fastcdr::Cdr ser(
     fastbuffer,
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!publisher_data->type_support->serialize_ros_message(
       ros_message,
       ser,
@@ -925,7 +926,7 @@ rmw_publish(
     return RMW_RET_ERROR;
   }
 
-  const size_t data_length = ser.getSerializedDataLength();
+  const size_t data_length = ser.get_serialized_data_length();
 
   int64_t sequence_number = publisher_data->get_next_sequence_number();
 
@@ -1057,7 +1058,7 @@ rmw_publish_serialized_message(
   eprosima::fastcdr::FastBuffer buffer(
     reinterpret_cast<char *>(serialized_message->buffer), serialized_message->buffer_length);
   eprosima::fastcdr::Cdr ser(
-    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!ser.jump(serialized_message->buffer_length)) {
     RMW_SET_ERROR_MSG("cannot correctly set serialized buffer");
     return RMW_RET_ERROR;
@@ -1077,7 +1078,7 @@ rmw_publish_serialized_message(
       z_bytes_map_drop(z_move(map));
     });
 
-  const size_t data_length = ser.getSerializedDataLength();
+  const size_t data_length = ser.get_serialized_data_length();
 
   // The encoding is simply forwarded and is useful when key expressions in the
   // session use different encoding formats. In our case, all key expressions
@@ -1162,7 +1163,7 @@ rmw_serialize(
   eprosima::fastcdr::FastBuffer buffer(
     reinterpret_cast<char *>(serialized_message->buffer), data_length);
   eprosima::fastcdr::Cdr ser(
-    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::Cdr::DDS_CDR);
+    buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN, eprosima::fastcdr::CdrVersion::DDS_CDR);
 
   auto ret = tss.serialize_ros_message(ros_message, ser, callbacks);
   serialized_message->buffer_length = data_length;
@@ -1189,7 +1190,7 @@ rmw_deserialize(
   eprosima::fastcdr::FastBuffer buffer(
     reinterpret_cast<char *>(serialized_message->buffer), serialized_message->buffer_length);
   eprosima::fastcdr::Cdr deser(buffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
 
   auto ret = tss.deserialize_ros_message(deser, ros_message, callbacks);
   return ret == true ? RMW_RET_OK : RMW_RET_ERROR;
@@ -1665,7 +1666,7 @@ static rmw_ret_t __rmw_take(
   eprosima::fastcdr::Cdr deser(
     fastbuffer,
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!sub_data->type_support->deserialize_ros_message(
       deser,
       ros_message,
@@ -2246,7 +2247,7 @@ rmw_send_request(
   eprosima::fastcdr::Cdr ser(
     fastbuffer,
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!client_data->request_type_support->serialize_ros_message(
       ros_request,
       ser,
@@ -2255,7 +2256,7 @@ rmw_send_request(
     return RMW_RET_ERROR;
   }
 
-  size_t data_length = ser.getSerializedDataLength();
+  size_t data_length = ser.get_serialized_data_length();
 
   *sequence_id = client_data->get_next_sequence_number();
 
@@ -2342,7 +2343,7 @@ rmw_take_response(
   eprosima::fastcdr::Cdr deser(
     fastbuffer,
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!client_data->response_type_support->deserialize_ros_message(
       deser,
       ros_response,
@@ -2791,7 +2792,7 @@ rmw_take_request(
   eprosima::fastcdr::Cdr deser(
     fastbuffer,
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!service_data->request_type_support->deserialize_ros_message(
       deser,
       ros_request,
@@ -2893,7 +2894,7 @@ rmw_send_response(
   eprosima::fastcdr::Cdr ser(
     fastbuffer,
     eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
-    eprosima::fastcdr::Cdr::DDS_CDR);
+    eprosima::fastcdr::CdrVersion::DDS_CDR);
   if (!service_data->response_type_support->serialize_ros_message(
       ros_response,
       ser,
@@ -2902,7 +2903,7 @@ rmw_send_response(
     return RMW_RET_ERROR;
   }
 
-  size_t data_length = ser.getSerializedDataLength();
+  size_t data_length = ser.get_serialized_data_length();
 
   // Create the queryable payload
   std::unique_ptr<ZenohQuery> query =


### PR DESCRIPTION
the ros2 rolling repo recently bumped FastCDR from version 1.1.x to 2.2.x. This moves around some of the constants for FastBuffers. Specifically it renames getSerializedDataLength to get_serialized_data_length and moves where the DDS_CDR serialization flag lives. 

References:
Rolling repos update: https://github.com/ros2/ros2/pull/1530/files
FastCDR Include Dirs @ 1.1.x: https://github.com/eProsima/Fast-CDR/tree/1.1.x/include/fastcdr
FastCDR Include Dirs @ 2.2.x: https://github.com/eProsima/Fast-CDR/tree/2.2.x/include/fastcdr