### PR TITLE
Fix checking of the guard condition.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/guard_condition.cpp
+++ b/rmw_zenoh_cpp/src/detail/guard_condition.cpp
@@ -53,16 +53,21 @@ void GuardCondition::detach_condition()
   condition_variable_ = nullptr;
 }
 
+bool GuardCondition::has_triggered() const
+{
+  std::lock_guard<std::mutex> lock(internal_mutex_);
+  return has_triggered_;
+}
+
 ///=============================================================================
 bool GuardCondition::get_and_reset_trigger()
 {
   std::lock_guard<std::mutex> lock(internal_mutex_);
   bool ret = has_triggered_;
 
-  // There is no data associated with the guard condition, so as soon as the callers asks about the
-  // state, we can immediately reset and get ready for the next trigger.
   has_triggered_ = false;
 
   return ret;
 }
+
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/guard_condition.hpp
+++ b/rmw_zenoh_cpp/src/detail/guard_condition.hpp
@@ -35,6 +35,8 @@ public:
 
   void detach_condition();
 
+  bool has_triggered() const;
+
   bool get_and_reset_trigger();
 
 private:

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3143,14 +3143,12 @@ static bool has_triggered_condition(
   rmw_clients_t * clients,
   rmw_events_t * events)
 {
-  static_cast<void>(events);
-
   if (guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {
       rmw_zenoh_cpp::GuardCondition * gc =
         static_cast<rmw_zenoh_cpp::GuardCondition *>(guard_conditions->guard_conditions[i]);
       if (gc != nullptr) {
-        if (gc->get_and_reset_trigger()) {
+        if (gc->has_triggered()) {
           return true;
         }
       }

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3137,11 +3137,11 @@ rmw_destroy_wait_set(rmw_wait_set_t * wait_set)
 }
 
 static bool has_triggered_condition(
-  rmw_subscriptions_t * subscriptions,
-  rmw_guard_conditions_t * guard_conditions,
-  rmw_services_t * services,
-  rmw_clients_t * clients,
-  rmw_events_t * events)
+  const rmw_subscriptions_t * const subscriptions,
+  const rmw_guard_conditions_t * const guard_conditions,
+  const rmw_services_t * const services,
+  const rmw_clients_t * const clients,
+  const rmw_events_t * const events)
 {
   if (guard_conditions) {
     for (size_t i = 0; i < guard_conditions->guard_condition_count; ++i) {


### PR DESCRIPTION
Previously, when we were checking if a guard condition was triggered, we would actually check and reset it. But that means that when we later on went to set the appropriate things in the wait_set, we wouldn't actually set the guard_condition true, since it was false by that point.

Instead, add in two separate methods; the one that just returns whether it is triggered, which we call when checking, and the one that checks and resets, which we call when setting it in the wait_set.