### PR TITLE
Fix compilation when building zenohc in debug mode.

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -23,7 +23,10 @@ find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_dds_common REQUIRED)
 find_package(zenoh_c_vendor REQUIRED)
-find_package(zenohc REQUIRED)
+find_package(zenohc_debug QUIET)
+if(NOT zenohc_debug_FOUND)
+  find_package(zenohc REQUIRED)
+endif()
 
 add_library(rmw_zenoh_cpp SHARED
   src/detail/attachment_helpers.cpp


### PR DESCRIPTION
When zenohc is built in debug mode, it actually changes the name of the zenohcConfig.cmake file to zenohc_debugConfig.cmake. Luckily it does not change the name of the library.

To deal with this, first quietly look for the debug version. If we don't find that, then fall back to the release version. This should make it compile in both circumstances.

This should fix #165 