### PR TITLE
print router id on startup

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -104,12 +104,14 @@ install(
 add_executable(rmw_zenohd
   src/zenohd/main.cpp
   src/detail/zenoh_config.cpp
+  src/detail/liveliness_utils.cpp
 )
 
 target_link_libraries(rmw_zenohd
   PRIVATE
     ament_index_cpp::ament_index_cpp
     rcutils::rcutils
+    rcpputils::rcpputils
     rmw::rmw
     zenohc::lib
 )

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -32,6 +32,7 @@
 #include <ament_index_cpp/get_package_share_directory.hpp>
 
 #include "../detail/zenoh_config.hpp"
+#include "../detail/liveliness_utils.hpp"
 
 #include "rmw/error_handling.h"
 
@@ -188,7 +189,9 @@ int main(int argc, char ** argv)
     printf("Unable to open router session!\n");
     return 1;
   }
-
+  printf(
+    "router id: %s\n",
+    rmw_zenoh_cpp::liveliness::zid_to_str(z_info_zid(z_session_loan(&s))).c_str());
 #ifdef _WIN32
   SetConsoleCtrlHandler(quit, TRUE);
 #else

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, char ** argv)
     return 1;
   }
   printf(
-    "Started Zenoh router with id: %s.\n",
+    "Started Zenoh router with id %s.\n",
     rmw_zenoh_cpp::liveliness::zid_to_str(z_info_zid(z_session_loan(&s))).c_str());
 #ifdef _WIN32
   SetConsoleCtrlHandler(quit, TRUE);

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -190,7 +190,7 @@ int main(int argc, char ** argv)
     return 1;
   }
   printf(
-    "router id: %s\n",
+    "Started Zenoh router with id: %s.\n",
     rmw_zenoh_cpp::liveliness::zid_to_str(z_info_zid(z_session_loan(&s))).c_str());
 #ifdef _WIN32
   SetConsoleCtrlHandler(quit, TRUE);


### PR DESCRIPTION
Minimal PR related to #188 
This was enough for me to realize that it would take too long to ramp up (learning the basics of rust, loaning etc) to do a better job here. Pulling in the liveliness utils to print out the router id is ugly as well (but still beats code replication).
I agree with @Yadunund that having the router ids of connected routers logged would be much better, but this is the best I can do in a limited amount of time. Please close if you plan on doing it right in the near future.
Your work on rmw_zenoh is much appreciated. 