### PR TITLE
-v option for zenohd

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,14 @@ In this example, the `Zenoh router` will connect to the `Zenoh router` running o
 
 ### Logging
 
-The core of Zenoh is implemented in Rust and uses a logging library that can be configured via a `RUST_LOG` environment variable.
-This variable can be configured independently for each Node and the Zenoh router.
-For instance:
+The core of Zenoh is implemented in Rust and uses a logging library that can be configured via a `RUST_LOG` environment variable. This variable can be configured independently for each Node and for the Zenoh router.  
+The router also supports a `-v` command line option that internally set this environment variable to different values depending the number of `-v` flags.
+
+Examples of setting:
 - `RUST_LOG=zenoh=info` activates information logs about Zenoh initialization and the endpoints it's listening on.
 - `RUST_LOG=zenoh=info,zenoh_transport=debug` adds some debug logs about the connectivity events in Zenoh.
 - `RUST_LOG=zenoh=info,zenoh::net::routing::queries=trace` adds some trace logs for each query (i.e. calls to services and actions).
 - `RUST_LOG=zenoh=debug` activates all the debug logs.
+- `RUST_LOG=zenoh=trace` most verbose setting (use with cautious considering the amount of logs).
 
 For more information on the `RUST_LOG` syntax, see https://docs.rs/env_logger/latest/env_logger/#enabling-logging.

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -25,6 +25,7 @@
 #include <signal.h>
 #include <termios.h>
 #include <unistd.h>
+#include <getopt.h>
 #endif
 
 #include <zenoh.h>
@@ -168,10 +169,71 @@ void quit(int sig)
 }
 #endif
 
+// "RUST_LOG" environment variable used to configure Zenoh logging
+static const char* LOG_ENV_VAR = "RUST_LOG";
+// Values for this environment variables depending the verbosity level
+static const int LOG_LEVEL_MAX = 3;
+static const char* LOG_LEVELS[LOG_LEVEL_MAX+1] = {
+  // 0: only error logs
+  "zenoh=error",
+  // 1: add warning and info logs
+  "zenoh=info",
+  // 2: add session and connectivity events at debug level
+  "zenoh=info,zenoh::session=debug,zenoh_transport=debug",
+  // 3: add all debug logs
+  "zenoh=debug",
+};
+
+
+void print_usage(const char* progname) {
+  printf("Usage: %s [-h|--help] [-v]\n", progname);
+  printf("Options:\n");
+  printf("  -h, --help   Show this help\n");
+  printf("  -v           Increase log level (can be used several time - max:%d). Ignored if 'RUST_LOG' environment variable is set\n", LOG_LEVEL_MAX);
+}
+
 int main(int argc, char ** argv)
 {
   (void)argc;
   (void)argv;
+  int opt;
+  int verbosity = 0;
+
+  // Parse arguments
+  const char* short_opts = "hv";
+  const struct option long_opts[] = {
+    {nullptr, 0, nullptr, 0},
+    {"help", no_argument, nullptr, 'h'}
+  };
+
+  while ((opt = getopt_long(argc, argv, short_opts, long_opts, nullptr)) != -1) {
+    switch (opt) {
+      case 'v':
+        verbosity++;
+        break;
+      case 'h':
+        print_usage(argv[0]);
+        return 0;
+      default:
+        printf("ERROR: unkown option\n");
+        print_usage(argv[0]);
+        return 1;
+    }
+  }
+
+  // check if "RUST_LOG" is set
+  char* rust_log = getenv(LOG_ENV_VAR);
+  if (rust_log == nullptr) {
+    if (verbosity <= LOG_LEVEL_MAX) {
+      setenv(LOG_ENV_VAR, LOG_LEVELS[verbosity], 1);
+    } else {
+      setenv(LOG_ENV_VAR, LOG_LEVELS[LOG_LEVEL_MAX], 1);
+    }
+  } else {
+    if (verbosity > 0) {
+      printf("\"%s\" is already defined - ignoring -v options\n", LOG_ENV_VAR);
+    }
+  }
 
   // Initialize the zenoh configuration for the router.
   z_owned_config_t config;

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -197,7 +197,8 @@ void print_usage(const char * progname)
   printf("Options:\n");
   printf("  -h, --help   Show this help\n");
   printf(
-    "  -v           Increase log level (can be used several time - max:%d). Ignored if 'RUST_LOG' environment variable is set\n",
+    "  -v           Increase log level (can be used several time - max:%d). "
+    "Ignored if 'RUST_LOG' environment variable is set\n",
     LOG_LEVEL_MAX);
 }
 

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -173,7 +173,7 @@ void quit(int sig)
 static const char * LOG_ENV_VAR = "RUST_LOG";
 // Values for this environment variables depending the verbosity level
 static const int LOG_LEVEL_MAX = 3;
