### PR TITLE
Drop the rustup iron requirement

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,8 +21,6 @@ jobs:
     - name: Deps
       run: |
         apt update && apt install -y curl
-    - name: Setup Rust
-      uses: dtolnay/rust-toolchain@1.75.0
     - uses: actions/checkout@v2
     - name: rosdep
       run: |

--- a/README.md
+++ b/README.md
@@ -15,14 +15,6 @@ For information about the Design please visit [design](docs/design.md) page.
 
 ## Setup
 
-Install latest rustc via `rustup` if building on Ubuntu Jammy.
-Skip this step if building on Ubuntu Noble as `cargo` and `rustc` will be
-installed via `rosdep`.
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-rustup install 1.75.0
-```
-
 Build `rmw_zenoh_cpp`
 
 ```bash


### PR DESCRIPTION
It seems to work just fine in Iron without it:

```Dockerfile
FROM ros:iron
SHELL [ "/bin/bash", "-c" ]
RUN apt-get update -qq && apt-get install -qqy python3-colcon-core ros-iron-demo-nodes-cpp
RUN mkdir -p /ws/src
WORKDIR /ws
RUN git clone https://github.com/ros2/rmw_zenoh /ws/src/rmw_zenoh
RUN rosdep update && rosdep install --from-paths src --ignore-src -y
RUN source /opt/ros/iron/setup.bash && colcon build
CMD [ "bash", "-c", "source /ws/install/setup.bash && \
  export RMW_IMPLEMENTATION=rmw_zenoh_cpp && \
  ros2 run rmw_zenoh_cpp rmw_zenohd & \
  ros2 run demo_nodes_cpp talker & \
  ros2 run demo_nodes_cpp listener" ]
```