### PR TITLE
remove rmw_localhost_only_t.

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_init_options.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init_options.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <zenoh.h>
+#include <string.h>
 
 #include "detail/identifier.hpp"
 #include "detail/rmw_init_options_impl.hpp"
@@ -40,6 +41,7 @@ rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t all
     return RMW_RET_INVALID_ARGUMENT;
   }
 
+  memset(init_options, 0, sizeof(rmw_init_options_t));
   init_options->instance_id = 0;
   init_options->implementation_identifier = rmw_zenoh_cpp::rmw_zenoh_identifier;
   init_options->allocator = allocator;
@@ -75,9 +77,8 @@ rmw_init_options_copy(const rmw_init_options_t * src, rmw_init_options_t * dst)
   RCUTILS_CHECK_ALLOCATOR(&allocator, return RMW_RET_INVALID_ARGUMENT);
 
   rmw_init_options_t tmp;
-  tmp.instance_id = src->instance_id;
+  memcpy(&tmp, src, sizeof(rmw_init_options_t));
   tmp.implementation_identifier = rmw_zenoh_cpp::rmw_zenoh_identifier;
-  tmp.domain_id = src->domain_id;
   tmp.security_options = rmw_get_zero_initialized_security_options();
   rmw_ret_t ret =
     rmw_security_options_copy(&src->security_options, &allocator, &tmp.security_options);
@@ -88,7 +89,6 @@ rmw_init_options_copy(const rmw_init_options_t * src, rmw_init_options_t * dst)
     [&tmp, allocator]() {
       rmw_security_options_fini(&tmp.security_options, &allocator);
     });
-  tmp.localhost_only = src->localhost_only;
   tmp.discovery_options = rmw_get_zero_initialized_discovery_options();
   ret = rmw_discovery_options_copy(
     &src->discovery_options,

--- a/rmw_zenoh_cpp/src/rmw_init_options.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init_options.cpp
@@ -47,7 +47,6 @@ rmw_init_options_init(rmw_init_options_t * init_options, rcutils_allocator_t all
   init_options->enclave = nullptr;
   init_options->domain_id = RMW_DEFAULT_DOMAIN_ID;
   init_options->security_options = rmw_get_default_security_options();
-  init_options->localhost_only = RMW_LOCALHOST_ONLY_DEFAULT;
   init_options->discovery_options = rmw_get_zero_initialized_discovery_options();
   return rmw_discovery_options_init(&(init_options->discovery_options), 0, &allocator);
 }


### PR DESCRIPTION
Hello, maybe it's also in your plan, but i wanted to open PR about deprecated usage of rmw_localhost_only_t just in case you have overlooked this PR ( https://github.com/ros2/rcl/pull/1169 )  in rcl. I have discovered this one while running ros-industrial ci in my repo and some errors happen like below in the `ROS_REPO=testing` case.

```shell
       Finished release [optimized] target(s) in 7m 07s
  ---
  Finished <<< zenoh_c_vendor [7min 14s]
  Starting >>> rmw_zenoh_cpp
  --- stderr: rmw_zenoh_cpp
  /root/upstream_ws/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init_options.cpp: In function ‘rmw_ret_t rmw_init_options_init(rmw_init_options_t*, rcutils_allocator_t)’:
  /root/upstream_ws/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init_options.cpp:50:17: error: ‘rmw_init_options_t’ {aka ‘struct rmw_init_options_s’} has no member named ‘localhost_only’
     50 |   init_options->localhost_only = RMW_LOCALHOST_ONLY_DEFAULT;
        |                 ^~~~~~~~~~~~~~
  /root/upstream_ws/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init_options.cpp:50:34: error: ‘RMW_LOCALHOST_ONLY_DEFAULT’ was not declared in this scope
     50 |   init_options->localhost_only = RMW_LOCALHOST_ONLY_DEFAULT;
        |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~
  /root/upstream_ws/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init_options.cpp: In function ‘rmw_ret_t rmw_init_options_copy(const rmw_init_options_t*, rmw_init_options_t*)’:
  /root/upstream_ws/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init_options.cpp:92:7: error: ‘rmw_init_options_t’ {aka ‘struct rmw_init_options_s’} has no member named ‘localhost_only’
     92 |   tmp.localhost_only = src->localhost_only;
        |       ^~~~~~~~~~~~~~
  /root/upstream_ws/src/rmw_zenoh/rmw_zenoh_cpp/src/rmw_init_options.cpp:92:29: error: ‘const rmw_init_options_t’ {aka ‘const struct rmw_init_options_s’} has no member named ‘localhost_only’
     92 |   tmp.localhost_only = src->localhost_only;
        |                             ^~~~~~~~~~~~~~
  gmake[2]: *** [CMakeFiles/rmw_zenoh_cpp.dir/build.make:384: CMakeFiles/rmw_zenoh_cpp.dir/src/rmw_init_options.cpp.o] Error 1
  gmake[2]: *** Waiting for unfinished jobs....
  gmake[1]: *** [CMakeFiles/Makefile2:139: CMakeFiles/rmw_zenoh_cpp.dir/all] Error 2
  gmake: *** [Makefile:146: all] Error 2
  ---
  Failed   <<< rmw_zenoh_cpp [14.0s, exited with code 2]
  
  Summary: 14 packages finished [7min 29s]
    1 package failed: rmw_zenoh_cpp
    2 packages had stderr output: rmw_zenoh_cpp zenoh_c_vendor
'build_upstream_workspace' returned with code '2' after 7 min 29 sec
```