### PR TITLE
Add TLS and compression features by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ For information about the Design please visit [design](docs/design.md) page.
 
 Build `rmw_zenoh_cpp`
 
+>Note: By default, we vendor and compile `zenoh-c` with a subset of `zenoh` features.
+The `ZENOHC_CARGO_FLAGS` CMake argument may be overwritten with other features included if required.
+See [zenoh_c_vendor/CMakeLists.txt](./zenoh_c_vendor/CMakeLists.txt) for more details.
+
 ```bash
 mkdir ~/ws_rmw_zenoh/src -p && cd ~/ws_rmw_zenoh/src
 git clone https://github.com/ros2/rmw_zenoh.git

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
 # Disable default features and enable only the most useful ones. This reduces build time and footprint.
-# You can add here any Zenoh feature that are listed in this file: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
+# For a complete list of features see: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
 # Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
 # latter is a list separater in cmake and hence the string will be split into two
 # when expanded.
@@ -26,11 +26,7 @@ ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 390ec14e1b3785cd771bd6931db65062222bb735
   CMAKE_ARGS
-  "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
-)# set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/install")
-# install(
-# DIRECTORY "${INSTALL_DIR}/lib/"
-# DESTINATION "lib/${PROJECT_NAME}"
-# USE_SOURCE_PERMISSIONS
-# )
+    "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
+)
+
 ament_package()

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -10,15 +10,8 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-# Disable default features and only enable tcp, tls and shared-memory transport for zenoh.
-# This reduces build time but more importantly allows us to limit the number of threads that
-# the zenoh session can spin via the session config as well as the ASYNC_STD_THREAD_COUNT
-# environment variable. Without this limit, applications with multiple zenoh sessions can
-# encounter system resource errors when trying to create new threads.
-# Once zenoh migrates to relying on tokio for its async runtime,
-# see https://github.com/eclipse-zenoh/zenoh/pull/566, we can consider
-# removing these flags since with tokio, zenoh can better manage the threads it spins
-# with the help of thread pools.
+# Disable default features and enable only the most useful ones. This reduces build time and footprint.
+# You can add here any Zenoh feature that are listed in this file: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
 # Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
 # latter is a list separater in cmake and hence the string will be split into two
 # when expanded.
@@ -34,8 +27,7 @@ ament_vendor(zenoh_c_vendor
   VCS_VERSION 390ec14e1b3785cd771bd6931db65062222bb735
   CMAKE_ARGS
   "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
-)
-# set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/install")
+)# set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/install")
 # install(
 # DIRECTORY "${INSTALL_DIR}/lib/"
 # DESTINATION "lib/${PROJECT_NAME}"

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -10,8 +10,8 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-# Disable default features and only enable tcp transport for zenoh. This reduces
-# build time but more importantly allows us to limit the number of threads that
+# Disable default features and only enable tcp, tls and shared-memory transport for zenoh.
+# This reduces build time but more importantly allows us to limit the number of threads that
 # the zenoh session can spin via the session config as well as the ASYNC_STD_THREAD_COUNT
 # environment variable. Without this limit, applications with multiple zenoh sessions can
 # encounter system resource errors when trying to create new threads.
@@ -22,7 +22,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
 # latter is a list separater in cmake and hence the string will be split into two
 # when expanded.
-set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp zenoh/shared-memory")
+set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp zenoh/transport_tls zenoh/shared-memory")
 
 # Set VCS_VERSION to include latest changes from zenoh-c to benefit from :
 # - https://github.com/eclipse-zenoh/zenoh-c/pull/340 (fix build issue)
@@ -33,12 +33,12 @@ ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 390ec14e1b3785cd771bd6931db65062222bb735
   CMAKE_ARGS
-    "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
+  "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
 )
 # set(INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-prefix/install")
 # install(
-#   DIRECTORY "${INSTALL_DIR}/lib/"
-#   DESTINATION "lib/${PROJECT_NAME}"
-#   USE_SOURCE_PERMISSIONS
+# DIRECTORY "${INSTALL_DIR}/lib/"
+# DESTINATION "lib/${PROJECT_NAME}"
+# USE_SOURCE_PERMISSIONS
 # )
 ament_package()

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
 # latter is a list separater in cmake and hence the string will be split into two
 # when expanded.
-set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp zenoh/transport_compression zenoh/transport_tls zenoh/shared-memory")
+set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/shared-memory zenoh/transport_compression zenoh/transport_tcp zenoh/transport_tls")
 
 # Set VCS_VERSION to include latest changes from zenoh-c to benefit from :
 # - https://github.com/eclipse-zenoh/zenoh-c/pull/340 (fix build issue)

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -22,7 +22,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
 # latter is a list separater in cmake and hence the string will be split into two
 # when expanded.
-set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp zenoh/transport_tls zenoh/shared-memory")
+set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/transport_tcp zenoh/transport_compression zenoh/transport_tls zenoh/shared-memory")
 
 # Set VCS_VERSION to include latest changes from zenoh-c to benefit from :
 # - https://github.com/eclipse-zenoh/zenoh-c/pull/340 (fix build issue)


### PR DESCRIPTION
Both TLS and compression are important features available in Zenoh.
This PR make them build by default for `rmw_zenoh`.

It also updates a comment wrt. threading and Tokio. This comment became obsolete after the switch of Zenoh from async_std to Tokio.