### PR TITLE
Switch wait_for_all_acked to return OK.

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1178,7 +1178,13 @@ rmw_publisher_wait_for_all_acked(
 {
   static_cast<void>(publisher);
   static_cast<void>(wait_timeout);
-  return RMW_RET_UNSUPPORTED;
+
+  // We are not currently tracking all published data, so we don't know what data is in flight that
+  // we might have to wait for.  Even if we did start tracking it, we don't have insight into the
+  // TCP stream that Zenoh is managing for us, so we couldn't guarantee this anyway.
+  // Just lie to the upper layers and say that everything is working as expected.
+  // We return OK rather than UNSUPPORTED so that certain upper-layer tests continue working.
+  return RMW_RET_OK;
 }
 
 //==============================================================================


### PR DESCRIPTION
This just keeps upper-layer tests working.

In particular, this fixes the test in rcl called `test_publisher_wait_all_ack__rmw_zenoh_cpp`.