### PR TITLE
Include enclave in liveliness tokens

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1038,7 +1038,7 @@ rmw_ret_t GraphCache::get_entity_names_and_types_by_node(
   // Check if namespace exists.
   NamespaceMap::const_iterator ns_it = graph_.find(node_namespace);
   if (ns_it == graph_.end()) {
-    return RMW_RET_OK;
+    return RMW_RET_NODE_NAME_NON_EXISTENT;
   }
 
   // Check if node exists.
@@ -1046,7 +1046,7 @@ rmw_ret_t GraphCache::get_entity_names_and_types_by_node(
   // name that is found.
   NodeMap::const_iterator node_it = ns_it->second.find(node_name);
   if (node_it == ns_it->second.end()) {
-    return RMW_RET_OK;
+    return RMW_RET_NODE_NAME_NON_EXISTENT;
   }
 
   // TODO(Yadunund): Support service and client when ready.
@@ -1059,10 +1059,8 @@ rmw_ret_t GraphCache::get_entity_names_and_types_by_node(
   } else if (entity_type == EntityType::Client) {
     return fill_names_and_types(node_it->second->clients_, allocator, names_and_types);
   } else {
-    return RMW_RET_OK;
+    return RMW_RET_UNSUPPORTED;
   }
-
-  return RMW_RET_OK;
 }
 
 

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -43,6 +43,9 @@
 class rmw_context_impl_s final
 {
 public:
+  // Enclave, name used to find security artifacts in a sros2 keystore.
+  char * enclave;
+
   // An owned session.
   z_owned_session_t session;
 

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -144,6 +144,9 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
       }
     });
 
+  // Set the enclave.
+  context->impl->enclave = options->enclave;
+
   // Initialize context's implementation
   context->impl->is_shutdown = false;
 

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -195,6 +195,10 @@ rmw_create_node(
     context->impl,
     "expected initialized context",
     return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context->impl->enclave,
+    "expected initialized enclave",
+    return nullptr);
   if (context->impl->is_shutdown) {
     RCUTILS_SET_ERROR_MSG("context has been shutdown");
     return nullptr;
@@ -279,7 +283,8 @@ rmw_create_node(
     std::to_string(node_data->id),
     std::to_string(node_data->id),
     rmw_zenoh_cpp::liveliness::EntityType::Node,
-    rmw_zenoh_cpp::liveliness::NodeInfo{context->actual_domain_id, namespace_, name, ""});
+    rmw_zenoh_cpp::liveliness::NodeInfo{context->actual_domain_id, namespace_, name,
+      context->impl->enclave});
   if (node_data->entity == nullptr) {
     RCUTILS_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
@@ -470,6 +475,10 @@ rmw_create_publisher(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context_impl->enclave,
+    "expected initialized enclave",
+    return nullptr);
   if (!z_check(context_impl->session)) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -630,7 +639,7 @@ rmw_create_publisher(
       context_impl->get_next_entity_id()),
     rmw_zenoh_cpp::liveliness::EntityType::Publisher,
     rmw_zenoh_cpp::liveliness::NodeInfo{
-      node->context->actual_domain_id, node->namespace_, node->name, ""},
+      node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
     rmw_zenoh_cpp::liveliness::TopicInfo{rmw_publisher->topic_name,
       publisher_data->type_support->get_name(), publisher_data->adapted_qos_profile}
   );
@@ -1258,6 +1267,10 @@ rmw_create_subscription(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context_impl->enclave,
+    "expected initialized enclave",
+    return nullptr);
   if (!z_check(context_impl->session)) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -1440,7 +1453,7 @@ rmw_create_subscription(
       context_impl->get_next_entity_id()),
     rmw_zenoh_cpp::liveliness::EntityType::Subscription,
     rmw_zenoh_cpp::liveliness::NodeInfo{
-      node->context->actual_domain_id, node->namespace_, node->name, ""},
+      node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
     rmw_zenoh_cpp::liveliness::TopicInfo{rmw_subscription->topic_name,
       sub_data->type_support->get_name(), sub_data->adapted_qos_profile}
   );
@@ -1902,6 +1915,10 @@ rmw_create_client(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context_impl->enclave,
+    "expected initialized enclave",
+    return nullptr);
   if (!z_check(context_impl->session)) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -2087,7 +2104,7 @@ rmw_create_client(
       context_impl->get_next_entity_id()),
     rmw_zenoh_cpp::liveliness::EntityType::Client,
     rmw_zenoh_cpp::liveliness::NodeInfo{
-      node->context->actual_domain_id, node->namespace_, node->name, ""},
+      node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
     rmw_zenoh_cpp::liveliness::TopicInfo{rmw_client->service_name,
       std::move(service_type), client_data->adapted_qos_profile}
   );
@@ -2464,6 +2481,10 @@ rmw_create_service(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context_impl->enclave,
+    "expected initialized enclave",
+    return nullptr);
   if (!z_check(context_impl->session)) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -2645,7 +2666,7 @@ rmw_create_service(
       context_impl->get_next_entity_id()),
     rmw_zenoh_cpp::liveliness::EntityType::Service,
     rmw_zenoh_cpp::liveliness::NodeInfo{
-      node->context->actual_domain_id, node->namespace_, node->name, ""},
+      node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
     rmw_zenoh_cpp::liveliness::TopicInfo{rmw_service->service_name,
       std::move(service_type), service_data->adapted_qos_profile}
   );


### PR DESCRIPTION
To ensure enclaves are tracked in the graph_cache. The mechanism to report enclaves was already present.
Also fixed the return type in `get_entity_names_and_types_by_node()`.

With these changes I can get [rcl/test_get_node_names](https://github.com/ros2/rcl/blob/iron/rcl/test/rcl/test_get_node_names.cpp) and most of [ecl/test_graph](https://github.com/ros2/rcl/blob/rolling/rcl/test/rcl/test_graph.cpp) to pass.