### PR TITLE
Make has_triggered a regular boolean.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/guard_condition.hpp
+++ b/rmw_zenoh_cpp/src/detail/guard_condition.hpp
@@ -16,7 +16,6 @@
 #ifndef DETAIL__GUARD_CONDITION_HPP_
 #define DETAIL__GUARD_CONDITION_HPP_
 
-#include <atomic>
 #include <condition_variable>
 #include <mutex>
 
@@ -39,7 +38,7 @@ public:
 
 private:
   mutable std::mutex internal_mutex_;
-  std::atomic_bool has_triggered_;
+  bool has_triggered_;
   rmw_wait_set_data_t * wait_set_data_;
 };
 }  // namespace rmw_zenoh_cpp


### PR DESCRIPTION
Since it is protected by the mutex now, there is no reason to also make it an atomic (it just makes it slower).