### PR TITLE
Move the event_map out of the header file.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
 #include <utility>
 
 #include "event.hpp"
@@ -20,8 +24,34 @@
 
 #include "rmw/error_handling.h"
 
+namespace
+{
+// RMW Event types that we support in rmw_zenoh.
+static const std::unordered_map<rmw_event_type_t, rmw_zenoh_cpp::rmw_zenoh_event_type_t> event_map{
+  {RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE, rmw_zenoh_cpp::ZENOH_EVENT_REQUESTED_QOS_INCOMPATIBLE},
+  {RMW_EVENT_OFFERED_QOS_INCOMPATIBLE, rmw_zenoh_cpp::ZENOH_EVENT_OFFERED_QOS_INCOMPATIBLE},
+  {RMW_EVENT_MESSAGE_LOST, rmw_zenoh_cpp::ZENOH_EVENT_MESSAGE_LOST},
+  {RMW_EVENT_SUBSCRIPTION_MATCHED, rmw_zenoh_cpp::ZENOH_EVENT_SUBSCRIPTION_MATCHED},
+  {RMW_EVENT_PUBLICATION_MATCHED, rmw_zenoh_cpp::ZENOH_EVENT_PUBLICATION_MATCHED},
+  {RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE,
+    rmw_zenoh_cpp::ZENOH_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE},
+  {RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE, rmw_zenoh_cpp::ZENOH_EVENT_PUBLISHER_INCOMPATIBLE_TYPE}
+  // TODO(clalancette): Implement remaining events
+};
+}  // namespace
+
 namespace rmw_zenoh_cpp
 {
+rmw_zenoh_event_type_t zenoh_event_from_rmw_event(rmw_event_type_t rmw_event_type)
+{
+  auto zenoh_event_it = event_map.find(rmw_event_type);
+  if (zenoh_event_it != event_map.end()) {
+    return zenoh_event_it->second;
+  }
+
+  return ZENOH_EVENT_INVALID;
+}
+
 ///=============================================================================
 void DataCallbackManager::set_callback(
   const void * user_data, rmw_event_callback_t callback)

--- a/rmw_zenoh_cpp/src/detail/event.hpp
+++ b/rmw_zenoh_cpp/src/detail/event.hpp
@@ -15,12 +15,10 @@
 #ifndef DETAIL__EVENT_HPP_
 #define DETAIL__EVENT_HPP_
 
-#include <condition_variable>
 #include <deque>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <unordered_map>
 
 #include "rmw/event.h"
 #include "rmw/event_callback_type.h"
@@ -53,17 +51,7 @@ enum rmw_zenoh_event_type_t
 /// Helper value to indicate the maximum index of events supported.
 #define ZENOH_EVENT_ID_MAX rmw_zenoh_event_type_t::ZENOH_EVENT_PUBLICATION_MATCHED
 
-// RMW Event types that we support in rmw_zenoh.
-static const std::unordered_map<rmw_event_type_t, rmw_zenoh_event_type_t> event_map{
-  {RMW_EVENT_REQUESTED_QOS_INCOMPATIBLE, ZENOH_EVENT_REQUESTED_QOS_INCOMPATIBLE},
-  {RMW_EVENT_OFFERED_QOS_INCOMPATIBLE, ZENOH_EVENT_OFFERED_QOS_INCOMPATIBLE},
-  {RMW_EVENT_MESSAGE_LOST, ZENOH_EVENT_MESSAGE_LOST},
-  {RMW_EVENT_SUBSCRIPTION_MATCHED, ZENOH_EVENT_SUBSCRIPTION_MATCHED},
-  {RMW_EVENT_PUBLICATION_MATCHED, ZENOH_EVENT_PUBLICATION_MATCHED},
-  {RMW_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE, ZENOH_EVENT_SUBSCRIPTION_INCOMPATIBLE_TYPE},
-  {RMW_EVENT_PUBLISHER_INCOMPATIBLE_TYPE, ZENOH_EVENT_PUBLISHER_INCOMPATIBLE_TYPE}
-  // TODO(clalancette): Implement remaining events
-};
+rmw_zenoh_event_type_t zenoh_event_from_rmw_event(rmw_event_type_t rmw_event_type);
 
 ///=============================================================================
 /// A struct to store status changes which can be mapped to rmw event statuses.


### PR DESCRIPTION
The main reason for this is that putting it in the header file means that it is duplicated into every compilation unit that includes it.  This is slow, and in theory can cause issues if a pointer to the map is passed between compilation units.

Instead, hide the map inside of the events.cpp file, and add a free function that converts between an RMW event type and a Zenoh event type.