### PR TITLE
Activate Zenoh logs by default

### DIFF
--- a/rmw_zenoh_cpp/src/detail/zenoh_config.hpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.hpp
@@ -23,6 +23,10 @@
 
 #include "rmw/ret_types.h"
 
+#define ZENOH_LOG_ENV_VAR_STR "RUST_LOG"
+#define ZENOH_LOG_WARN_LEVEL_STR "warn"
+#define ZENOH_LOG_INFO_LEVEL_STR "info"
+
 namespace rmw_zenoh_cpp
 {
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -42,10 +42,6 @@ extern "C"
 // TODO(clalancette): Make this configurable, or get it from the configuration
 #define SHM_BUFFER_SIZE_MB 10
 
-// Environment variable for Zenoh logging
-const char * ZENOH_LOG_ENV_VAR = "RUST_LOG";
-const char * ZENOH_LOG_DEFAULT_LEVEL = "warn";
-
 namespace
 {
 void
@@ -172,8 +168,9 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   // Initialize context's implementation
   context->impl->is_shutdown = false;
 
-  // If not already defined, set the logging environment variable for Zenoh to default value
-  if (setenv(ZENOH_LOG_ENV_VAR, ZENOH_LOG_DEFAULT_LEVEL, 0) != 0) {
+  // If not already defined, set the logging environment variable for Zenoh
+  // to warning level by default
+  if (setenv(ZENOH_LOG_ENV_VAR_STR, ZENOH_LOG_WARN_LEVEL_STR, 0) != 0) {
     RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
     return 1;
   }

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -42,6 +42,10 @@ extern "C"
 // TODO(clalancette): Make this configurable, or get it from the configuration
 #define SHM_BUFFER_SIZE_MB 10
 
+// Environment variable for Zenoh logging
+const char* ZENOH_LOG_ENV_VAR = "RUST_LOG";
+const char* ZENOH_LOG_DEFAULT_LEVEL = "warn";
+
 namespace
 {
 void
@@ -167,6 +171,12 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 
   // Initialize context's implementation
   context->impl->is_shutdown = false;
+
+  // If not already defined, set the logging environment variable for Zenoh to default value
+  if (setenv(ZENOH_LOG_ENV_VAR, ZENOH_LOG_DEFAULT_LEVEL, 0) != 0) {
+      RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
+      return 1;
+  }
 
   // Initialize the zenoh configuration.
   z_owned_config_t config;

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -168,11 +168,12 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   // Initialize context's implementation
   context->impl->is_shutdown = false;
 
-  // If not already defined, set the logging environment variable for Zenoh
-  // to warning level by default
+  // If not already defined, set the logging environment variable for Zenoh sessions
+  // to warning level by default.
+  // TODO(Yadunund): Switch to rcutils_get_env once it supports not overwriting values.
   if (setenv(ZENOH_LOG_ENV_VAR_STR, ZENOH_LOG_WARN_LEVEL_STR, 0) != 0) {
     RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
-    return 1;
+    return RMW_RET_ERROR;
   }
 
   // Initialize the zenoh configuration.

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -43,8 +43,8 @@ extern "C"
 #define SHM_BUFFER_SIZE_MB 10
 
 // Environment variable for Zenoh logging
-const char* ZENOH_LOG_ENV_VAR = "RUST_LOG";
-const char* ZENOH_LOG_DEFAULT_LEVEL = "warn";
+const char * ZENOH_LOG_ENV_VAR = "RUST_LOG";
+const char * ZENOH_LOG_DEFAULT_LEVEL = "warn";
 
 namespace
 {
@@ -174,8 +174,8 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 
   // If not already defined, set the logging environment variable for Zenoh to default value
   if (setenv(ZENOH_LOG_ENV_VAR, ZENOH_LOG_DEFAULT_LEVEL, 0) != 0) {
-      RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
-      return 1;
+    RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
+    return 1;
   }
 
   // Initialize the zenoh configuration.

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -40,7 +40,7 @@ static bool running = true;
 
 // Environment variable for Zenoh logging
 const char* ZENOH_LOG_ENV_VAR = "RUST_LOG";
-const char* ZENOH_LOG_DEFAULT_LEVEL = "warn";
+const char* ZENOH_LOG_DEFAULT_LEVEL = "info";
 
 class KeyboardReader final
 {

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -174,8 +174,9 @@ int main(int argc, char ** argv)
   (void)argc;
   (void)argv;
 
-  // If not already defined, set the logging environment variable for Zenoh
-  // to info level by default
+  // If not already defined, set the logging environment variable for Zenoh router
+  // to info level by default.
+  // TODO(Yadunund): Switch to rcutils_get_env once it supports not overwriting values.
   if (setenv(ZENOH_LOG_ENV_VAR_STR, ZENOH_LOG_INFO_LEVEL_STR, 0) != 0) {
     RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
     return 1;

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -38,10 +38,6 @@
 
 static bool running = true;
 
-// Environment variable for Zenoh logging
-const char * ZENOH_LOG_ENV_VAR = "RUST_LOG";
-const char * ZENOH_LOG_DEFAULT_LEVEL = "info";
-
 class KeyboardReader final
 {
 public:
@@ -178,8 +174,9 @@ int main(int argc, char ** argv)
   (void)argc;
   (void)argv;
 
-  // If not already defined, set the logging environment variable for Zenoh to default value
-  if (setenv(ZENOH_LOG_ENV_VAR, ZENOH_LOG_DEFAULT_LEVEL, 0) != 0) {
+  // If not already defined, set the logging environment variable for Zenoh
+  // to info level by default
+  if (setenv(ZENOH_LOG_ENV_VAR_STR, ZENOH_LOG_INFO_LEVEL_STR, 0) != 0) {
     RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
     return 1;
   }

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -39,8 +39,8 @@
 static bool running = true;
 
 // Environment variable for Zenoh logging
-const char* ZENOH_LOG_ENV_VAR = "RUST_LOG";
-const char* ZENOH_LOG_DEFAULT_LEVEL = "info";
+const char * ZENOH_LOG_ENV_VAR = "RUST_LOG";
+const char * ZENOH_LOG_DEFAULT_LEVEL = "info";
 
 class KeyboardReader final
 {
@@ -180,8 +180,8 @@ int main(int argc, char ** argv)
 
   // If not already defined, set the logging environment variable for Zenoh to default value
   if (setenv(ZENOH_LOG_ENV_VAR, ZENOH_LOG_DEFAULT_LEVEL, 0) != 0) {
-      RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
-      return 1;
+    RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
+    return 1;
   }
 
   // Initialize the zenoh configuration for the router.

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -38,6 +38,10 @@
 
 static bool running = true;
 
+// Environment variable for Zenoh logging
+const char* ZENOH_LOG_ENV_VAR = "RUST_LOG";
+const char* ZENOH_LOG_DEFAULT_LEVEL = "warn";
+
 class KeyboardReader final
 {
 public:
@@ -173,6 +177,12 @@ int main(int argc, char ** argv)
 {
   (void)argc;
   (void)argv;
+
+  // If not already defined, set the logging environment variable for Zenoh to default value
+  if (setenv(ZENOH_LOG_ENV_VAR, ZENOH_LOG_DEFAULT_LEVEL, 0) != 0) {
+      RMW_SET_ERROR_MSG("Error configuring Zenoh logging.");
+      return 1;
+  }
 
   // Initialize the zenoh configuration for the router.
   z_owned_config_t config;


### PR DESCRIPTION
Currently no logs from Zenoh are shown, neither "error" level, neither "warn" level.
The user would have to define the `RUST_LOG` environment variable to enable those logs.

This PR checks automatically defines the `RUST_LOG` environment variable before opening a Zenoh Session, if not already defined in the environment.
- For the Router it's set by default to `RUST_LOG=info` (similar level than the original Zenoh Router)
- For the Nodes it's set by default to `RUST_LOG=warn`
