### PR TITLE
git is required in buildstep

### DIFF
--- a/zenoh_c_vendor/package.xml
+++ b/zenoh_c_vendor/package.xml
@@ -8,7 +8,6 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <build_depend>cargo</build_depend>

--- a/zenoh_c_vendor/package.xml
+++ b/zenoh_c_vendor/package.xml
@@ -8,12 +8,12 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
   <build_depend>cargo</build_depend>
   <build_depend>clang</build_depend>
+  <build_depend>git</build_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
It's probably not coming in via `ament_cmake_vendor_package` as that package supports multiple vcs. 