### PR TITLE
ci: bump `actions/checkout`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Deps
       run: |
         apt update && apt install -y curl
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: rosdep
       run: |
         rosdep update

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -17,7 +17,7 @@ jobs:
       image: ros:${{ matrix.distro }}-ros-base
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: uncrustify
       run: /ros_entrypoint.sh ament_uncrustify rmw_zenoh_cpp/
     - name: cpplint


### PR DESCRIPTION
As per title.

Avoids "Node.js 16" deprecation warning.
