### PR TITLE
Include type hash in liveliness token and fill endpoint info

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -33,6 +33,8 @@
 #include "rmw/validate_namespace.h"
 #include "rmw/validate_node_name.h"
 
+#include "rosidl_runtime_c/type_hash.h"
+
 #include "graph_cache.hpp"
 #include "rmw_data_types.hpp"
 
@@ -1173,7 +1175,21 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
           return ret;
         }
 
-        // TODO(Yadunund): Set type_hash, gid.
+        rosidl_type_hash_t type_hash;
+        rcutils_ret_t rc_ret = rosidl_parse_type_hash_string(
+          topic_data->info_.type_hash_.c_str(),
+          &type_hash);
+        if (RCUTILS_RET_OK == rc_ret) {
+          ret = rmw_topic_endpoint_info_set_topic_type_hash(
+            &endpoint_info,
+            &type_hash
+          );
+          if (RMW_RET_OK != ret) {
+            return ret;
+          }
+        }
+
+        // TODO(Yadunund): Set gid.
       }
     }
   }

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -50,9 +50,11 @@ NodeInfo::NodeInfo(
 TopicInfo::TopicInfo(
   std::string name,
   std::string type,
+  std::string type_hash,
   rmw_qos_profile_t qos)
 : name_(std::move(name)),
   type_(std::move(type)),
+  type_hash_(std::move(type_hash)),
   qos_(std::move(qos))
 {
   // Do nothing.
@@ -75,6 +77,7 @@ enum KeyexprIndex
   NodeName,
   TopicName,
   TopicType,
+  TopicTypeHash,
   TopicQoS
 };
 
@@ -272,6 +275,7 @@ Entity::Entity(
     const auto & topic_info = this->topic_info_.value();
     keyexpr_parts[KeyexprIndex::TopicName] = mangle_name(topic_info.name_);
     keyexpr_parts[KeyexprIndex::TopicType] = mangle_name(topic_info.type_);
+    keyexpr_parts[KeyexprIndex::TopicTypeHash] = mangle_name(topic_info.type_hash_);
     keyexpr_parts[KeyexprIndex::TopicQoS] = qos_to_keyexpr(topic_info.qos_);
   }
 
@@ -398,6 +402,7 @@ std::shared_ptr<Entity> Entity::make(const std::string & keyexpr)
     topic_info = TopicInfo{
       demangle_name(std::move(parts[KeyexprIndex::TopicName])),
       demangle_name(std::move(parts[KeyexprIndex::TopicType])),
+      demangle_name(std::move(parts[KeyexprIndex::TopicTypeHash])),
       std::move(qos.value())
     };
   }

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -49,11 +49,13 @@ struct TopicInfo
 {
   std::string name_;
   std::string type_;
+  std::string type_hash_;
   rmw_qos_profile_t qos_;
 
   TopicInfo(
     std::string name,
     std::string type,
+    std::string type_hash,
     rmw_qos_profile_t qos);
 };
 
@@ -91,9 +93,10 @@ enum class EntityType : uint8_t
  *
  * For entities with topic infomation, the liveliness token keyexpr have additional fields:
  *
- * <ADMIN_SPACE>/<domainid>/<zid>/<id>/<entity>/<namespace>/<nodename>/<topic_name>/<topic_type>/<topic_qos>
+ * <ADMIN_SPACE>/<domainid>/<zid>/<id>/<entity>/<namespace>/<nodename>/<topic_name>/<topic_type>/<topic_type_hash>/<topic_qos>
  *  <topic_name> - The ROS topic name for this entity.
  *  <topic_type> - The type for the topic.
