### PR TITLE
Modify CI to track ros testing repo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,21 +4,52 @@ on:
   push:
     branches: [ rolling ]
   workflow_dispatch:
+  schedule:
+    # Run every morning to detect flakiness and broken dependencies
+    - cron: '03 5 * * *'
 defaults:
   run:
     shell: bash
 jobs:
-  test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        ROS_DISTRO: ['iron', 'jazzy', 'rolling']
-        ROS_REPO: ['main', 'testing']
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-      - uses: 'ros-industrial/industrial_ci@master'
-        env:
-          ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
-          ROS_REPO: ${{ matrix.ROS_REPO }}
+  build_and_test_source_rolling:
+      runs-on: ubuntu-latest
+      container:
+        image: rostooling/setup-ros-docker:ubuntu-noble-latest
+      steps:
+      - name: Build and run tests
+        id: action-ros-ci
+        uses: ros-tooling/action-ros-ci@v0.3
+        with:
+          package-name: |
+            rmw_zenoh_cpp
+            zenoh_c_vendor
+          target-ros2-distro: rolling
+          vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+
+    build_and_test_binaries_jazzy:
+      runs-on: ubuntu-latest
+      container:
+        image: rostooling/setup-ros-docker:ubuntu-noble-latest
+      steps:
+      - name: Build and run tests
+        id: action-ros-ci
+        uses: ros-tooling/action-ros-ci@v0.3
+        with:
+          package-name: |
+            rmw_zenoh_cpp
+            zenoh_c_vendor
+          target-ros2-distro: jazzy
+
+    build_and_test_binaries_iron:
+      runs-on: ubuntu-latest
+      container:
+        image: rostooling/setup-ros-docker:ubuntu-noble-latest
+      steps:
+      - name: Build and run tests
+        id: action-ros-ci
+        uses: ros-tooling/action-ros-ci@v0.3
+        with:
+          package-name: |
+            rmw_zenoh_cpp
+            zenoh_c_vendor
+          target-ros2-distro: iron

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,7 +42,7 @@ jobs:
   build_and_test_binaries_iron:
     runs-on: ubuntu-latest
     container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-latest
+      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
     steps:
     - name: Build and run tests
       id: action-ros-ci

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,11 @@ defaults:
   run:
     shell: bash
 jobs:
-  build_and_test_source_rolling:
+  build_and_test:
+      name: build_and_test_binaries_${{ matrix.ROS_DISTRO }}
+      strategy:
+        matrix:
+          ROS_DISTRO: [rolling, jazzy, iron]
       runs-on: ubuntu-latest
       container:
         image: rostooling/setup-ros-docker:ubuntu-noble-latest
@@ -23,32 +27,5 @@ jobs:
           package-name: |
             rmw_zenoh_cpp
             zenoh_c_vendor
-          target-ros2-distro: rolling
+          target-ros2-distro: ${{ matrix.ROS_DISTRO }}
           vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
-  build_and_test_binaries_jazzy:
-    runs-on: ubuntu-latest
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-noble-latest
-    steps:
-    - name: Build and run tests
-      id: action-ros-ci
-      uses: ros-tooling/action-ros-ci@v0.3
-      with:
-        package-name: |
-          rmw_zenoh_cpp
-          zenoh_c_vendor
-        target-ros2-distro: jazzy
-
-  build_and_test_binaries_iron:
-    runs-on: ubuntu-latest
-    container:
-      image: rostooling/setup-ros-docker:ubuntu-jammy-latest
-    steps:
-    - name: Build and run tests
-      id: action-ros-ci
-      uses: ros-tooling/action-ros-ci@v0.3
-      with:
-        package-name: |
-          rmw_zenoh_cpp
-          zenoh_c_vendor
-        target-ros2-distro: iron

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,4 +28,4 @@ jobs:
             rmw_zenoh_cpp
             zenoh_c_vendor
           target-ros2-distro: ${{ matrix.ROS_DISTRO }}
-          vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+          vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,20 +12,38 @@ defaults:
     shell: bash
 jobs:
   build_and_test:
