### PR TITLE
Fix a race condition in rmw_wait.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/event.hpp
+++ b/rmw_zenoh_cpp/src/detail/event.hpp
@@ -25,6 +25,8 @@
 #include "rmw/event.h"
 #include "rmw/event_callback_type.h"
 
+#include "rmw_wait_set_data.hpp"
+
 namespace rmw_zenoh_cpp
 {
 ///=============================================================================
@@ -135,7 +137,7 @@ public:
   /// @param condition_variable to attach.
   bool queue_has_data_and_attach_condition_if_not(
     rmw_zenoh_event_type_t event_id,
-    std::condition_variable * condition_variable);
+    rmw_wait_set_data_t * wait_set_data);
 
   /// @brief Detach the condition variable provided by rmw_wait.
   bool detach_condition_and_event_queue_is_empty(rmw_zenoh_event_type_t event_id);
@@ -153,7 +155,7 @@ private:
   /// Mutex to lock for event_condition.
   mutable std::mutex event_condition_mutex_;
   /// Condition variable to attach for event notifications.
-  std::condition_variable * event_conditions_[ZENOH_EVENT_ID_MAX + 1]{nullptr};
+  rmw_wait_set_data_t * wait_set_data_[ZENOH_EVENT_ID_MAX + 1]{nullptr};
 
   rmw_event_callback_t event_callback_[ZENOH_EVENT_ID_MAX + 1] {nullptr};
   const void * event_data_[ZENOH_EVENT_ID_MAX + 1] {nullptr};

--- a/rmw_zenoh_cpp/src/detail/guard_condition.hpp
+++ b/rmw_zenoh_cpp/src/detail/guard_condition.hpp
@@ -20,6 +20,8 @@
 #include <condition_variable>
 #include <mutex>
 
+#include "rmw_wait_set_data.hpp"
+
 namespace rmw_zenoh_cpp
 {
 ///=============================================================================
@@ -31,14 +33,14 @@ public:
   // Sets has_triggered_ to true and calls notify_one() on condition_variable_ if set.
   void trigger();
 
-  bool check_and_attach_condition_if_not(std::condition_variable * condition_variable);
+  bool check_and_attach_condition_if_not(rmw_wait_set_data_t * wait_set_data);
 
-  bool detach_condition_and_trigger_set();
+  bool detach_condition_and_is_trigger_set();
 
 private:
   mutable std::mutex internal_mutex_;
   std::atomic_bool has_triggered_;
-  std::condition_variable * condition_variable_;
+  rmw_wait_set_data_t * wait_set_data_;
 };
 }  // namespace rmw_zenoh_cpp
 

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -37,6 +37,7 @@
 #include "event.hpp"
 #include "graph_cache.hpp"
 #include "message_type_support.hpp"
+#include "rmw_wait_set_data.hpp"
 #include "service_type_support.hpp"
 
 /// Structs for various type erased data fields.
@@ -129,15 +130,6 @@ private:
 };
 
 ///=============================================================================
-struct rmw_wait_set_data_t
-{
-  std::condition_variable condition_variable;
-  std::mutex condition_mutex;
-
-  rmw_context_t * context;
-};
-
-///=============================================================================
 // z_owned_closure_sample_t
 void sub_data_handler(const z_sample_t * sample, void * sub_data);
 
@@ -181,7 +173,7 @@ public:
   MessageTypeSupport * type_support;
   rmw_context_t * context;
 
-  bool queue_has_data_and_attach_condition_if_not(std::condition_variable * condition_variable);
+  bool queue_has_data_and_attach_condition_if_not(rmw_wait_set_data_t * wait_set_data);
 
   bool detach_condition_and_queue_is_empty();
 
@@ -202,7 +194,7 @@ private:
 
   void notify();
 
-  std::condition_variable * condition_{nullptr};
+  rmw_wait_set_data_t * wait_set_data_{nullptr};
   std::mutex condition_mutex_;
 };
 
@@ -253,7 +245,7 @@ public:
 
   rmw_context_t * context;
 
-  bool queue_has_data_and_attach_condition_if_not(std::condition_variable * condition_variable);
+  bool queue_has_data_and_attach_condition_if_not(rmw_wait_set_data_t * wait_set_data);
 
   bool detach_condition_and_queue_is_empty();
 