+ *  <topic_type_hash> - The type hash for the topic.
  *  <topic_qos> - The qos for the topic (see qos_to_keyexpr() docstring for more information).
  *
  * For example, the liveliness expression for a publisher within a /talker node that publishes

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -686,8 +686,11 @@ rmw_create_publisher(
     rmw_zenoh_cpp::liveliness::EntityType::Publisher,
     rmw_zenoh_cpp::liveliness::NodeInfo{
       node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
-    rmw_zenoh_cpp::liveliness::TopicInfo{rmw_publisher->topic_name,
-      publisher_data->type_support->get_name(), publisher_data->adapted_qos_profile}
+    rmw_zenoh_cpp::liveliness::TopicInfo{
+      rmw_publisher->topic_name,
+      publisher_data->type_support->get_name(),
+      type_hash_c_str,
+      publisher_data->adapted_qos_profile}
   );
   if (publisher_data->entity == nullptr) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -1519,8 +1522,11 @@ rmw_create_subscription(
     rmw_zenoh_cpp::liveliness::EntityType::Subscription,
     rmw_zenoh_cpp::liveliness::NodeInfo{
       node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
-    rmw_zenoh_cpp::liveliness::TopicInfo{rmw_subscription->topic_name,
-      sub_data->type_support->get_name(), sub_data->adapted_qos_profile}
+    rmw_zenoh_cpp::liveliness::TopicInfo{
+      rmw_subscription->topic_name,
+      sub_data->type_support->get_name(),
+      type_hash_c_str,
+      sub_data->adapted_qos_profile}
   );
   if (sub_data->entity == nullptr) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -2191,8 +2197,11 @@ rmw_create_client(
     rmw_zenoh_cpp::liveliness::EntityType::Client,
     rmw_zenoh_cpp::liveliness::NodeInfo{
       node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
-    rmw_zenoh_cpp::liveliness::TopicInfo{rmw_client->service_name,
-      std::move(service_type), client_data->adapted_qos_profile}
+    rmw_zenoh_cpp::liveliness::TopicInfo{
+      rmw_client->service_name,
+      std::move(service_type),
+      type_hash_c_str,
+      client_data->adapted_qos_profile}
   );
   if (client_data->entity == nullptr) {
     RCUTILS_LOG_ERROR_NAMED(
@@ -2775,8 +2784,11 @@ rmw_create_service(
     rmw_zenoh_cpp::liveliness::EntityType::Service,
     rmw_zenoh_cpp::liveliness::NodeInfo{
       node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
-    rmw_zenoh_cpp::liveliness::TopicInfo{rmw_service->service_name,
-      std::move(service_type), service_data->adapted_qos_profile}
+    rmw_zenoh_cpp::liveliness::TopicInfo{
+      rmw_service->service_name,
+      std::move(service_type),
+      type_hash_c_str,
+      service_data->adapted_qos_profile}
   );
   if (service_data->entity == nullptr) {
     RCUTILS_LOG_ERROR_NAMED(


### PR DESCRIPTION
Builds off #171 to include the type hash in the liveliness token and populate the same when filling out endpoint info. As a result the type hash is now available when introspecting topics. Previously the type hash would show `INVALID`.

> Note: since the liveliness token is updated, please make sure to kill all ROS 2 nodes including the `ros2 daemon` prior to testing.

To test:

```bash
# terminal 1
ros2 run demo_nodes_cpp talker
```

```bash
# terminal 2
ros2 topic info -v /chatter
```

The type hash should be filled in the result
```bash
yadunund@ubuntu-noble-20240225:~/ros2_rolling$ ros2 topic info -v /chatter
Type: std_msgs/msg/String

Publisher count: 1

Node name: talker
Node namespace: /
Topic type: std_msgs/msg/String
Topic type hash: RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18
Endpoint type: PUBLISHER
GID: 01.10.0e.70.a8.7f.35.22.74.35.d2.74.00.00.17.03
QoS profile:
  Reliability: RELIABLE
  History (Depth): KEEP_LAST (7)
  Durability: VOLATILE
  Lifespan: Infinite
  Deadline: Infinite
  Liveliness: AUTOMATIC
  Liveliness lease duration: Infinite

Subscription count: 0
```