### PR TITLE
Pass `-r` to rosdep during Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See [zenoh_c_vendor/CMakeLists.txt](./zenoh_c_vendor/CMakeLists.txt) for more de
 mkdir ~/ws_rmw_zenoh/src -p && cd ~/ws_rmw_zenoh/src
 git clone https://github.com/ros2/rmw_zenoh.git
 cd ~/ws_rmw_zenoh
-rosdep install --from-paths src --ignore-src --rosdistro <DISTRO> -y # replace <DISTRO> with ROS 2 distro of choice
+rosdep install --from-paths src --ignore-src --rosdistro <DISTRO> -y -r # replace <DISTRO> with ROS 2 distro of choice
 source /opt/ros/<DISTRO>/setup.bash # replace <DISTRO> with ROS 2 distro of choice
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```


### PR DESCRIPTION
On Ubuntu 22.04.4 LTS, with ROS2 Rolling installed via [Debian packages](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html#ubuntu-debian-packages), I get the following error when following the README [Setup](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html#ubuntu-debian-packages) instructions:

```console
$ rosdep install --ignore-src --from-paths src --rosdistro rolling -y
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
zenoh_c_vendor: No definition of [ament_cmake_vendor_package] for OS version [jammy]
rmw_zenoh_cpp: No definition of [rmw] for OS version [jammy]
```

While skimming some [ROS2-related Github issues](https://github.com/IntelRealSense/realsense-ros/issues/2309) it seems that passing `-r` which means "Continue installing despite errors." resolves the issue (at least for me).