### PR TITLE
Fix `zid_to_str` to treat `z_id_t` as little endian

### DIFF
--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -224,7 +224,7 @@ std::string zid_to_str(const z_id_t & id)
   std::stringstream ss;
   ss << std::hex;
   // By Zenoh convention a z_id_t is a little endian u128
-  size_t i = sizeof(id.id)-1;
+  size_t i = sizeof(id.id) - 1;
   for (; i >= 0; i--) {
     ss << static_cast<int>(id.id[i]);
   }

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -223,8 +223,9 @@ std::string zid_to_str(const z_id_t & id)
 {
   std::stringstream ss;
   ss << std::hex;
-  size_t i = 0;
-  for (; i < (sizeof(id.id)); i++) {
+  // By Zenoh convention a z_id_t is a little endian u128
+  size_t i = sizeof(id.id)-1;
+  for (; i >= 0; i--) {
     ss << static_cast<int>(id.id[i]);
   }
   return ss.str();


### PR DESCRIPTION
By convention in Zenoh, a `z_id_t` is a little endian u128.
[`rmw_zenoh_cpp::liveliness::zid_to_str()`](https://github.com/ros2/rmw_zenoh/blob/60b131ea969cc9711e08efd9e44e7fef6485d96e/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp#L222) was treating it as big endian, leading to inconsistency with representation in Zenoh logs.