### PR TITLE
fix: log the function name, the file name, and the line number with macros

### DIFF
--- a/rmw_zenoh_cpp/src/detail/logging.cpp
+++ b/rmw_zenoh_cpp/src/detail/logging.cpp
@@ -36,6 +36,9 @@ void Logger::set_log_level(RCUTILS_LOG_SEVERITY new_level)
 
 void Logger::log_named(
   RCUTILS_LOG_SEVERITY level,
+  const char * function_name,
+  const char * file_name,
+  size_t line_number,
   const char * name,
   const char * message,
   ...) const
@@ -47,7 +50,7 @@ void Logger::log_named(
       RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to get timestamp while doing a console logging.\n");
       return;
     }
-    static rcutils_log_location_t log_location = {__func__, __FILE__, __LINE__};
+    static rcutils_log_location_t log_location = {function_name, file_name, line_number};
     va_list args;
     va_start(args, message);
     rcutils_logging_console_output_handler(

--- a/rmw_zenoh_cpp/src/detail/logging.hpp
+++ b/rmw_zenoh_cpp/src/detail/logging.hpp
@@ -32,6 +32,9 @@ public:
   // Log to the console.
   void log_named(
     RCUTILS_LOG_SEVERITY level,
+    const char * function_name,
+    const char * file_name,
+    size_t line_number,
     const char * name,
     const char * message,
     ...) const;

--- a/rmw_zenoh_cpp/src/detail/logging_macros.hpp
+++ b/rmw_zenoh_cpp/src/detail/logging_macros.hpp
@@ -24,14 +24,14 @@
 // invoke GraphCache::parse_put() and GraphCache::parse_del() functions.
 // See https://github.com/ros2/rmw_zenoh/issues/182 for more details.
 #define RMW_ZENOH_LOG_DEBUG_NAMED(...) {rmw_zenoh_cpp::Logger::get().log_named( \
-      RCUTILS_LOG_SEVERITY_DEBUG, __VA_ARGS__);}
+      RCUTILS_LOG_SEVERITY_DEBUG, __func__, __FILE__, __LINE__, __VA_ARGS__);}
 #define RMW_ZENOH_LOG_ERROR_NAMED(...) {rmw_zenoh_cpp::Logger::get().log_named( \
-      RCUTILS_LOG_SEVERITY_ERROR, __VA_ARGS__);}
+      RCUTILS_LOG_SEVERITY_ERROR, __func__, __FILE__, __LINE__, __VA_ARGS__);}
 #define RMW_ZENOH_LOG_FATAL_NAMED(...) {rmw_zenoh_cpp::Logger::get().log_named( \
-      RCUTILS_LOG_SEVERITY_FATAL, __VA_ARGS__);}
+      RCUTILS_LOG_SEVERITY_FATAL, __func__, __FILE__, __LINE__, __VA_ARGS__);}
 #define RMW_ZENOH_LOG_INFO_NAMED(...) {rmw_zenoh_cpp::Logger::get().log_named( \
-      RCUTILS_LOG_SEVERITY_INFO, __VA_ARGS__);}
+      RCUTILS_LOG_SEVERITY_INFO, __func__, __FILE__, __LINE__, __VA_ARGS__);}
 #define RMW_ZENOH_LOG_WARN_NAMED(...) {rmw_zenoh_cpp::Logger::get().log_named( \
-      RCUTILS_LOG_SEVERITY_WARN, __VA_ARGS__);}
+      RCUTILS_LOG_SEVERITY_WARN, __func__, __FILE__, __LINE__, __VA_ARGS__);}
 
 #endif   // DETAIL__LOGGING_MACROS_HPP_


### PR DESCRIPTION
We should log the information of function names, file names, and line numbers with macros rather than doing so inside a function. 


Taking `export RCUTILS_CONSOLE_OUTPUT_FORMAT="[{severity} {time}] [{name}]: {message} ({function_name}() at {file_name}:{line_number})"` as an example,

- Current

```txt
[ERROR 1721033624.485865217] [Logging Test]: Message (log_named() at /workspace/src/rmw_zenoh/rmw_zenoh_cpp/src/detail/logging.cpp:50)
```

- After fixed
```txt
[ERROR 1721034005.478704138] [Logging Test]: Message (rmw_init() at /workspace/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init.cpp:95)
```
