### PR TITLE
Add Jazzy to list of ROS distros supported in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A ROS 2 RMW implementation based on Zenoh that is written using the zenoh-c bind
 For information about the Design please visit [design](docs/design.md) page.
 
 ## Requirements
-- [ROS 2](https://docs.ros.org): Rolling/Iron
+- [ROS 2](https://docs.ros.org): Rolling/Jazzy/Iron
 
 
 ## Setup


### PR DESCRIPTION
Follow up to #167 