@@ -279,7 +271,7 @@ private:
   std::unordered_map<size_t, SequenceToQuery> sequence_to_query_map_;
   std::mutex sequence_to_query_map_mutex_;
 
-  std::condition_variable * condition_{nullptr};
+  rmw_wait_set_data_t * wait_set_data_{nullptr};
   std::mutex condition_mutex_;
 };
 
@@ -329,7 +321,7 @@ public:
 
   void add_new_reply(std::unique_ptr<rmw_zenoh_cpp::ZenohReply> reply);
 
-  bool queue_has_data_and_attach_condition_if_not(std::condition_variable * condition_variable);
+  bool queue_has_data_and_attach_condition_if_not(rmw_wait_set_data_t * wait_set_data);
 
   bool detach_condition_and_queue_is_empty();
 
@@ -343,7 +335,7 @@ private:
   size_t sequence_number_{1};
   std::mutex sequence_number_mutex_;
 
-  std::condition_variable * condition_{nullptr};
+  rmw_wait_set_data_t * wait_set_data_{nullptr};
   std::mutex condition_mutex_;
 
   std::deque<std::unique_ptr<rmw_zenoh_cpp::ZenohReply>> reply_queue_;

--- a/rmw_zenoh_cpp/src/detail/rmw_wait_set_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_wait_set_data.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Open Source Robotics Foundation, Inc.
+// Copyright 2024 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,6 +25,29 @@ namespace rmw_zenoh_cpp
 
 struct rmw_wait_set_data_t
 {
+  // The combination of condition_variable, condition_mutex, and triggered are used to make sure
+  // there isn't a race in rmw_wait().  That could happen because of the following sequence:
+  //
+  // 1. Without taking a lock, rmw_wait() checks if any of the entities in the wait_set are ready,
+  //    and if not attachs the condition_variable to it.
+  // 2. It then takes the lock, and sleeps on the condition_variable.
+  //
+  // However, doing step 1 takes time, and checks in a particular order: guard_conditions, events,
+  // subscriptions, services, clients. The race could happen because a subscription may come in
+  // subscriptions have been checked in the above list (while services and clients are being
+  // checked). In that case, rmw_wait() will unnecessarily go to sleep on the condition_variable,
+  // even though something is ready. This increases the latency.
+  //
+  // To solve the issue, rmw_wait() still does all of the checking and attaching unlocked. However,
+  // the "notify" method of each entity takes the condition_mutex lock, and in addition to kicking
+  // the condition_variable it sets "triggreed" in this structure to "true". Then after rmw_wait()
+  // has finished attaching, it takes the lock and sets a predicate on the condition_variable so
+  // that it will quit if wait_set_data->triggered is true. Thus, if one of the entities became
+  // ready after we checked, the condition_variable will notice it and not go to sleep.
+  //
+  // This also deals with "spurious" wakeups, where the condition_variable was woken up even though
+  // nothing in this wait_set became ready.
+
   std::condition_variable condition_variable;
   std::mutex condition_mutex;
 

--- a/rmw_zenoh_cpp/src/detail/rmw_wait_set_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_wait_set_data.hpp
@@ -1,0 +1,37 @@
+// Copyright 2023 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DETAIL__RMW_WAIT_SET_DATA_HPP_
+#define DETAIL__RMW_WAIT_SET_DATA_HPP_
+
+#include <condition_variable>
+#include <mutex>
+
+#include "rmw/rmw.h"
+
+namespace rmw_zenoh_cpp
+{
+
+struct rmw_wait_set_data_t
+{
+  std::condition_variable condition_variable;
+  std::mutex condition_mutex;
+
+  bool triggered{false};
+
+  rmw_context_t * context;
+};
+}  // namespace rmw_zenoh_cpp
+
+#endif  // DETAIL__RMW_WAIT_SET_DATA_HPP_

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3292,7 +3292,7 @@ static bool check_and_attach_condition(
       if (gc == nullptr) {
         continue;
       }
-      if (gc->check_and_attach_condition_if_not(&wait_set_data->condition_variable)) {
+      if (gc->check_and_attach_condition_if_not(wait_set_data)) {
         return true;
       }
     }
@@ -3307,7 +3307,7 @@ static bool check_and_attach_condition(
         if (event_data != nullptr) {
           if (event_data->queue_has_data_and_attach_condition_if_not(
               zenoh_event_it->second,
-              &wait_set_data->condition_variable))
+              wait_set_data))
           {
             return true;
           }
@@ -3327,9 +3327,7 @@ static bool check_and_attach_condition(
       if (sub_data == nullptr) {
         continue;
       }
-      if (sub_data->queue_has_data_and_attach_condition_if_not(
-          &wait_set_data->condition_variable))
-      {
+      if (sub_data->queue_has_data_and_attach_condition_if_not(wait_set_data)) {
         return true;
       }
     }
@@ -3341,9 +3339,7 @@ static bool check_and_attach_condition(
       if (serv_data == nullptr) {
         continue;
       }
-      if (serv_data->queue_has_data_and_attach_condition_if_not(
-          &wait_set_data->condition_variable))
-      {
+      if (serv_data->queue_has_data_and_attach_condition_if_not(wait_set_data)) {
         return true;
       }
     }
@@ -3356,9 +3352,7 @@ static bool check_and_attach_condition(
       if (client_data == nullptr) {
         continue;
       }
-      if (client_data->queue_has_data_and_attach_condition_if_not(
-          &wait_set_data->condition_variable))
-      {
+      if (client_data->queue_has_data_and_attach_condition_if_not(wait_set_data)) {
         return true;
       }
     }
@@ -3416,13 +3410,22 @@ rmw_wait(
     // "wait forever", if it specified as 0 it means "never wait", and if it is anything else wait
     // for that amount of time.
     if (wait_timeout == nullptr) {
-      wait_set_data->condition_variable.wait(lock);
+      wait_set_data->condition_variable.wait(
+        lock, [wait_set_data]() {
+          return wait_set_data->triggered;
+        });
     } else {
       if (wait_timeout->sec != 0 || wait_timeout->nsec != 0) {
         wait_set_data->condition_variable.wait_for(
-          lock, std::chrono::nanoseconds(wait_timeout->nsec + RCUTILS_S_TO_NS(wait_timeout->sec)));
+          lock,
+          std::chrono::nanoseconds(wait_timeout->nsec + RCUTILS_S_TO_NS(wait_timeout->sec)),
+          [wait_set_data]() {return wait_set_data->triggered;});
       }
     }
+
+    // We reset here (while still holding the lock) because we only cared about this through this
+    // particular call.
+    wait_set_data->triggered = false;
   }
 
   bool wait_result = false;
@@ -3436,7 +3439,7 @@ rmw_wait(
       if (gc == nullptr) {
         continue;
       }
-      if (!gc->detach_condition_and_trigger_set()) {
+      if (!gc->detach_condition_and_is_trigger_set()) {
         // Setting to nullptr lets rcl know that this guard condition is not ready
         guard_conditions->guard_conditions[i] = nullptr;
       } else {

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -3423,8 +3423,10 @@ rmw_wait(
       }
     }
 
-    // We reset here (while still holding the lock) because we only cared about this through this
-    // particular call.
+    // It is important to reset this here while still holding the lock, otherwise every subsequent
+    // call to rmw_wait() will be immediately ready.  We could handle this another way by making
+    // "triggered" a stack variable in this function and "attaching" it during
+    // "check_and_attach_condition", but that isn't clearly better so leaving this.
     wait_set_data->triggered = false;
   }
 


### PR DESCRIPTION
In the current code, there is a race condition in rmw_wait. This happens because of the following sequence:

1.  Without taking a lock, we check if any of the entities in the wait_set are ready, and if not attach the condition_variable to it.
2.  Then we take the lock, and go to sleep on the condition_variable.

However, doing step 1 takes time, and we check in a particular order: guard_conditions, events, subscriptions, services, clients.  The race happens because a subscription may come in after we've checked subscriptions in the above list (while we are checking services and clients).  In that case, we'll unnecessarily go to sleep on the condition_variable, even though something is ready.  This increases the latency.

To solve the issue, we still do all of the checking and attaching unlocked.  However, we update the "notify" method of each entity so that it takes the condition_variable lock, and in addition to kicking the condition_variable it sets a boolean in the wait_set structure to "true".  Then, in rmw_wait(), after we have finished attaching, we take the lock, and set a predicate on the condition_variable so that it will quit if wait_set_data->triggered is true.  Thus, if one of the entities became ready after we checked, we'll notice it and not go to sleep.

This also allows us to deal with "spurious" wakeups, where the condition_variable was woken up even though nothing in this wait_set became ready.