-static const char * LOG_LEVELS[LOG_LEVEL_MAX+1] = {
+static const char * LOG_LEVELS[LOG_LEVEL_MAX + 1] = {
   // 0: only error logs
   "zenoh=error",
   // 1: add warning and info logs
@@ -191,7 +191,7 @@ static const struct option LONG_OPTS[] = {
   {nullptr, 0, nullptr, 0}
 };
 
-void print_usage(const char* progname)
+void print_usage(const char * progname)
 {
   printf("Usage: %s [-h|--help] [-v]\n", progname);
   printf("Options:\n");

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -184,12 +184,20 @@ static const char* LOG_LEVELS[LOG_LEVEL_MAX+1] = {
   "zenoh=debug",
 };
 
+// Command line options
+static const char * SHORT_OPTS = "hv";
+static const struct option LONG_OPTS[] = {
+  {"help", no_argument, nullptr, 'h'},
+  {nullptr, 0, nullptr, 0}
+};
 
 void print_usage(const char* progname) {
   printf("Usage: %s [-h|--help] [-v]\n", progname);
   printf("Options:\n");
   printf("  -h, --help   Show this help\n");
-  printf("  -v           Increase log level (can be used several time - max:%d). Ignored if 'RUST_LOG' environment variable is set\n", LOG_LEVEL_MAX);
+  printf(
+    "  -v           Increase log level (can be used several time - max:%d). Ignored if 'RUST_LOG' environment variable is set\n",
+    LOG_LEVEL_MAX);
 }
 
 int main(int argc, char ** argv)
@@ -200,13 +208,7 @@ int main(int argc, char ** argv)
   int verbosity = 0;
 
   // Parse arguments
-  const char* short_opts = "hv";
-  const struct option long_opts[] = {
-    {nullptr, 0, nullptr, 0},
-    {"help", no_argument, nullptr, 'h'}
-  };
-
-  while ((opt = getopt_long(argc, argv, short_opts, long_opts, nullptr)) != -1) {
+  while ((opt = getopt_long(argc, argv, SHORT_OPTS, LONG_OPTS, nullptr)) != -1) {
     switch (opt) {
       case 'v':
         verbosity++;
@@ -222,7 +224,7 @@ int main(int argc, char ** argv)
   }
 
   // check if "RUST_LOG" is set
-  char* rust_log = getenv(LOG_ENV_VAR);
+  char * rust_log = getenv(LOG_ENV_VAR);
   if (rust_log == nullptr) {
     if (verbosity <= LOG_LEVEL_MAX) {
       setenv(LOG_ENV_VAR, LOG_LEVELS[verbosity], 1);

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -170,10 +170,10 @@ void quit(int sig)
 #endif
 
 // "RUST_LOG" environment variable used to configure Zenoh logging
-static const char* LOG_ENV_VAR = "RUST_LOG";
+static const char * LOG_ENV_VAR = "RUST_LOG";
 // Values for this environment variables depending the verbosity level
 static const int LOG_LEVEL_MAX = 3;
-static const char* LOG_LEVELS[LOG_LEVEL_MAX+1] = {
+static const char * LOG_LEVELS[LOG_LEVEL_MAX+1] = {
   // 0: only error logs
   "zenoh=error",
   // 1: add warning and info logs
@@ -191,7 +191,8 @@ static const struct option LONG_OPTS[] = {
   {nullptr, 0, nullptr, 0}
 };
 
-void print_usage(const char* progname) {
+void print_usage(const char* progname)
+{
   printf("Usage: %s [-h|--help] [-v]\n", progname);
   printf("Options:\n");
   printf("  -h, --help   Show this help\n");


### PR DESCRIPTION
Following discussion in https://github.com/ros2/rmw_zenoh/pull/189 this PR makes `zenohd` to support a `-v` command line option to set the logs verbosity level.

Internally, it set the `RUST_LOG` environment variable a value that depends on the number of `-v` options in the command line.
If `RUST_LOG` is already defined when starting the command, the `-v` options are ignored. This allows user to finely tune the logging if he wants.