### PR TITLE
construct and destruct rmw_node_data_t

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -275,7 +275,7 @@ rmw_create_node(
     });
 
   // Put metadata into node->data.
-  auto node_data =  static_cast<rmw_zenoh_cpp::rmw_node_data_t *>(
+  auto node_data = static_cast<rmw_zenoh_cpp::rmw_node_data_t *>(
     allocator->allocate(sizeof(rmw_zenoh_cpp::rmw_node_data_t), allocator->state));
   RMW_CHECK_FOR_NULL_WITH_MSG(
     node_data,


### PR DESCRIPTION
Construct and destruct node->data after allocating memory. When we add non-POD data fields to `rmw_node_data_t`, we will run into issues when accessing fields. 