### PR TITLE
Include topic type and hash in key expression

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -32,6 +32,8 @@
 
 #include "rmw/rmw.h"
 
+#include "rosidl_runtime_c/type_hash.h"
+
 #include "event.hpp"
 #include "graph_cache.hpp"
 #include "message_type_support.hpp"
@@ -106,6 +108,7 @@ public:
   // Type support fields
   const void * type_support_impl;
   const char * typesupport_identifier;
+  const rosidl_type_hash_t * type_hash;
   MessageTypeSupport * type_support;
 
   // Context for memory allocation for messages.
@@ -171,6 +174,7 @@ public:
 
   const void * type_support_impl;
   const char * typesupport_identifier;
+  const rosidl_type_hash_t * type_hash;
   MessageTypeSupport * type_support;
   rmw_context_t * context;
 
@@ -242,6 +246,7 @@ public:
   const void * request_type_support_impl;
   const void * response_type_support_impl;
   const char * typesupport_identifier;
+  const rosidl_type_hash_t * type_hash;
   RequestTypeSupport * request_type_support;
   ResponseTypeSupport * response_type_support;
 
@@ -313,6 +318,7 @@ public:
   const void * request_type_support_impl;
   const void * response_type_support_impl;
   const char * typesupport_identifier;
+  const rosidl_type_hash_t * type_hash;
   RequestTypeSupport * request_type_support;
   ResponseTypeSupport * response_type_support;
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -102,10 +102,13 @@ z_owned_keyexpr_t ros_topic_name_to_zenoh_key(
   const char * const topic_type,
   const char * const type_hash)
 {
-  const std::string keyexpr_str = std::to_string(domain_id) + "/" +
-    strip_slashes(topic_name) + "/" +
-    std::string(topic_type) + "/" +
-    std::string(type_hash);
+  std::string keyexpr_str = std::to_string(domain_id);
+  keyexpr_str += "/";
+  keyexpr_str += strip_slashes(topic_name);
+  keyexpr_str += "/";
+  keyexpr_str += topic_type;
+  keyexpr_str += "/";
+  keyexpr_str += type_hash;
 
   return z_keyexpr_new(keyexpr_str.c_str());
 }

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -84,7 +84,7 @@ std::string strip_slashes(const char * const str)
   if (str[end] == '/') {
     --end;
   }
-  return ret.substr(start, end - start);
+  return ret.substr(start, end - start + 1);
 }
 
 //==============================================================================

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -74,7 +74,6 @@ namespace
 // <ros_domain_id>/<topic_name>/<topic_type>/<topic_hash>
 // In particular, Zenoh keys cannot start or end with a /, so this function
 // will strip them out.
-// The Zenoh key is also prefixed with the ros_domain_id.
 // Performance note: at present, this function allocates a new string and copies
 // the old string into it. If this becomes a performance problem, we could consider
 // modifying the topic_name in place. But this means we need to be much more


### PR DESCRIPTION
Fix https://github.com/ros2/rmw_zenoh/issues/117 while factoring in https://github.com/ros2/rmw_zenoh/issues/201#issuecomment-2166445736.

The keyexprs now adopt the format

```
<ros_domain_id>/<topic_name>/<topic_type>/<topic_hash>
``` 

Topic names are no longer mangled.

I will follow up with a separate PR to also add the `topic_hash` to the liveliness tokens so that we can include the hash in the endpoint info when querying topic info.