### PR TITLE
Fix query queue for multiple clients

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -251,9 +251,9 @@ public:
 
   void add_new_query(std::unique_ptr<ZenohQuery> query);
 
-  bool add_to_query_map(uint8_t client_gid[RMW_GID_STORAGE_SIZE], int64_t sequence_number, std::unique_ptr<ZenohQuery> query);
+  bool add_to_query_map(const rmw_request_id_t & request_id, std::unique_ptr<ZenohQuery> query);
 
-  std::unique_ptr<ZenohQuery> take_from_query_map(uint8_t client_gid[RMW_GID_STORAGE_SIZE], int64_t sequence_number);
+  std::unique_ptr<ZenohQuery> take_from_query_map(const rmw_request_id_t & request_id);
 
   DataCallbackManager data_callback_mgr;
 

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -24,7 +24,6 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -252,9 +251,9 @@ public:
 
   void add_new_query(std::unique_ptr<ZenohQuery> query);
 
-  bool add_to_query_map(int64_t sequence_number, std::unique_ptr<ZenohQuery> query);
+  bool add_to_query_map(uint8_t client_gid[RMW_GID_STORAGE_SIZE], int64_t sequence_number, std::unique_ptr<ZenohQuery> query);
 
-  std::unique_ptr<ZenohQuery> take_from_query_map(int64_t sequence_number);
+  std::unique_ptr<ZenohQuery> take_from_query_map(uint8_t client_gid[RMW_GID_STORAGE_SIZE], int64_t sequence_number);
 
   DataCallbackManager data_callback_mgr;
 
@@ -265,8 +264,9 @@ private:
   std::deque<std::unique_ptr<ZenohQuery>> query_queue_;
   mutable std::mutex query_queue_mutex_;
 
-  // Map to store the sequence_number -> query_id
-  std::unordered_map<int64_t, std::unique_ptr<ZenohQuery>> sequence_to_query_map_;
+  // Map to store the sequence_number (as given by the client) -> ZenohQuery
+  using SequenceToQuery = std::unordered_map<int64_t, std::unique_ptr<ZenohQuery>>;
+  std::unordered_map<size_t, SequenceToQuery> sequence_to_query_map_;
   std::mutex sequence_to_query_map_mutex_;
 
   std::condition_variable * condition_{nullptr};

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2812,6 +2812,7 @@ rmw_take_request(
 
   // Add this query to the map, so that rmw_send_response can quickly look it up later
   if (!service_data->add_to_query_map(
+      request_header->request_id.writer_guid,
       request_header->request_id.sequence_number, std::move(query)))
   {
     RMW_SET_ERROR_MSG("duplicate sequence number in the map");

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2811,9 +2811,7 @@ rmw_take_request(
   request_header->received_timestamp = now_ns.count();
 
   // Add this query to the map, so that rmw_send_response can quickly look it up later
-  if (!service_data->add_to_query_map(
-      request_header->request_id.writer_guid,
-      request_header->request_id.sequence_number, std::move(query)))
+  if (!service_data->add_to_query_map(request_header->request_id, std::move(query)))
   {
     RMW_SET_ERROR_MSG("duplicate sequence number in the map");
     return RMW_RET_ERROR;
@@ -2852,7 +2850,7 @@ rmw_send_response(
 
   // Create the queryable payload
   std::unique_ptr<ZenohQuery> query =
-    service_data->take_from_query_map(request_header->writer_guid, request_header->sequence_number);
+    service_data->take_from_query_map(*request_header);
   if (query == nullptr) {
     // If there is no data associated with this request, the higher layers of
     // ROS 2 seem to expect that we just silently return with no work.

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2851,7 +2851,7 @@ rmw_send_response(
 
   // Create the queryable payload
   std::unique_ptr<ZenohQuery> query =
-    service_data->take_from_query_map(request_header->sequence_number);
+    service_data->take_from_query_map(request_header->writer_guid, request_header->sequence_number);
   if (query == nullptr) {
     // If there is no data associated with this request, the higher layers of
     // ROS 2 seem to expect that we just silently return with no work.

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -2811,8 +2811,7 @@ rmw_take_request(
   request_header->received_timestamp = now_ns.count();
 
   // Add this query to the map, so that rmw_send_response can quickly look it up later
-  if (!service_data->add_to_query_map(request_header->request_id, std::move(query)))
-  {
+  if (!service_data->add_to_query_map(request_header->request_id, std::move(query))) {
     RMW_SET_ERROR_MSG("duplicate sequence number in the map");
     return RMW_RET_ERROR;
   }

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3417,7 +3417,7 @@ rmw_get_node_names(
 }
 
 //==============================================================================
-/// Return the name, namespae, and enclave name of all nodes in the ROS graph.
+/// Return the name, namespace, and enclave name of all nodes in the ROS graph.
 rmw_ret_t
 rmw_get_node_names_with_enclaves(
   const rmw_node_t * node,


### PR DESCRIPTION
This PR cherry-picks commits from #153 that were reverted in #157 that fix how we store and access queries from different clients.

Validated that the changes here fix [#152 ](https://github.com/ros2/rmw_zenoh/issues/152)

nav2 and open-rmf also work.