### PR TITLE
Support RMW_EVENT_MESSAGE_LOST

### DIFF
--- a/rmw_zenoh_cpp/src/detail/event.hpp
+++ b/rmw_zenoh_cpp/src/detail/event.hpp
@@ -158,12 +158,7 @@ private:
   mutable std::mutex event_condition_mutex_;
   /// Condition variable to attach for event notifications.
   std::condition_variable * event_conditions_[ZENOH_EVENT_ID_MAX + 1]{nullptr};
-  /// User callback that can be set via data_callback_mgr.set_callback().
-  rmw_event_callback_t callback_ {nullptr};
-  /// User data that should be passed to the user callback.
-  const void * user_data_ {nullptr};
-  /// Count for
-  size_t unread_count_ {0};
+
   rmw_event_callback_t event_callback_[ZENOH_EVENT_ID_MAX + 1] {nullptr};
   const void * event_data_[ZENOH_EVENT_ID_MAX + 1] {nullptr};
   size_t event_unread_count_[ZENOH_EVENT_ID_MAX + 1] {0};

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -88,7 +88,6 @@ static const char PUB_STR[] = "MP";
 static const char SUB_STR[] = "MS";
 static const char SRV_STR[] = "SS";
 static const char CLI_STR[] = "SC";
-static const char EMPTY_NAMESPACE_REPLACEMENT = '_';
 static const char KEYEXPR_DELIMITER = '/';
 static const char SLASH_REPLACEMENT = '%';
 static const char QOS_DELIMITER = ':';
@@ -261,7 +260,7 @@ Entity::Entity(
   keyexpr_parts[KeyexprIndex::Id] = id_;
   keyexpr_parts[KeyexprIndex::EntityStr] = entity_to_str.at(type_);
   // An empty namespace from rcl will contain "/" but zenoh does not allow keys with "//".
-  // Hence we add an "_" to denote an empty namespace such that splitting the key
+  // Hence we mangle the empty namespace such that splitting the key
   // will always result in 5 parts.
   keyexpr_parts[KeyexprIndex::Namespace] = mangle_name(node_info_.ns_);
   keyexpr_parts[KeyexprIndex::NodeName] = mangle_name(node_info_.name_);

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -191,6 +191,10 @@ private:
   std::deque<std::unique_ptr<saved_msg_data>> message_queue_;
   mutable std::mutex message_queue_mutex_;
 
+  // Map GID of a publisher to the sequence number of the message it published.
+  std::unordered_map<size_t, int64_t> last_known_published_msg_;
+  size_t total_messages_lost_{0};
+
   void notify();
 
   std::condition_variable * condition_{nullptr};


### PR DESCRIPTION
This PR brings support for `RMW_EVENT_MESSAGE_LOST`.

It's best to test with https://github.com/ros2/demos/pull/679.

Run the `message_lost_talker` node to publish at 1000Hz. See https://github.com/ros2/demos/tree/rolling/quality_of_service_demo#message-lost-status-event-demo for more details.


Also removes unused variables from #103 

