### PR TITLE
Fix memory leak in `rmw_publisher`

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -859,7 +859,7 @@ rmw_publish(
       }
     });
   auto free_msg_bytes = rcpputils::make_scope_exit(
-    [msg_bytes, allocator, &shmbuf]() {
+    [&msg_bytes, allocator, &shmbuf]() {
       if (msg_bytes && !shmbuf.has_value()) {
         allocator->deallocate(msg_bytes, allocator->state);
       }


### PR DESCRIPTION
The msg_bytes capture for the lambda to clean up memory was captured by value which meant it couldn't actually discard the memory. Passing by reference allows the allocator to dealloc the memory.