### PR TITLE
Change Node config to listen only on loopback

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -24,7 +24,7 @@
   /// peers, or client can use to establish a zenoh session.
   listen: {
     endpoints: [
-      // "tcp/localhost:7447",
+      "tcp/localhost:0",
     ],
   },
   /// Configure the scouting mechanisms and their behaviours

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -13,7 +13,7 @@
 
   /// Which endpoints to connect to. E.g. tcp/localhost:7447.
   /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
-  /// ROS setting: By default connect to the Zenoh router on localhost on port 7447
+  /// ROS setting: By default connect to the Zenoh router on localhost on port 7447.
   connect: {
     endpoints: [
       "tcp/localhost:7447",

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -13,6 +13,7 @@
 
   /// Which endpoints to connect to. E.g. tcp/localhost:7447.
   /// By configuring the endpoints, it is possible to tell zenoh which router/peer to connect to at startup.
+  /// ROS setting: By default connect to the Zenoh router on localhost on port 7447
   connect: {
     endpoints: [
       "tcp/localhost:7447",
@@ -22,6 +23,8 @@
   /// Which endpoints to listen on. E.g. tcp/localhost:7447.
   /// By configuring the endpoints, it is possible to tell zenoh which are the endpoints that other routers,
   /// peers, or client can use to establish a zenoh session.
+  /// ROS setting: By default accept incoming connections only from localhost (i.e. from colocalized Nodes).
+  ///              All communications with other hosts are routed by the Zenoh router.
   listen: {
     endpoints: [
       "tcp/localhost:0",


### PR DESCRIPTION
In [DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5](https://github.com/ros2/rmw_zenoh/blob/868b64ef3fd64e4f52d76f9933308791a915b6de/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5#L27) no listen endpoints is set. For a `peer` configuration, this implies that Zenoh will by default open a listening TCP socket on a random port (chosen by the OS) and on ANY network interface.
This means that each Node can be directly connected on TCP via any interface, bypassing the router and its possible security configurations (TLS and access control).

This PR changes the default configuration to make each Node to listen for TCP connection only on the loopback interface: `tcp/localhost:0` (port `0` meaning let the OS choose a random port)
