### PR TITLE
Add rmw_zenoh_cpp to the implementations group.

### DIFF
--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>zenoh_c_vendor</build_depend>
+  <build_export_depend>zenoh_c_vendor</build_export_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>fastcdr</depend>

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -23,6 +23,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <member_of_group>rmw_implementation_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Otherwise, the correct ament index resource files won't be generated, and rmw_zenoh_cpp won't be picked up as a viable RMW during automatic detection.