-      name: build_and_test_binaries_${{ matrix.ROS_DISTRO }}
-      strategy:
-        matrix:
-          ROS_DISTRO: [rolling, jazzy, iron]
-      runs-on: ubuntu-latest
-      container:
-        image: rostooling/setup-ros-docker:ubuntu-noble-latest
-      steps:
-      - name: Build and run tests
-        id: action-ros-ci
-        uses: ros-tooling/action-ros-ci@v0.3
-        with:
-          package-name: |
-            rmw_zenoh_cpp
-            zenoh_c_vendor
-          target-ros2-distro: ${{ matrix.ROS_DISTRO }}
-          vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos
+    name: build_and_test_${{ matrix.BUILD_TYPE }}_${{ matrix.ROS_DISTRO }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Rolling (source)
+          - ROS_DISTRO: rolling
+            BUILD_TYPE: source
+            DOCKER_IMAGE: ubuntu:noble
+          # Jazzy (binary)
+          - ROS_DISTRO: jazzy
+            BUILD_TYPE: binary
+            DOCKER_IMAGE: ubuntu:noble
+          # Iron (binary)
+          - ROS_DISTRO: iron
+            BUILD_TYPE: binary
+            DOCKER_IMAGE: ubuntu:jammy
+    env:
+      ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos'
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.DOCKER_IMAGE }}
+    steps:
+    - uses: ros-tooling/setup-ros@v0.7
+      with:
+        required-ros-distributions: ${{ matrix.BUILD_TYPE == 'binary' && matrix.ROS_DISTRO || ''}}
+    - name: Build and run tests
+      id: action-ros-ci
+      uses: ros-tooling/action-ros-ci@v0.3
+      with:
+        package-name: |
+          rmw_zenoh_cpp
+          zenoh_c_vendor
+        target-ros2-distro: ${{ matrix.ROS_DISTRO }}
+        vcs-repo-file-url: ${{ matrix.BUILD_TYPE == 'source' && env.ROS2_REPOS_FILE_URL || '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,31 +25,30 @@ jobs:
             zenoh_c_vendor
           target-ros2-distro: rolling
           vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/rolling/ros2.repos
+  build_and_test_binaries_jazzy:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
+    steps:
+    - name: Build and run tests
+      id: action-ros-ci
+      uses: ros-tooling/action-ros-ci@v0.3
+      with:
+        package-name: |
+          rmw_zenoh_cpp
+          zenoh_c_vendor
+        target-ros2-distro: jazzy
 
-    build_and_test_binaries_jazzy:
-      runs-on: ubuntu-latest
-      container:
-        image: rostooling/setup-ros-docker:ubuntu-noble-latest
-      steps:
-      - name: Build and run tests
-        id: action-ros-ci
-        uses: ros-tooling/action-ros-ci@v0.3
-        with:
-          package-name: |
-            rmw_zenoh_cpp
-            zenoh_c_vendor
-          target-ros2-distro: jazzy
-
-    build_and_test_binaries_iron:
-      runs-on: ubuntu-latest
-      container:
-        image: rostooling/setup-ros-docker:ubuntu-noble-latest
-      steps:
-      - name: Build and run tests
-        id: action-ros-ci
-        uses: ros-tooling/action-ros-ci@v0.3
-        with:
-          package-name: |
-            rmw_zenoh_cpp
-            zenoh_c_vendor
-          target-ros2-distro: iron
+  build_and_test_binaries_iron:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-noble-latest
+    steps:
+    - name: Build and run tests
+      id: action-ros-ci
+      uses: ros-tooling/action-ros-ci@v0.3
+      with:
+        package-name: |
+          rmw_zenoh_cpp
+          zenoh_c_vendor
+        target-ros2-distro: iron

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,18 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ['iron', 'jazzy', 'rolling']
-    container:
-      image: ros:${{ matrix.distro }}-ros-base
+        ROS_DISTRO: ['iron', 'jazzy', 'rolling']
+        ROS_REPO: ['main', 'testing']
     timeout-minutes: 30
     steps:
-    - name: Deps
-      run: |
-        apt update && apt install -y curl
     - uses: actions/checkout@v4
-    - name: rosdep
-      run: |
-        rosdep update
-        rosdep install --from-paths . -yir
-    - name: build
-      run: /ros_entrypoint.sh colcon build
+    - uses: 'ros-industrial/industrial_ci@master'
+        env:
+          ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
+          ROS_REPO: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,8 @@ jobs:
         ROS_REPO: ['main', 'testing']
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@v4
-    - uses: 'ros-industrial/industrial_ci@master'
+      - uses: actions/checkout@v4
+      - uses: 'ros-industrial/industrial_ci@master'
         env:
           ROS_DISTRO: ${{ matrix.ROS_DISTRO }}
           ROS_REPO: ${{ matrix.ROS_REPO }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,24 +20,23 @@ jobs:
           # Rolling (source)
           - ROS_DISTRO: rolling
             BUILD_TYPE: source
-            DOCKER_IMAGE: ubuntu:noble
           # Jazzy (binary)
           - ROS_DISTRO: jazzy
             BUILD_TYPE: binary
-            DOCKER_IMAGE: ubuntu:noble
           # Iron (binary)
           - ROS_DISTRO: iron
             BUILD_TYPE: binary
-            DOCKER_IMAGE: ubuntu:jammy
     env:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos'
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.DOCKER_IMAGE }}
+      image: ${{ matrix.BUILD_TYPE == 'binary' && format('ros:{0}-ros-base', matrix.ROS_DISTRO) || 'ubuntu:noble' }}
     steps:
     - uses: ros-tooling/setup-ros@v0.7
-      with:
-        required-ros-distributions: ${{ matrix.BUILD_TYPE == 'binary' && matrix.ROS_DISTRO || ''}}
+      if: ${{ matrix.BUILD_TYPE == 'source' }}
+    - name: Install Coverage Tools
+      if: ${{ matrix.BUILD_TYPE == 'binary' }}
+      run: sudo apt update && sudo apt install -y python3-colcon-coveragepy-result python3-colcon-lcov-result
     - name: Build and run tests
       id: action-ros-ci
       uses: ros-tooling/action-ros-ci@v0.3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
       if: ${{ matrix.BUILD_TYPE == 'source' }}
     - name: Install Coverage Tools
       if: ${{ matrix.BUILD_TYPE == 'binary' }}
-      run: sudo apt update && sudo apt install -y python3-colcon-coveragepy-result python3-colcon-lcov-result
+      run: sudo apt update && sudo apt install -y python3-colcon-coveragepy-result python3-colcon-lcov-result lcov
     - name: Build and run tests
       id: action-ros-ci
       uses: ros-tooling/action-ros-ci@v0.3


### PR DESCRIPTION
To prevent the errors stated in this PR ( https://github.com/ros2/rmw_zenoh/pull/255 ) , i have refactored the build CI so that it can be tracked the modifications, API changes etc. for rolling, jazzy and iron continuously. I don't know what type of approach this team has, however i wanted to come up with some option. It's ready to your service. It doesn't matter if you accepted or not. Btw to just modify container except this PR's idea can be another option. I can do it too.