### PR TITLE
Thread-safe access to graph cache

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(rmw_zenoh_cpp SHARED
   src/detail/logging.cpp
   src/detail/message_type_support.cpp
   src/detail/qos.cpp
+  src/detail/rmw_context_impl_s.cpp
   src/detail/rmw_data_types.cpp
   src/detail/service_type_support.cpp
   src/detail/type_support.cpp

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -54,6 +54,7 @@ void rmw_context_impl_s::graph_sub_data_handler(const z_sample_t * sample, void 
       break;
     case z_sample_kind_t::Z_SAMPLE_KIND_DELETE:
       data_ptr->graph_cache_->parse_del(keystr._cstr);
+      break;
     default:
       return;
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -15,15 +15,22 @@
 #include "rmw_context_impl_s.hpp"
 
 #include <utility>
+#include <thread>
 
 #include "guard_condition.hpp"
+#include "identifier.hpp"
 #include "liveliness_utils.hpp"
 #include "logging_macros.hpp"
 #include "zenoh_config.hpp"
+#include "zenoh_router_check.hpp"
 
 #include "rcpputils/scope_exit.hpp"
 #include "rmw/error_handling.h"
 #include "rmw/impl/cpp/macros.hpp"
+
+// Megabytes of SHM to reserve.
+// TODO(clalancette): Make this configurable, or get it from the configuration
+#define SHM_BUFFER_SIZE_MB 10
 
 ///=============================================================================
 void rmw_context_impl_s::graph_sub_data_handler(const z_sample_t * sample, void * data)
@@ -72,66 +79,24 @@ void rmw_context_impl_s::graph_sub_data_handler(const z_sample_t * sample, void 
 ///=============================================================================
 rmw_context_impl_s::Data::Data(
   const rcutils_allocator_t * allocator,
-  const std::size_t domain_id,
   const std::string & enclave,
   z_owned_session_t session,
   std::optional<zc_owned_shm_manager_t> shm_manager,
+  const std::string & liveliness_str,
+  std::unique_ptr<rmw_zenoh_cpp::GraphCache> graph_cache,
   rmw_guard_condition_t * graph_guard_condition)
 : allocator_(allocator),
   enclave_(std::move(enclave)),
   session_(std::move(session)),
   shm_manager_(std::move(shm_manager)),
+  liveliness_str_(std::move(liveliness_str)),
+  graph_cache_(std::move(graph_cache)),
   graph_guard_condition_(graph_guard_condition),
   is_shutdown_(false),
   next_entity_id_(0),
   is_initialized_(false)
 {
-  z_id_t zid = z_info_zid(z_loan(session_));
-  graph_cache_ = std::make_unique<rmw_zenoh_cpp::GraphCache>(std::move(zid));
-  // Setup liveliness subscriptions for discovery.
-  liveliness_str_ = rmw_zenoh_cpp::liveliness::subscription_token(
-    domain_id);
-
-  // Query router/liveliness participants to get graph information before this session was started.
-  // We create a blocking channel that is unbounded, ie. `bound` = 0, to receive
-  // replies for the zc_liveliness_get() call. This is necessary as if the `bound`
-  // is too low, the channel may starve the zenoh executor of its threads which
-  // would lead to deadlocks when trying to receive replies and block the
-  // execution here.
-  // The blocking channel will return when the sender end is closed which is
-  // the moment the query finishes.
-  // The non-blocking fifo exists only for the use case where we don't want to
-  // block the thread between responses (including the request termination response).
-  // In general, unless we want to cooperatively schedule other tasks on the same
-  // thread as reading the fifo, the blocking fifo will be more appropriate as
-  // the code will be simpler, and if we're just going to spin over the non-blocking
-  // reads until we obtain responses, we'll just be hogging CPU time by convincing
-  // the OS that we're doing actual work when it could instead park the thread.
-  z_owned_reply_channel_t channel = zc_reply_fifo_new(0);
-  zc_liveliness_get(
-    z_loan(session_), z_keyexpr(liveliness_str_.c_str()),
-    z_move(channel.send), NULL);
-  z_owned_reply_t reply = z_reply_null();
-  for (bool call_success = z_call(channel.recv, &reply); !call_success || z_check(reply);
-    call_success = z_call(channel.recv, &reply))
-  {
-    if (!call_success) {
-      continue;
-    }
-    if (z_reply_is_ok(&reply)) {
-      z_sample_t sample = z_reply_ok(&reply);
-      z_owned_str_t keystr = z_keyexpr_to_string(sample.keyexpr);
-      // Ignore tokens from the same session to avoid race conditions from this
-      // query and the liveliness subscription.
-      graph_cache_->parse_put(z_loan(keystr), true);
-      z_drop(z_move(keystr));
-    } else {
-      RMW_ZENOH_LOG_DEBUG_NAMED(
-        "rmw_zenoh_cpp", "[rmw_context_impl_s] z_call received an invalid reply\n");
-    }
-  }
-  z_drop(z_move(reply));
-  z_drop(z_move(channel));
+  // Do nothing.
 }
 
 ///=============================================================================
@@ -208,22 +173,189 @@ rmw_context_impl_s::Data::~Data()
 rmw_context_impl_s::rmw_context_impl_s(
   const rcutils_allocator_t * allocator,
   const std::size_t domain_id,
-  const std::string & enclave,
-  z_owned_session_t session,
-  std::optional<zc_owned_shm_manager_t> shm_manager,
-  rmw_guard_condition_t * graph_guard_condition)
+  const std::string & enclave)
 {
+  // Initialize the zenoh configuration.
+  z_owned_config_t config;
+  rmw_ret_t ret;
+  if ((ret =
+    rmw_zenoh_cpp::get_z_config(
+      rmw_zenoh_cpp::ConfigurableEntity::Session,
+      &config)) != RMW_RET_OK)
+  {
+    throw std::runtime_error("Error configuring Zenoh session.");
+  }
+
+  // Check if shm is enabled.
+  z_owned_str_t shm_enabled = zc_config_get(z_loan(config), "transport/shared_memory/enabled");
+  auto always_free_shm_enabled = rcpputils::make_scope_exit(
+    [&shm_enabled]() {
+      z_drop(z_move(shm_enabled));
+    });
+
+  // Initialize the zenoh session.
+  z_owned_session_t session = z_open(z_move(config));
+  if (!z_session_check(&session)) {
+    throw std::runtime_error("Error setting up zenoh session");
+  }
+  auto close_session = rcpputils::make_scope_exit(
+    [&session]() {
+      z_close(z_move(session));
+    });
+
+  // TODO(Yadunund) Move this check into a separate thread.
+  // Verify if the zenoh router is running if configured.
+  const std::optional<uint64_t> configured_connection_attempts =
+    rmw_zenoh_cpp::zenoh_router_check_attempts();
+  if (configured_connection_attempts.has_value()) {
+    ret = RMW_RET_ERROR;
+    uint64_t connection_attempts = 0;
+    // Retry until the connection is successful.
+    while (ret != RMW_RET_OK && connection_attempts < configured_connection_attempts.value()) {
+      if ((ret = rmw_zenoh_cpp::zenoh_router_check(z_loan(session))) != RMW_RET_OK) {
+        ++connection_attempts;
+      }
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
+    if (ret != RMW_RET_OK) {
+      throw std::runtime_error(
+        "Unable to connect to a Zenoh router after " +
+        std::to_string(configured_connection_attempts.value()) +
+        " retries.");
+    }
+  }
+
+  // Initialize the graph cache.
+  const z_id_t zid = z_info_zid(z_loan(session));
+  auto graph_cache = std::make_unique<rmw_zenoh_cpp::GraphCache>(zid);
+  // Setup liveliness subscriptions for discovery.
+  std::string liveliness_str = rmw_zenoh_cpp::liveliness::subscription_token(
+    domain_id);
+
+  // Query router/liveliness participants to get graph information before this session was started.
+  // We create a blocking channel that is unbounded, ie. `bound` = 0, to receive
+  // replies for the zc_liveliness_get() call. This is necessary as if the `bound`
+  // is too low, the channel may starve the zenoh executor of its threads which
+  // would lead to deadlocks when trying to receive replies and block the
+  // execution here.
+  // The blocking channel will return when the sender end is closed which is
+  // the moment the query finishes.
+  // The non-blocking fifo exists only for the use case where we don't want to
+  // block the thread between responses (including the request termination response).
+  // In general, unless we want to cooperatively schedule other tasks on the same
+  // thread as reading the fifo, the blocking fifo will be more appropriate as
+  // the code will be simpler, and if we're just going to spin over the non-blocking
+  // reads until we obtain responses, we'll just be hogging CPU time by convincing
+  // the OS that we're doing actual work when it could instead park the thread.
+  z_owned_reply_channel_t channel = zc_reply_fifo_new(0);
+  zc_liveliness_get(
+    z_loan(session), z_keyexpr(liveliness_str.c_str()),
+    z_move(channel.send), NULL);
+  z_owned_reply_t reply = z_reply_null();
+  for (bool call_success = z_call(channel.recv, &reply); !call_success || z_check(reply);
+    call_success = z_call(channel.recv, &reply))
+  {
+    if (!call_success) {
+      continue;
+    }
+    if (z_reply_is_ok(&reply)) {
+      z_sample_t sample = z_reply_ok(&reply);
+      z_owned_str_t keystr = z_keyexpr_to_string(sample.keyexpr);
+      // Ignore tokens from the same session to avoid race conditions from this
+      // query and the liveliness subscription.
+      graph_cache->parse_put(z_loan(keystr), true);
+      z_drop(z_move(keystr));
+    } else {
+      RMW_ZENOH_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp", "[rmw_context_impl_s] z_call received an invalid reply\n");
+    }
+  }
+  z_drop(z_move(reply));
+  z_drop(z_move(channel));
+
+  // Initialize the shm manager if shared_memory is enabled in the config.
+  std::optional<zc_owned_shm_manager_t> shm_manager = std::nullopt;
+  if (shm_enabled._cstr != nullptr &&
+    strcmp(shm_enabled._cstr, "true") == 0)
+  {
+    char idstr[sizeof(zid.id) * 2 + 1];  // 2 bytes for each byte of the id, plus the trailing \0
+    static constexpr size_t max_size_of_each = 3;  // 2 for each byte, plus the trailing \0
+    for (size_t i = 0; i < sizeof(zid.id); ++i) {
+      snprintf(idstr + 2 * i, max_size_of_each, "%02x", zid.id[i]);
+    }
+    idstr[sizeof(zid.id) * 2] = '\0';
+    // TODO(yadunund): Can we get the size of the shm from the config even though it's not
+    // a standard parameter?
+    shm_manager =
+      zc_shm_manager_new(
+      z_loan(session),
+      idstr,
+      SHM_BUFFER_SIZE_MB * 1024 * 1024);
+    if (!shm_manager.has_value() ||
+      !zc_shm_manager_check(&shm_manager.value()))
+    {
+      throw std::runtime_error("Unable to create shm manager.");
+    }
+  }
+  auto free_shm_manager = rcpputils::make_scope_exit(
+    [&shm_manager]() {
+      if (shm_manager.has_value()) {
+        z_drop(z_move(shm_manager.value()));
+      }
+    });
+
+  // Initialize the guard condition.
+  rmw_guard_condition_t * graph_guard_condition =
+    static_cast<rmw_guard_condition_t *>(allocator->zero_allocate(
+      1, sizeof(rmw_guard_condition_t), allocator->state));
+  if (graph_guard_condition == NULL) {
+    throw std::runtime_error( "failed to allocate graph guard condition");
+  }
+  auto free_guard_condition = rcpputils::make_scope_exit(
+    [graph_guard_condition, allocator]() {
+      allocator->deallocate(graph_guard_condition, allocator->state);
+    });
+  graph_guard_condition->implementation_identifier =
+    rmw_zenoh_cpp::rmw_zenoh_identifier;
+  graph_guard_condition->data =
+    allocator->zero_allocate(1, sizeof(rmw_zenoh_cpp::GuardCondition), allocator->state);
+  if (graph_guard_condition->data == NULL) {
+    throw std::runtime_error("failed to allocate graph guard condition data");
+  }
+  auto free_guard_condition_data = rcpputils::make_scope_exit(
+    [graph_guard_condition, allocator]() {
+      allocator->deallocate(graph_guard_condition->data, allocator->state);
+    });
+  RMW_TRY_PLACEMENT_NEW(
+    graph_guard_condition->data,
+    graph_guard_condition->data,
+    throw std::runtime_error("failed to initialize graph_guard_condition->data."),
+    rmw_zenoh_cpp::GuardCondition);
+  auto destruct_guard_condition_data = rcpputils::make_scope_exit(
+    [graph_guard_condition]() {
+      auto gc_data =
+      static_cast<rmw_zenoh_cpp::GuardCondition *>(graph_guard_condition->data);
+      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
+        gc_data->~GuardCondition(),
+        rmw_zenoh_cpp::GuardCondition);
+    });
+
+  close_session.cancel();
+  free_shm_manager.cancel();
+  destruct_guard_condition_data.cancel();
+  free_guard_condition_data.cancel();
+  free_guard_condition.cancel();
+
   data_ = std::make_shared<Data>(
     allocator,
-    std::move(domain_id),
     std::move(enclave),
     std::move(session),
     std::move(shm_manager),
+    std::move(liveliness_str),
+    std::move(graph_cache),
     graph_guard_condition);
 
-  // TODO(Yadunund): Consider switching to a make() pattern to avoid throwing
-  // errors.
-  auto ret = data_->subscribe();
+  ret = data_->subscribe();
   if (ret != RMW_RET_OK) {
     throw std::runtime_error("Unable to subscribe to ROS Graph updates.");
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -219,9 +219,9 @@ rmw_context_impl_s::rmw_context_impl_s(
     }
     if (ret != RMW_RET_OK) {
       throw std::runtime_error(
-        "Unable to connect to a Zenoh router after " +
-        std::to_string(configured_connection_attempts.value()) +
-        " retries.");
+              "Unable to connect to a Zenoh router after " +
+              std::to_string(configured_connection_attempts.value()) +
+              " retries.");
     }
   }
 
@@ -309,7 +309,7 @@ rmw_context_impl_s::rmw_context_impl_s(
     static_cast<rmw_guard_condition_t *>(allocator->zero_allocate(
       1, sizeof(rmw_guard_condition_t), allocator->state));
   if (graph_guard_condition == NULL) {
-    throw std::runtime_error( "failed to allocate graph guard condition");
+    throw std::runtime_error("failed to allocate graph guard condition");
   }
   auto free_guard_condition = rcpputils::make_scope_exit(
     [graph_guard_condition, allocator]() {

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -14,8 +14,9 @@
 
 #include "rmw_context_impl_s.hpp"
 
-#include <utility>
+#include <mutex>
 #include <thread>
+#include <utility>
 
 #include "guard_condition.hpp"
 #include "identifier.hpp"

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -196,7 +196,7 @@ rmw_context_impl_s::rmw_context_impl_s(
   // Initialize the zenoh session.
   z_owned_session_t session = z_open(z_move(config));
   if (!z_session_check(&session)) {
-    throw std::runtime_error("Error setting up zenoh session");
+    throw std::runtime_error("Error setting up zenoh session.");
   }
   auto close_session = rcpputils::make_scope_exit(
     [&session]() {
@@ -267,7 +267,7 @@ rmw_context_impl_s::rmw_context_impl_s(
       z_drop(z_move(keystr));
     } else {
       RMW_ZENOH_LOG_DEBUG_NAMED(
-        "rmw_zenoh_cpp", "[rmw_context_impl_s] z_call received an invalid reply\n");
+        "rmw_zenoh_cpp", "[rmw_context_impl_s] z_call received an invalid reply.\n");
     }
   }
   z_drop(z_move(reply));

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -582,3 +582,14 @@ void rmw_context_impl_s::set_qos_event_callback(
     event_type,
     std::move(callback));
 }
+
+///=============================================================================
+void rmw_context_impl_s::set_querying_subscriber_callback(
+  const std::string & keyexpr,
+  QueryingSubscriberCallback cb)
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->set_querying_subscriber_callback(
+    std::move(keyexpr),
+    std::move(cb));
+}

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -1,0 +1,451 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw_context_impl_s.hpp"
+
+#include <utility>
+
+#include "guard_condition.hpp"
+#include "liveliness_utils.hpp"
+#include "logging_macros.hpp"
+#include "zenoh_config.hpp"
+
+#include "rcpputils/scope_exit.hpp"
+#include "rmw/error_handling.h"
+#include "rmw/impl/cpp/macros.hpp"
+
+///=============================================================================
+void rmw_context_impl_s::graph_sub_data_handler(const z_sample_t * sample, void * data)
+{
+  z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
+  auto free_keystr = rcpputils::make_scope_exit(
+    [&keystr]() {
+      z_drop(z_move(keystr));
+    });
+
+  auto data_ptr = static_cast<Data *>(data);
+  if (data_ptr == nullptr) {
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "[graph_sub_data_handler] Unable to lock data_wp."
+    );
+    return;
+  }
+
+  // Update the graph cache.
+  std::lock_guard<std::mutex> lock(data_ptr->mutex_);
+  if (data_ptr->is_shutdown_) {
+    return;
+  }
+  switch (sample->kind) {
+    case z_sample_kind_t::Z_SAMPLE_KIND_PUT:
+      data_ptr->graph_cache_->parse_put(keystr._cstr);
+      break;
+    case z_sample_kind_t::Z_SAMPLE_KIND_DELETE:
+      data_ptr->graph_cache_->parse_del(keystr._cstr);
+    default:
+      return;
+  }
+
+  // Trigger the ROS graph guard condition.
+  rmw_ret_t rmw_ret = rmw_trigger_guard_condition(data_ptr->graph_guard_condition_);
+  if (RMW_RET_OK != rmw_ret) {
+    RMW_ZENOH_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp",
+      "[graph_sub_data_handler] Unable to trigger graph guard condition."
+    );
+  }
+}
+
+///=============================================================================
+rmw_context_impl_s::Data::Data(
+  const rcutils_allocator_t * allocator,
+  const std::size_t domain_id,
+  const std::string & enclave,
+  z_owned_session_t session,
+  std::optional<zc_owned_shm_manager_t> shm_manager,
+  rmw_guard_condition_t * graph_guard_condition)
+: allocator_(allocator),
+  enclave_(std::move(enclave)),
+  session_(std::move(session)),
+  shm_manager_(std::move(shm_manager)),
+  graph_guard_condition_(graph_guard_condition),
+  is_shutdown_(false),
+  next_entity_id_(0),
+  is_initialized_(false)
+{
+  z_id_t zid = z_info_zid(z_loan(session_));
+  graph_cache_ = std::make_unique<rmw_zenoh_cpp::GraphCache>(std::move(zid));
+  // Setup liveliness subscriptions for discovery.
+  liveliness_str_ = rmw_zenoh_cpp::liveliness::subscription_token(
+    domain_id);
+
+  // Query router/liveliness participants to get graph information before this session was started.
+  // We create a blocking channel that is unbounded, ie. `bound` = 0, to receive
+  // replies for the zc_liveliness_get() call. This is necessary as if the `bound`
+  // is too low, the channel may starve the zenoh executor of its threads which
+  // would lead to deadlocks when trying to receive replies and block the
+  // execution here.
+  // The blocking channel will return when the sender end is closed which is
+  // the moment the query finishes.
+  // The non-blocking fifo exists only for the use case where we don't want to
+  // block the thread between responses (including the request termination response).
+  // In general, unless we want to cooperatively schedule other tasks on the same
+  // thread as reading the fifo, the blocking fifo will be more appropriate as
+  // the code will be simpler, and if we're just going to spin over the non-blocking
+  // reads until we obtain responses, we'll just be hogging CPU time by convincing
+  // the OS that we're doing actual work when it could instead park the thread.
+  z_owned_reply_channel_t channel = zc_reply_fifo_new(0);
+  zc_liveliness_get(
+    z_loan(session_), z_keyexpr(liveliness_str_.c_str()),
+    z_move(channel.send), NULL);
+  z_owned_reply_t reply = z_reply_null();
+  for (bool call_success = z_call(channel.recv, &reply); !call_success || z_check(reply);
+    call_success = z_call(channel.recv, &reply))
+  {
+    if (!call_success) {
+      continue;
+    }
+    if (z_reply_is_ok(&reply)) {
+      z_sample_t sample = z_reply_ok(&reply);
+      z_owned_str_t keystr = z_keyexpr_to_string(sample.keyexpr);
+      // Ignore tokens from the same session to avoid race conditions from this
+      // query and the liveliness subscription.
+      graph_cache_->parse_put(z_loan(keystr), true);
+      z_drop(z_move(keystr));
+    } else {
+      RMW_ZENOH_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp", "[rmw_context_impl_s] z_call received an invalid reply\n");
+    }
+  }
+  z_drop(z_move(reply));
+  z_drop(z_move(channel));
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::Data::subscribe()
+{
+  if (is_initialized_) {
+    return RMW_RET_OK;
+  }
+  // Setup the liveliness subscriber to receives updates from the ROS graph
+  // and update the graph cache.
+  auto sub_options = zc_liveliness_subscriber_options_null();
+  z_owned_closure_sample_t callback = z_closure(
+    rmw_context_impl_s::graph_sub_data_handler, nullptr,
+    this->shared_from_this().get());
+  graph_subscriber_ = zc_liveliness_declare_subscriber(
+    z_loan(session_),
+    z_keyexpr(liveliness_str_.c_str()),
+    z_move(callback),
+    &sub_options);
+  zc_liveliness_subscriber_options_drop(z_move(sub_options));
+  auto undeclare_z_sub = rcpputils::make_scope_exit(
+    [this]() {
+      z_undeclare_subscriber(z_move(this->graph_subscriber_));
+    });
+  if (!z_check(graph_subscriber_)) {
+    RMW_SET_ERROR_MSG("unable to create zenoh subscription");
+    return RMW_RET_ERROR;
+  }
+
+  undeclare_z_sub.cancel();
+  is_initialized_ = true;
+  return RMW_RET_OK;
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::Data::shutdown()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (is_shutdown_) {
+    return RMW_RET_OK;
+  }
+
+  z_undeclare_subscriber(z_move(graph_subscriber_));
+  if (shm_manager_.has_value()) {
+    z_drop(z_move(shm_manager_.value()));
+  }
+  // Close the zenoh session
+  if (z_close(z_move(session_)) < 0) {
+    RMW_SET_ERROR_MSG("Error while closing zenoh session");
+    return RMW_RET_ERROR;
+  }
+  is_shutdown_ = true;
+  return RMW_RET_OK;
+}
+
+///=============================================================================
+rmw_context_impl_s::Data::~Data()
+{
+  RMW_TRY_DESTRUCTOR(
+    static_cast<rmw_zenoh_cpp::GuardCondition *>(
+      graph_guard_condition_->data)->~GuardCondition(),
+    rmw_zenoh_cpp::GuardCondition, );
+  if (rcutils_allocator_is_valid(allocator_)) {
+    allocator_->deallocate(graph_guard_condition_->data, allocator_->state);
+    allocator_->deallocate(graph_guard_condition_, allocator_->state);
+    graph_guard_condition_ = nullptr;
+  }
+
+  auto ret = this->shutdown();
+  static_cast<void>(ret);
+}
+
+///=============================================================================
+rmw_context_impl_s::rmw_context_impl_s(
+  const rcutils_allocator_t * allocator,
+  const std::size_t domain_id,
+  const std::string & enclave,
+  z_owned_session_t session,
+  std::optional<zc_owned_shm_manager_t> shm_manager,
+  rmw_guard_condition_t * graph_guard_condition)
+{
+  data_ = std::make_shared<Data>(
+    allocator,
+    std::move(domain_id),
+    std::move(enclave),
+    std::move(session),
+    std::move(shm_manager),
+    graph_guard_condition);
+
+  // TODO(Yadunund): Consider switching to a make() pattern to avoid throwing
+  // errors.
+  auto ret = data_->subscribe();
+  if (ret != RMW_RET_OK) {
+    throw std::runtime_error("Unable to subscribe to ROS Graph updates.");
+  }
+}
+
+///=============================================================================
+std::string rmw_context_impl_s::enclave() const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->enclave_;
+}
+
+///=============================================================================
+z_session_t rmw_context_impl_s::session() const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return z_loan(data_->session_);
+}
+
+///=============================================================================
+std::optional<zc_owned_shm_manager_t> & rmw_context_impl_s::shm_manager()
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->shm_manager_;
+}
+
+///=============================================================================
+rmw_guard_condition_t * rmw_context_impl_s::graph_guard_condition()
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_guard_condition_;
+}
+
+///=============================================================================
+size_t rmw_context_impl_s::get_next_entity_id()
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->next_entity_id_++;
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::shutdown()
+{
+  return data_->shutdown();
+}
+
+///=============================================================================
+bool rmw_context_impl_s::is_shutdown() const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->is_shutdown_;
+}
+
+///=============================================================================
+bool rmw_context_impl_s::session_is_valid() const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return z_check(data_->session_);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::get_node_names(
+  rcutils_string_array_t * node_names,
+  rcutils_string_array_t * node_namespaces,
+  rcutils_string_array_t * enclaves,
+  rcutils_allocator_t * allocator) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->get_node_names(
+    node_names,
+    node_namespaces,
+    enclaves,
+    allocator);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::get_topic_names_and_types(
+  rcutils_allocator_t * allocator,
+  bool no_demangle,
+  rmw_names_and_types_t * topic_names_and_types) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->get_topic_names_and_types(
+    allocator,
+    no_demangle,
+    topic_names_and_types);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::publisher_count_matched_subscriptions(
+  const rmw_publisher_t * publisher,
+  size_t * subscription_count)
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->publisher_count_matched_subscriptions(
+    publisher,
+    subscription_count);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::subscription_count_matched_publishers(
+  const rmw_subscription_t * subscription,
+  size_t * publisher_count)
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->subscription_count_matched_publishers(
+    subscription,
+    publisher_count);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::get_service_names_and_types(
+  rcutils_allocator_t * allocator,
+  rmw_names_and_types_t * service_names_and_types) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->get_service_names_and_types(
+    allocator,
+    service_names_and_types);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::count_publishers(
+  const char * topic_name,
+  size_t * count) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->count_publishers(
+    topic_name,
+    count);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::count_subscriptions(
+  const char * topic_name,
+  size_t * count) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->count_subscriptions(
+    topic_name,
+    count);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::count_services(
+  const char * service_name,
+  size_t * count) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->count_services(
+    service_name,
+    count);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::count_clients(
+  const char * service_name,
+  size_t * count) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->count_clients(
+    service_name,
+    count);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::get_entity_names_and_types_by_node(
+  rmw_zenoh_cpp::liveliness::EntityType entity_type,
+  rcutils_allocator_t * allocator,
+  const char * node_name,
+  const char * node_namespace,
+  bool no_demangle,
+  rmw_names_and_types_t * names_and_types) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->get_entity_names_and_types_by_node(
+    entity_type,
+    allocator,
+    node_name,
+    node_namespace,
+    no_demangle,
+    names_and_types);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::get_entities_info_by_topic(
+  rmw_zenoh_cpp::liveliness::EntityType entity_type,
+  rcutils_allocator_t * allocator,
+  const char * topic_name,
+  bool no_demangle,
+  rmw_topic_endpoint_info_array_t * endpoints_info) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->get_entities_info_by_topic(
+    entity_type,
+    allocator,
+    topic_name,
+    no_demangle,
+    endpoints_info);
+}
+
+///=============================================================================
+rmw_ret_t rmw_context_impl_s::service_server_is_available(
+  const char * service_name,
+  const char * service_type,
+  bool * is_available) const
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->service_server_is_available(
+    service_name,
+    service_type,
+    is_available);
+}
+
+///=============================================================================
+void rmw_context_impl_s::set_qos_event_callback(
+  rmw_zenoh_cpp::liveliness::ConstEntityPtr entity,
+  const rmw_zenoh_cpp::rmw_zenoh_event_type_t & event_type,
+  GraphCacheEventCallback callback)
+{
+  std::lock_guard<std::mutex> lock(data_->mutex_);
+  return data_->graph_cache_->set_qos_event_callback(
+    std::move(entity),
+    event_type,
+    std::move(callback));
+}

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -1,0 +1,197 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DETAIL__RMW_CONTEXT_IMPL_S_HPP_
+#define DETAIL__RMW_CONTEXT_IMPL_S_HPP_
+
+#include <zenoh.h>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "graph_cache.hpp"
+#include "liveliness_utils.hpp"
+
+#include "rcutils/types.h"
+#include "rmw/rmw.h"
+
+///=============================================================================
+class rmw_context_impl_s final
+{
+public:
+  using GraphCacheEventCallback = rmw_zenoh_cpp::GraphCache::GraphCacheEventCallback;
+
+  // Constructor.
+  // Once constructed, the context_impl instanced will manage the lifetime
+  // of these arguments.
+  rmw_context_impl_s(
+    const rcutils_allocator_t * allocator,
+    const std::size_t domain_id,
+    const std::string & enclave,
+    z_owned_session_t session,
+    std::optional<zc_owned_shm_manager_t> shm_manager,
+    rmw_guard_condition_t * graph_guard_condition);
+
+  // Get a copy of the enclave.
+  std::string enclave() const;
+
+  // Loan the Zenoh session.
+  z_session_t session() const;
+
+  // Get a reference to the shm_manager.
+  // Note: This is not thread-safe.
+  // TODO(Yadunund): Remove this API and instead include a publish() API
+  // that handles the shm_manager once the context manages publishers.
+  std::optional<zc_owned_shm_manager_t> & shm_manager();
+
+  // Get the graph guard condition.
+  rmw_guard_condition_t * graph_guard_condition();
+
+  // Get a unique id for a new entity.
+  size_t get_next_entity_id();
+
+  // Shutdown the Zenoh session.
+  rmw_ret_t shutdown();
+
+  // Check if the Zenoh session is shutdown.
+  bool is_shutdown() const;
+
+  // Returns true if the Zenoh session is valid.
+  bool session_is_valid() const;
+
+  rmw_ret_t get_node_names(
+    rcutils_string_array_t * node_names,
+    rcutils_string_array_t * node_namespaces,
+    rcutils_string_array_t * enclaves,
+    rcutils_allocator_t * allocator) const;
+
+  rmw_ret_t get_topic_names_and_types(
+    rcutils_allocator_t * allocator,
+    bool no_demangle,
+    rmw_names_and_types_t * topic_names_and_types) const;
+
+  rmw_ret_t publisher_count_matched_subscriptions(
+    const rmw_publisher_t * publisher,
+    size_t * subscription_count);
+
+  rmw_ret_t subscription_count_matched_publishers(
+    const rmw_subscription_t * subscription,
+    size_t * publisher_count);
+
+  rmw_ret_t get_service_names_and_types(
+    rcutils_allocator_t * allocator,
+    rmw_names_and_types_t * service_names_and_types) const;
+
+  rmw_ret_t count_publishers(
+    const char * topic_name,
+    size_t * count) const;
+
+  rmw_ret_t count_subscriptions(
+    const char * topic_name,
+    size_t * count) const;
+
+  rmw_ret_t count_services(
+    const char * service_name,
+    size_t * count) const;
+
+  rmw_ret_t count_clients(
+    const char * service_name,
+    size_t * count) const;
+
+  rmw_ret_t get_entity_names_and_types_by_node(
+    rmw_zenoh_cpp::liveliness::EntityType entity_type,
+    rcutils_allocator_t * allocator,
+    const char * node_name,
+    const char * node_namespace,
+    bool no_demangle,
+    rmw_names_and_types_t * names_and_types) const;
+
+  rmw_ret_t get_entities_info_by_topic(
+    rmw_zenoh_cpp::liveliness::EntityType entity_type,
+    rcutils_allocator_t * allocator,
+    const char * topic_name,
+    bool no_demangle,
+    rmw_topic_endpoint_info_array_t * endpoints_info) const;
+
+  rmw_ret_t service_server_is_available(
+    const char * service_name,
+    const char * service_type,
+    bool * is_available) const;
+
+  void set_qos_event_callback(
+    rmw_zenoh_cpp::liveliness::ConstEntityPtr entity,
+    const rmw_zenoh_cpp::rmw_zenoh_event_type_t & event_type,
+    GraphCacheEventCallback callback);
+
+private:
+  // Bundle all class members into a data struct which can be passed as a
+  // weak ptr to various threads for thread-safe access without capturing
+  // "this" ptr by reference.
+  struct Data : public std::enable_shared_from_this<Data>
+  {
+    // Constructor.
+    Data(
+      const rcutils_allocator_t * allocator,
+      const std::size_t domain_id,
+      const std::string & enclave,
+      z_owned_session_t session,
+      std::optional<zc_owned_shm_manager_t> shm_manager,
+      rmw_guard_condition_t * graph_guard_condition);
+
+    // Subscribe to the ROS graph.
+    rmw_ret_t subscribe();
+
+    // Shutdown the Zenoh session.
+    rmw_ret_t shutdown();
+
+    // Destructor.
+    ~Data();
+
+    // Mutex to lock when accessing members.
+    mutable std::mutex mutex_;
+    // RMW allocator.
+    const rcutils_allocator_t * allocator_;
+    // Enclave, name used to find security artifacts in a sros2 keystore.
+    std::string enclave_;
+    // An owned session.
+    z_owned_session_t session_;
+    // An optional SHM manager that is initialized of SHM is enabled in the
+    // zenoh session config.
+    std::optional<zc_owned_shm_manager_t> shm_manager_;
+    // Liveliness keyexpr string to subscribe to for ROS graph changes.
+    std::string liveliness_str_;
+    // ROS graph liveliness subscriber.
+    z_owned_subscriber_t graph_subscriber_;
+    // Equivalent to rmw_dds_common::Context's guard condition
+    /// Guard condition that should be triggered when the graph changes.
+    rmw_guard_condition_t * graph_guard_condition_;
+    /// Shutdown flag.
+    bool is_shutdown_;
+    // A counter to assign a local id for every entity created in this session.
+    size_t next_entity_id_;
+    // Graph cache.
+    std::unique_ptr<rmw_zenoh_cpp::GraphCache> graph_cache_;
+    // True once graph subscriber is initialized.
+    bool is_initialized_;
+  };
+
+  std::shared_ptr<Data> data_{nullptr};
+
+  static void graph_sub_data_handler(const z_sample_t * sample, void * data);
+};
+
+
+#endif  // DETAIL__RMW_CONTEXT_IMPL_S_HPP_

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -33,7 +33,8 @@ class rmw_context_impl_s final
 {
 public:
   using GraphCacheEventCallback = rmw_zenoh_cpp::GraphCache::GraphCacheEventCallback;
-
+  using QueryingSubscriberCallback =
+    rmw_zenoh_cpp::GraphCache::QueryingSubscriberCallback;
   // Constructor that internally initializees the Zenoh session and other artifacts.
   // Throws an std::runtime_error if any of the initializations fail.
   // The construction will block until a Zenoh router is detected.
@@ -137,6 +138,10 @@ public:
     rmw_zenoh_cpp::liveliness::ConstEntityPtr entity,
     const rmw_zenoh_cpp::rmw_zenoh_event_type_t & event_type,
     GraphCacheEventCallback callback);
+
+  void set_querying_subscriber_callback(
+    const std::string & keyexpr,
+    QueryingSubscriberCallback cb);
 
 private:
   // Bundle all class members into a data struct which can be passed as a

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -32,9 +32,6 @@
 class rmw_context_impl_s final
 {
 public:
-  using GraphCacheEventCallback = rmw_zenoh_cpp::GraphCache::GraphCacheEventCallback;
-  using QueryingSubscriberCallback =
-    rmw_zenoh_cpp::GraphCache::QueryingSubscriberCallback;
   // Constructor that internally initializees the Zenoh session and other artifacts.
   // Throws an std::runtime_error if any of the initializations fail.
   // The construction will block until a Zenoh router is detected.
@@ -75,73 +72,8 @@ public:
   // Returns true if the Zenoh session is valid.
   bool session_is_valid() const;
 
-  rmw_ret_t get_node_names(
-    rcutils_string_array_t * node_names,
-    rcutils_string_array_t * node_namespaces,
-    rcutils_string_array_t * enclaves,
-    rcutils_allocator_t * allocator) const;
-
-  rmw_ret_t get_topic_names_and_types(
-    rcutils_allocator_t * allocator,
-    bool no_demangle,
-    rmw_names_and_types_t * topic_names_and_types) const;
-
-  rmw_ret_t publisher_count_matched_subscriptions(
-    const rmw_publisher_t * publisher,
-    size_t * subscription_count);
-
-  rmw_ret_t subscription_count_matched_publishers(
-    const rmw_subscription_t * subscription,
-    size_t * publisher_count);
-
-  rmw_ret_t get_service_names_and_types(
-    rcutils_allocator_t * allocator,
-    rmw_names_and_types_t * service_names_and_types) const;
-
-  rmw_ret_t count_publishers(
-    const char * topic_name,
-    size_t * count) const;
-
-  rmw_ret_t count_subscriptions(
-    const char * topic_name,
-    size_t * count) const;
-
-  rmw_ret_t count_services(
-    const char * service_name,
-    size_t * count) const;
-
-  rmw_ret_t count_clients(
-    const char * service_name,
-    size_t * count) const;
-
-  rmw_ret_t get_entity_names_and_types_by_node(
-    rmw_zenoh_cpp::liveliness::EntityType entity_type,
-    rcutils_allocator_t * allocator,
-    const char * node_name,
-    const char * node_namespace,
-    bool no_demangle,
-    rmw_names_and_types_t * names_and_types) const;
-
-  rmw_ret_t get_entities_info_by_topic(
-    rmw_zenoh_cpp::liveliness::EntityType entity_type,
-    rcutils_allocator_t * allocator,
-    const char * topic_name,
-    bool no_demangle,
-    rmw_topic_endpoint_info_array_t * endpoints_info) const;
-
-  rmw_ret_t service_server_is_available(
-    const char * service_name,
-    const char * service_type,
-    bool * is_available) const;
-
-  void set_qos_event_callback(
-    rmw_zenoh_cpp::liveliness::ConstEntityPtr entity,
-    const rmw_zenoh_cpp::rmw_zenoh_event_type_t & event_type,
-    GraphCacheEventCallback callback);
-
-  void set_querying_subscriber_callback(
-    const std::string & keyexpr,
-    QueryingSubscriberCallback cb);
+  /// Return a shared_ptr to the GraphCache stored in this context.
+  std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache();
 
 private:
   // Bundle all class members into a data struct which can be passed as a
@@ -156,7 +88,7 @@ private:
       z_owned_session_t session,
       std::optional<zc_owned_shm_manager_t> shm_manager,
       const std::string & liveliness_str,
-      std::unique_ptr<rmw_zenoh_cpp::GraphCache> graph_cache,
+      std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache,
       rmw_guard_condition_t * graph_guard_condition);
 
     // Subscribe to the ROS graph.
@@ -182,7 +114,7 @@ private:
     // Liveliness keyexpr string to subscribe to for ROS graph changes.
     std::string liveliness_str_;
     // Graph cache.
-    std::unique_ptr<rmw_zenoh_cpp::GraphCache> graph_cache_;
+    std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache_;
     // ROS graph liveliness subscriber.
     z_owned_subscriber_t graph_subscriber_;
     // Equivalent to rmw_dds_common::Context's guard condition

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "graph_cache.hpp"
+#include "guard_condition.hpp"
 #include "liveliness_utils.hpp"
 
 #include "rcutils/types.h"
@@ -39,7 +40,6 @@ public:
   // router in a separate thread. Instead block when creating a node if router
   // check has not succeeded.
   rmw_context_impl_s(
-    const rcutils_allocator_t * allocator,
     const std::size_t domain_id,
     const std::string & enclave);
 
@@ -83,13 +83,11 @@ private:
   {
     // Constructor.
     Data(
-      const rcutils_allocator_t * allocator,
       const std::string & enclave,
       z_owned_session_t session,
       std::optional<zc_owned_shm_manager_t> shm_manager,
       const std::string & liveliness_str,
-      std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache,
-      rmw_guard_condition_t * graph_guard_condition);
+      std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache);
 
     // Subscribe to the ROS graph.
     rmw_ret_t subscribe_to_ros_graph();
@@ -119,7 +117,9 @@ private:
     z_owned_subscriber_t graph_subscriber_;
     // Equivalent to rmw_dds_common::Context's guard condition
     /// Guard condition that should be triggered when the graph changes.
-    rmw_guard_condition_t * graph_guard_condition_;
+    std::unique_ptr<rmw_guard_condition_t> graph_guard_condition_;
+    // The GuardCondition data structure.
+    rmw_zenoh_cpp::GuardCondition guard_condition_data_;
     /// Shutdown flag.
     bool is_shutdown_;
     // A counter to assign a local id for every entity created in this session.

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -92,7 +92,7 @@ private:
       rmw_guard_condition_t * graph_guard_condition);
 
     // Subscribe to the ROS graph.
-    rmw_ret_t subscribe();
+    rmw_ret_t subscribe_to_ros_graph();
 
     // Shutdown the Zenoh session.
     rmw_ret_t shutdown();

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -49,6 +49,8 @@ public:
   std::string enclave() const;
 
   // Loan the Zenoh session.
+  // TODO(Yadunund): Remove this API once rmw_context_impl_s is updated to
+  // create other Zenoh objects.
   z_session_t session() const;
 
   // Get a reference to the shm_manager.

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -17,6 +17,7 @@
 
 #include <zenoh.h>
 
+# include <cstddef>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -115,12 +116,12 @@ private:
     std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache_;
     // ROS graph liveliness subscriber.
     z_owned_subscriber_t graph_subscriber_;
-    // Equivalent to rmw_dds_common::Context's guard condition
-    /// Guard condition that should be triggered when the graph changes.
+    // Equivalent to rmw_dds_common::Context's guard condition.
+    // Guard condition that should be triggered when the graph changes.
     std::unique_ptr<rmw_guard_condition_t> graph_guard_condition_;
     // The GuardCondition data structure.
     rmw_zenoh_cpp::GuardCondition guard_condition_data_;
-    /// Shutdown flag.
+    // Shutdown flag.
     bool is_shutdown_;
     // A counter to assign a local id for every entity created in this session.
     size_t next_entity_id_;

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.cpp
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <zenoh.h>
-
 #include <condition_variable>
 #include <cstring>
 #include <memory>
@@ -53,12 +51,6 @@ size_t hash_gid(const rmw_request_id_t & request_id)
   return hash_gid(request_id.writer_guid);
 }
 }  // namespace
-
-///=============================================================================
-size_t rmw_context_impl_s::get_next_entity_id()
-{
-  return next_entity_id_++;
-}
 
 namespace rmw_zenoh_cpp
 {

--- a/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_data_types.hpp
@@ -42,38 +42,6 @@
 
 /// Structs for various type erased data fields.
 
-///=============================================================================
-class rmw_context_impl_s final
-{
-public:
-  // Enclave, name used to find security artifacts in a sros2 keystore.
-  char * enclave;
-
-  // An owned session.
-  z_owned_session_t session;
-
-  // An optional SHM manager that is initialized of SHM is enabled in the
-  // zenoh session config.
-  std::optional<zc_owned_shm_manager_t> shm_manager;
-
-  z_owned_subscriber_t graph_subscriber;
-
-  /// Shutdown flag.
-  bool is_shutdown;
-
-  // Equivalent to rmw_dds_common::Context's guard condition
-  /// Guard condition that should be triggered when the graph changes.
-  rmw_guard_condition_t * graph_guard_condition;
-
-  std::unique_ptr<rmw_zenoh_cpp::GraphCache> graph_cache;
-
-  size_t get_next_entity_id();
-
-private:
-  // A counter to assign a local id for every entity created in this session.
-  size_t next_entity_id_{0};
-};
-
 namespace rmw_zenoh_cpp
 {
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -20,6 +20,7 @@
 #include "detail/event.hpp"
 #include "detail/graph_cache.hpp"
 #include "detail/identifier.hpp"
+#include "detail/rmw_context_impl_s.hpp"
 #include "detail/rmw_data_types.hpp"
 
 
@@ -41,6 +42,8 @@ rmw_publisher_event_init(
     static_cast<rmw_zenoh_cpp::rmw_publisher_data_t *>(publisher->data);
   RMW_CHECK_ARGUMENT_FOR_NULL(pub_data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(pub_data->context, RMW_RET_INVALID_ARGUMENT);
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(pub_data->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(pub_data->entity, RMW_RET_INVALID_ARGUMENT);
 
   if (publisher->implementation_identifier != rmw_zenoh_cpp::rmw_zenoh_identifier) {
@@ -61,7 +64,7 @@ rmw_publisher_event_init(
   rmw_event->event_type = event_type;
 
   // Register the event with graph cache.
-  pub_data->context->impl->graph_cache->set_qos_event_callback(
+  context_impl->set_qos_event_callback(
     pub_data->entity,
     zenoh_event_type,
     [pub_data,
@@ -95,6 +98,8 @@ rmw_subscription_event_init(
     static_cast<rmw_zenoh_cpp::rmw_subscription_data_t *>(subscription->data);
   RMW_CHECK_ARGUMENT_FOR_NULL(sub_data, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(sub_data->context, RMW_RET_INVALID_ARGUMENT);
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(sub_data->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(sub_data->entity, RMW_RET_INVALID_ARGUMENT);
 
   if (subscription->implementation_identifier != rmw_zenoh_cpp::rmw_zenoh_identifier) {
@@ -121,7 +126,7 @@ rmw_subscription_event_init(
     return RMW_RET_OK;
   }
 
-  sub_data->context->impl->graph_cache->set_qos_event_callback(
+  sub_data->context->impl->set_qos_event_callback(
     sub_data->entity,
     zenoh_event_type,
     [sub_data,

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -64,7 +64,7 @@ rmw_publisher_event_init(
   rmw_event->event_type = event_type;
 
   // Register the event with graph cache.
-  context_impl->set_qos_event_callback(
+  context_impl->graph_cache()->set_qos_event_callback(
     pub_data->entity,
     zenoh_event_type,
     [pub_data,
@@ -126,7 +126,7 @@ rmw_subscription_event_init(
     return RMW_RET_OK;
   }
 
-  sub_data->context->impl->set_qos_event_callback(
+  context_impl->graph_cache()->set_qos_event_callback(
     sub_data->entity,
     zenoh_event_type,
     [sub_data,

--- a/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
@@ -14,7 +14,7 @@
 
 #include "detail/identifier.hpp"
 #include "detail/liveliness_utils.hpp"
-#include "detail/rmw_data_types.hpp"
+#include "detail/rmw_context_impl_s.hpp"
 
 #include "rcutils/allocator.h"
 
@@ -43,7 +43,9 @@ rmw_get_subscriber_names_and_types_by_node(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
-  return node->context->impl->graph_cache->get_entity_names_and_types_by_node(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Subscription,
     allocator,
     node_name,
@@ -71,7 +73,9 @@ rmw_get_publisher_names_and_types_by_node(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
-  return node->context->impl->graph_cache->get_entity_names_and_types_by_node(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Publisher,
     allocator,
     node_name,
@@ -98,7 +102,9 @@ rmw_get_service_names_and_types_by_node(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
-  return node->context->impl->graph_cache->get_entity_names_and_types_by_node(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Service,
     allocator,
     node_name,
@@ -125,7 +131,9 @@ rmw_get_client_names_and_types_by_node(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
-  return node->context->impl->graph_cache->get_entity_names_and_types_by_node(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Client,
     allocator,
     node_name,

--- a/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_node_info_and_types.cpp
@@ -45,7 +45,7 @@ rmw_get_subscriber_names_and_types_by_node(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_entity_names_and_types_by_node(
+  return context_impl->graph_cache()->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Subscription,
     allocator,
     node_name,
@@ -75,7 +75,7 @@ rmw_get_publisher_names_and_types_by_node(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_entity_names_and_types_by_node(
+  return context_impl->graph_cache()->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Publisher,
     allocator,
     node_name,
@@ -104,7 +104,7 @@ rmw_get_service_names_and_types_by_node(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_entity_names_and_types_by_node(
+  return context_impl->graph_cache()->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Service,
     allocator,
     node_name,
@@ -133,7 +133,7 @@ rmw_get_client_names_and_types_by_node(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_entity_names_and_types_by_node(
+  return context_impl->graph_cache()->get_entity_names_and_types_by_node(
     rmw_zenoh_cpp::liveliness::EntityType::Client,
     allocator,
     node_name,

--- a/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
@@ -38,7 +38,7 @@ rmw_get_service_names_and_types(
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
 
-  return context_impl->get_service_names_and_types(
+  return context_impl->graph_cache()->get_service_names_and_types(
     allocator, service_names_and_types);
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_service_names_and_types.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "detail/rmw_data_types.hpp"
+#include "detail/rmw_context_impl_s.hpp"
 
 #include "rcutils/allocator.h"
 
@@ -35,8 +35,10 @@ rmw_get_service_names_and_types(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(allocator, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(service_names_and_types, RMW_RET_INVALID_ARGUMENT);
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->graph_cache->get_service_names_and_types(
+  return context_impl->get_service_names_and_types(
     allocator, service_names_and_types);
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -15,7 +15,7 @@
 
 #include "detail/identifier.hpp"
 #include "detail/liveliness_utils.hpp"
-#include "detail/rmw_data_types.hpp"
+#include "detail/rmw_context_impl_s.hpp"
 
 #include "rcutils/allocator.h"
 
@@ -43,7 +43,9 @@ rmw_get_publishers_info_by_topic(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
-  return node->context->impl->graph_cache->get_entities_info_by_topic(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_entities_info_by_topic(
     rmw_zenoh_cpp::liveliness::EntityType::Publisher,
     allocator,
     topic_name,
@@ -69,7 +71,9 @@ rmw_get_subscriptions_info_by_topic(
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
-  return node->context->impl->graph_cache->get_entities_info_by_topic(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_entities_info_by_topic(
     rmw_zenoh_cpp::liveliness::EntityType::Subscription,
     allocator,
     topic_name,

--- a/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -45,7 +45,7 @@ rmw_get_publishers_info_by_topic(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_entities_info_by_topic(
+  return context_impl->graph_cache()->get_entities_info_by_topic(
     rmw_zenoh_cpp::liveliness::EntityType::Publisher,
     allocator,
     topic_name,
@@ -73,7 +73,7 @@ rmw_get_subscriptions_info_by_topic(
   RMW_CHECK_ARGUMENT_FOR_NULL(node->context->impl, RMW_RET_INVALID_ARGUMENT);
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_entities_info_by_topic(
+  return context_impl->graph_cache()->get_entities_info_by_topic(
     rmw_zenoh_cpp::liveliness::EntityType::Subscription,
     allocator,
     topic_name,

--- a/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "detail/rmw_data_types.hpp"
+#include "detail/rmw_context_impl_s.hpp"
 
 #include "rcutils/allocator.h"
 
@@ -37,7 +37,9 @@ rmw_get_topic_names_and_types(
   RMW_CHECK_ARGUMENT_FOR_NULL(allocator, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_ARGUMENT_FOR_NULL(topic_names_and_types, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->graph_cache->get_topic_names_and_types(
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
+  return context_impl->get_topic_names_and_types(
     allocator, no_demangle, topic_names_and_types);
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
+++ b/rmw_zenoh_cpp/src/rmw_get_topic_names_and_types.cpp
@@ -39,7 +39,7 @@ rmw_get_topic_names_and_types(
 
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
-  return context_impl->get_topic_names_and_types(
+  return context_impl->graph_cache()->get_topic_names_and_types(
     allocator, no_demangle, topic_names_and_types);
 }
 }  // extern "C"

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -112,7 +112,6 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     context->impl,
     return RMW_RET_BAD_ALLOC,
     rmw_context_impl_t,
-    allocator,
     context->actual_domain_id,
     std::string(options->enclave)
   );

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -21,6 +21,7 @@
 #include "detail/guard_condition.hpp"
 #include "detail/identifier.hpp"
 #include "detail/liveliness_utils.hpp"
+#include "detail/rmw_context_impl_s.hpp"
 #include "detail/rmw_data_types.hpp"
 #include "detail/zenoh_config.hpp"
 #include "detail/zenoh_router_check.hpp"
@@ -41,51 +42,6 @@ extern "C"
 // Megabytes of SHM to reserve.
 // TODO(clalancette): Make this configurable, or get it from the configuration
 #define SHM_BUFFER_SIZE_MB 10
-
-namespace
-{
-void
-graph_sub_data_handler(const z_sample_t * sample, void * data)
-{
-  static_cast<void>(data);
-
-  z_owned_str_t keystr = z_keyexpr_to_string(sample->keyexpr);
-  auto free_keystr = rcpputils::make_scope_exit(
-    [&keystr]() {
-      z_drop(z_move(keystr));
-    });
-
-  // Get the context impl from data.
-  rmw_context_impl_s * context_impl = static_cast<rmw_context_impl_s *>(
-    data);
-  if (context_impl == nullptr) {
-    RMW_ZENOH_LOG_WARN_NAMED(
-      "rmw_zenoh_cpp",
-      "[graph_sub_data_handler] Unable to convert data into context_impl"
-    );
-    return;
-  }
-
-  switch (sample->kind) {
-    case z_sample_kind_t::Z_SAMPLE_KIND_PUT:
-      context_impl->graph_cache->parse_put(keystr._cstr);
-      break;
-    case z_sample_kind_t::Z_SAMPLE_KIND_DELETE:
-      context_impl->graph_cache->parse_del(keystr._cstr);
-      break;
-    default:
-      return;
-  }
-
-  rmw_ret_t rmw_ret = rmw_trigger_guard_condition(context_impl->graph_guard_condition);
-  if (RMW_RET_OK != rmw_ret) {
-    RMW_ZENOH_LOG_WARN_NAMED(
-      "rmw_zenoh_cpp",
-      "[graph_sub_data_handler] Unable to trigger graph guard condition"
-    );
-  }
-}
-}  // namespace
 
 //==============================================================================
 /// Initialize the middleware with the given options, and yielding an context.
@@ -123,24 +79,6 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 
   const rcutils_allocator_t * allocator = &options->allocator;
 
-  context->impl = static_cast<rmw_context_impl_t *>(
-    allocator->zero_allocate(1, sizeof(rmw_context_impl_t), allocator->state));
-  RMW_CHECK_FOR_NULL_WITH_MSG(
-    context->impl,
-    "failed to allocate context impl",
-    return RMW_RET_BAD_ALLOC);
-  auto free_impl = rcpputils::make_scope_exit(
-    [context, allocator]() {
-      allocator->deallocate(context->impl, allocator->state);
-    });
-
-  RMW_TRY_PLACEMENT_NEW(context->impl, context->impl, return RMW_RET_BAD_ALLOC, rmw_context_impl_t);
-  auto impl_destructor = rcpputils::make_scope_exit(
-    [context] {
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        context->impl->~rmw_context_impl_t(), rmw_context_impl_t *);
-    });
-
   rmw_ret_t ret;
   if ((ret = rmw_init_options_copy(options, &context->options)) != RMW_RET_OK) {
     // error already set
@@ -153,20 +91,6 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
         RMW_SAFE_FWRITE_TO_STDERR("Failed to cleanup context options during error handling");
       }
     });
-
-  // Set the enclave.
-  context->impl->enclave = rcutils_strdup(options->enclave, *allocator);
-  RMW_CHECK_FOR_NULL_WITH_MSG(
-    context->impl->enclave,
-    "failed to allocate enclave",
-    return RMW_RET_BAD_ALLOC);
-  auto free_enclave = rcpputils::make_scope_exit(
-    [context, allocator]() {
-      allocator->deallocate(context->impl->enclave, allocator->state);
-    });
-
-  // Initialize context's implementation
-  context->impl->is_shutdown = false;
 
   // If not already defined, set the logging environment variable for Zenoh sessions
   // to warning level by default.
@@ -189,26 +113,23 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 
   // Check if shm is enabled.
   z_owned_str_t shm_enabled = zc_config_get(z_loan(config), "transport/shared_memory/enabled");
-  auto free_shm_enabled = rcpputils::make_scope_exit(
+  auto always_free_shm_enabled = rcpputils::make_scope_exit(
     [&shm_enabled]() {
       z_drop(z_move(shm_enabled));
     });
 
   // Initialize the zenoh session.
-  context->impl->session = z_open(z_move(config));
-  if (!z_session_check(&context->impl->session)) {
+  z_owned_session_t session = z_open(z_move(config));
+  if (!z_session_check(&session)) {
     RMW_SET_ERROR_MSG("Error setting up zenoh session");
     return RMW_RET_ERROR;
   }
   auto close_session = rcpputils::make_scope_exit(
-    [context]() {
-      z_close(z_move(context->impl->session));
+    [&session]() {
+      z_close(z_move(session));
     });
 
-  /// Initialize the graph cache.
-  z_id_t zid = z_info_zid(z_loan(context->impl->session));
-  context->impl->graph_cache = std::make_unique<rmw_zenoh_cpp::GraphCache>(zid);
-
+  // TODO(Yadunund) Move this check into a separate thread.
   // Verify if the zenoh router is running if configured.
   const std::optional<uint64_t> configured_connection_attempts =
     rmw_zenoh_cpp::zenoh_router_check_attempts();
@@ -217,7 +138,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     uint64_t connection_attempts = 0;
     // Retry until the connection is successful.
     while (ret != RMW_RET_OK && connection_attempts < configured_connection_attempts.value()) {
-      if ((ret = rmw_zenoh_cpp::zenoh_router_check(z_loan(context->impl->session))) != RMW_RET_OK) {
+      if ((ret = rmw_zenoh_cpp::zenoh_router_check(z_loan(session))) != RMW_RET_OK) {
         ++connection_attempts;
       }
       std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -231,6 +152,8 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
   }
 
   // Initialize the shm manager if shared_memory is enabled in the config.
+  std::optional<zc_owned_shm_manager_t> shm_manager = std::nullopt;
+  const z_id_t zid = z_info_zid(z_loan(session));
   if (shm_enabled._cstr != nullptr &&
     strcmp(shm_enabled._cstr, "true") == 0)
   {
@@ -242,148 +165,94 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     idstr[sizeof(zid.id) * 2] = '\0';
     // TODO(yadunund): Can we get the size of the shm from the config even though it's not
     // a standard parameter?
-    context->impl->shm_manager =
+    shm_manager =
       zc_shm_manager_new(
-      z_loan(context->impl->session),
+      z_loan(session),
       idstr,
       SHM_BUFFER_SIZE_MB * 1024 * 1024);
-    if (!context->impl->shm_manager.has_value() ||
-      !zc_shm_manager_check(&context->impl->shm_manager.value()))
+    if (!shm_manager.has_value() ||
+      !zc_shm_manager_check(&shm_manager.value()))
     {
       RMW_SET_ERROR_MSG("Unable to create shm manager.");
       return RMW_RET_ERROR;
     }
   }
   auto free_shm_manager = rcpputils::make_scope_exit(
-    [context]() {
-      if (context->impl->shm_manager.has_value()) {
-        z_drop(z_move(context->impl->shm_manager.value()));
+    [&shm_manager]() {
+      if (shm_manager.has_value()) {
+        z_drop(z_move(shm_manager.value()));
       }
     });
 
   // Initialize the guard condition.
-  context->impl->graph_guard_condition =
+  rmw_guard_condition_t * graph_guard_condition =
     static_cast<rmw_guard_condition_t *>(allocator->zero_allocate(
       1, sizeof(rmw_guard_condition_t), allocator->state));
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    context->impl->graph_guard_condition,
+    graph_guard_condition,
     "failed to allocate graph guard condition",
     return RMW_RET_BAD_ALLOC);
   auto free_guard_condition = rcpputils::make_scope_exit(
-    [context, allocator]() {
-      allocator->deallocate(context->impl->graph_guard_condition, allocator->state);
+    [graph_guard_condition, allocator]() {
+      allocator->deallocate(graph_guard_condition, allocator->state);
     });
-
-  context->impl->graph_guard_condition->implementation_identifier =
+  graph_guard_condition->implementation_identifier =
     rmw_zenoh_cpp::rmw_zenoh_identifier;
-
-  context->impl->graph_guard_condition->data =
+  graph_guard_condition->data =
     allocator->zero_allocate(1, sizeof(rmw_zenoh_cpp::GuardCondition), allocator->state);
   RMW_CHECK_FOR_NULL_WITH_MSG(
-    context->impl->graph_guard_condition->data,
+    graph_guard_condition->data,
     "failed to allocate graph guard condition data",
     return RMW_RET_BAD_ALLOC);
   auto free_guard_condition_data = rcpputils::make_scope_exit(
-    [context, allocator]() {
-      allocator->deallocate(context->impl->graph_guard_condition->data, allocator->state);
+    [graph_guard_condition, allocator]() {
+      allocator->deallocate(graph_guard_condition->data, allocator->state);
     });
-
   RMW_TRY_PLACEMENT_NEW(
-    context->impl->graph_guard_condition->data,
-    context->impl->graph_guard_condition->data,
+    graph_guard_condition->data,
+    graph_guard_condition->data,
     return RMW_RET_BAD_ALLOC,
     rmw_zenoh_cpp::GuardCondition);
   auto destruct_guard_condition_data = rcpputils::make_scope_exit(
-    [context]() {
+    [graph_guard_condition]() {
       auto gc_data =
-      static_cast<rmw_zenoh_cpp::GuardCondition *>(context->impl->graph_guard_condition->data);
+      static_cast<rmw_zenoh_cpp::GuardCondition *>(graph_guard_condition->data);
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
         gc_data->~GuardCondition(),
         rmw_zenoh_cpp::GuardCondition);
     });
 
-  // Setup liveliness subscriptions for discovery.
-  const std::string liveliness_str = rmw_zenoh_cpp::liveliness::subscription_token(
-    context->actual_domain_id);
 
-  // Query router/liveliness participants to get graph information before this session was started.
-
-  // We create a blocking channel that is unbounded, ie. `bound` = 0, to receive
-  // replies for the zc_liveliness_get() call. This is necessary as if the `bound`
-  // is too low, the channel may starve the zenoh executor of its threads which
-  // would lead to deadlocks when trying to receive replies and block the
-  // execution here.
-  // The blocking channel will return when the sender end is closed which is
-  // the moment the query finishes.
-  // The non-blocking fifo exists only for the use case where we don't want to
-  // block the thread between responses (including the request termination response).
-  // In general, unless we want to cooperatively schedule other tasks on the same
-  // thread as reading the fifo, the blocking fifo will be more appropriate as
-  // the code will be simpler, and if we're just going to spin over the non-blocking
-  // reads until we obtain responses, we'll just be hogging CPU time by convincing
-  // the OS that we're doing actual work when it could instead park the thread.
-  z_owned_reply_channel_t channel = zc_reply_fifo_new(0);
-  zc_liveliness_get(
-    z_loan(context->impl->session), z_keyexpr(liveliness_str.c_str()),
-    z_move(channel.send), NULL);
-  z_owned_reply_t reply = z_reply_null();
-  for (bool call_success = z_call(channel.recv, &reply); !call_success || z_check(reply);
-    call_success = z_call(channel.recv, &reply))
-  {
-    if (!call_success) {
-      continue;
-    }
-    if (z_reply_is_ok(&reply)) {
-      z_sample_t sample = z_reply_ok(&reply);
-      z_owned_str_t keystr = z_keyexpr_to_string(sample.keyexpr);
-      // Ignore tokens from the same session to avoid race conditions from this
-      // query and the liveliness subscription.
-      context->impl->graph_cache->parse_put(z_loan(keystr), true);
-      z_drop(z_move(keystr));
-    } else {
-      printf("[discovery] Received an error\n");
-    }
-  }
-  z_drop(z_move(reply));
-  z_drop(z_move(channel));
-
-  // TODO(Yadunund): Switch this to a liveliness subscriptions once the API is available.
-
-  // Uncomment and rely on #if #endif blocks to enable this feature when building with
-  // zenoh-pico since liveliness is only available in zenoh-c.
-  // auto sub_options = z_subscriber_options_default();
-  // sub_options.reliability = Z_RELIABILITY_RELIABLE;
-  // context->impl->graph_subscriber = z_declare_subscriber(
-  //   z_loan(context->impl->session),
-  //   z_keyexpr(liveliness_str.c_str()),
-  //   z_move(callback),
-  //   &sub_options);
-  auto sub_options = zc_liveliness_subscriber_options_null();
-  z_owned_closure_sample_t callback = z_closure(graph_sub_data_handler, nullptr, context->impl);
-  context->impl->graph_subscriber = zc_liveliness_declare_subscriber(
-    z_loan(context->impl->session),
-    z_keyexpr(liveliness_str.c_str()),
-    z_move(callback),
-    &sub_options);
-  zc_liveliness_subscriber_options_drop(z_move(sub_options));
-  auto undeclare_z_sub = rcpputils::make_scope_exit(
-    [context]() {
-      z_undeclare_subscriber(z_move(context->impl->graph_subscriber));
+  // Create the context impl.
+  context->impl = static_cast<rmw_context_impl_t *>(
+    allocator->zero_allocate(1, sizeof(rmw_context_impl_t), allocator->state));
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    context->impl,
+    "failed to allocate context impl",
+    return RMW_RET_BAD_ALLOC);
+  auto free_impl = rcpputils::make_scope_exit(
+    [context, allocator]() {
+      allocator->deallocate(context->impl, allocator->state);
     });
-  if (!z_check(context->impl->graph_subscriber)) {
-    RMW_SET_ERROR_MSG("unable to create zenoh subscription");
-    return RMW_RET_ERROR;
-  }
 
-  undeclare_z_sub.cancel();
+  RMW_TRY_PLACEMENT_NEW(
+    context->impl,
+    context->impl,
+    return RMW_RET_BAD_ALLOC,
+    rmw_context_impl_t,
+    allocator,
+    context->actual_domain_id,
+    std::string(options->enclave),
+    std::move(session),
+    std::move(shm_manager),
+    graph_guard_condition
+  );
+
   close_session.cancel();
   destruct_guard_condition_data.cancel();
-  impl_destructor.cancel();
   free_guard_condition_data.cancel();
   free_guard_condition.cancel();
-  free_enclave.cancel();
   free_options.cancel();
-  impl_destructor.cancel();
   free_impl.cancel();
   free_shm_manager.cancel();
   restore_context.cancel();
@@ -407,19 +276,10 @@ rmw_shutdown(rmw_context_t * context)
     rmw_zenoh_cpp::rmw_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
 
-  z_undeclare_subscriber(z_move(context->impl->graph_subscriber));
-  if (context->impl->shm_manager.has_value()) {
-    z_drop(z_move(context->impl->shm_manager.value()));
-  }
-  // Close the zenoh session
-  if (z_close(z_move(context->impl->session)) < 0) {
-    RMW_SET_ERROR_MSG("Error while closing zenoh session");
-    return RMW_RET_ERROR;
-  }
+  rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(context->impl);
+  RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
 
-  context->impl->is_shutdown = true;
-
-  return RMW_RET_OK;
+  return context_impl->shutdown();
 }
 
 //==============================================================================
@@ -437,23 +297,12 @@ rmw_context_fini(rmw_context_t * context)
     context->implementation_identifier,
     rmw_zenoh_cpp::rmw_zenoh_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  if (!context->impl->is_shutdown) {
+  if (!context->impl->is_shutdown()) {
     RCUTILS_SET_ERROR_MSG("context has not been shutdown");
     return RMW_RET_INVALID_ARGUMENT;
   }
 
   const rcutils_allocator_t * allocator = &context->options.allocator;
-
-  RMW_TRY_DESTRUCTOR(
-    static_cast<rmw_zenoh_cpp::GuardCondition *>(
-      context->impl->graph_guard_condition->data)->~GuardCondition(),
-    rmw_zenoh_cpp::GuardCondition, );
-  allocator->deallocate(context->impl->graph_guard_condition->data, allocator->state);
-
-  allocator->deallocate(context->impl->graph_guard_condition, allocator->state);
-  context->impl->graph_guard_condition = nullptr;
-
-  allocator->deallocate(context->impl->enclave, allocator->state);
 
   RMW_TRY_DESTRUCTOR(context->impl->~rmw_context_impl_t(), rmw_context_impl_t *, );
 

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -24,7 +24,6 @@
 #include "detail/rmw_context_impl_s.hpp"
 #include "detail/rmw_data_types.hpp"
 #include "detail/zenoh_config.hpp"
-#include "detail/zenoh_router_check.hpp"
 
 #include "rcutils/env.h"
 #include "detail/logging_macros.hpp"
@@ -39,10 +38,6 @@
 
 extern "C"
 {
-// Megabytes of SHM to reserve.
-// TODO(clalancette): Make this configurable, or get it from the configuration
-#define SHM_BUFFER_SIZE_MB 10
-
 //==============================================================================
 /// Initialize the middleware with the given options, and yielding an context.
 rmw_ret_t
@@ -100,129 +95,6 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     return RMW_RET_ERROR;
   }
 
-  // Initialize the zenoh configuration.
-  z_owned_config_t config;
-  if ((ret =
-    rmw_zenoh_cpp::get_z_config(
-      rmw_zenoh_cpp::ConfigurableEntity::Session,
-      &config)) != RMW_RET_OK)
-  {
-    RMW_SET_ERROR_MSG("Error configuring Zenoh session.");
-    return ret;
-  }
-
-  // Check if shm is enabled.
-  z_owned_str_t shm_enabled = zc_config_get(z_loan(config), "transport/shared_memory/enabled");
-  auto always_free_shm_enabled = rcpputils::make_scope_exit(
-    [&shm_enabled]() {
-      z_drop(z_move(shm_enabled));
-    });
-
-  // Initialize the zenoh session.
-  z_owned_session_t session = z_open(z_move(config));
-  if (!z_session_check(&session)) {
-    RMW_SET_ERROR_MSG("Error setting up zenoh session");
-    return RMW_RET_ERROR;
-  }
-  auto close_session = rcpputils::make_scope_exit(
-    [&session]() {
-      z_close(z_move(session));
-    });
-
-  // TODO(Yadunund) Move this check into a separate thread.
-  // Verify if the zenoh router is running if configured.
-  const std::optional<uint64_t> configured_connection_attempts =
-    rmw_zenoh_cpp::zenoh_router_check_attempts();
-  if (configured_connection_attempts.has_value()) {
-    ret = RMW_RET_ERROR;
-    uint64_t connection_attempts = 0;
-    // Retry until the connection is successful.
-    while (ret != RMW_RET_OK && connection_attempts < configured_connection_attempts.value()) {
-      if ((ret = rmw_zenoh_cpp::zenoh_router_check(z_loan(session))) != RMW_RET_OK) {
-        ++connection_attempts;
-      }
-      std::this_thread::sleep_for(std::chrono::seconds(1));
-    }
-    if (ret != RMW_RET_OK) {
-      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        "Unable to connect to a Zenoh router after %zu retries.",
-        configured_connection_attempts.value());
-      return ret;
-    }
-  }
-
-  // Initialize the shm manager if shared_memory is enabled in the config.
-  std::optional<zc_owned_shm_manager_t> shm_manager = std::nullopt;
-  const z_id_t zid = z_info_zid(z_loan(session));
-  if (shm_enabled._cstr != nullptr &&
-    strcmp(shm_enabled._cstr, "true") == 0)
-  {
-    char idstr[sizeof(zid.id) * 2 + 1];  // 2 bytes for each byte of the id, plus the trailing \0
-    static constexpr size_t max_size_of_each = 3;  // 2 for each byte, plus the trailing \0
-    for (size_t i = 0; i < sizeof(zid.id); ++i) {
-      snprintf(idstr + 2 * i, max_size_of_each, "%02x", zid.id[i]);
-    }
-    idstr[sizeof(zid.id) * 2] = '\0';
-    // TODO(yadunund): Can we get the size of the shm from the config even though it's not
-    // a standard parameter?
-    shm_manager =
-      zc_shm_manager_new(
-      z_loan(session),
-      idstr,
-      SHM_BUFFER_SIZE_MB * 1024 * 1024);
-    if (!shm_manager.has_value() ||
-      !zc_shm_manager_check(&shm_manager.value()))
-    {
-      RMW_SET_ERROR_MSG("Unable to create shm manager.");
-      return RMW_RET_ERROR;
-    }
-  }
-  auto free_shm_manager = rcpputils::make_scope_exit(
-    [&shm_manager]() {
-      if (shm_manager.has_value()) {
-        z_drop(z_move(shm_manager.value()));
-      }
-    });
-
-  // Initialize the guard condition.
-  rmw_guard_condition_t * graph_guard_condition =
-    static_cast<rmw_guard_condition_t *>(allocator->zero_allocate(
-      1, sizeof(rmw_guard_condition_t), allocator->state));
-  RMW_CHECK_FOR_NULL_WITH_MSG(
-    graph_guard_condition,
-    "failed to allocate graph guard condition",
-    return RMW_RET_BAD_ALLOC);
-  auto free_guard_condition = rcpputils::make_scope_exit(
-    [graph_guard_condition, allocator]() {
-      allocator->deallocate(graph_guard_condition, allocator->state);
-    });
-  graph_guard_condition->implementation_identifier =
-    rmw_zenoh_cpp::rmw_zenoh_identifier;
-  graph_guard_condition->data =
-    allocator->zero_allocate(1, sizeof(rmw_zenoh_cpp::GuardCondition), allocator->state);
-  RMW_CHECK_FOR_NULL_WITH_MSG(
-    graph_guard_condition->data,
-    "failed to allocate graph guard condition data",
-    return RMW_RET_BAD_ALLOC);
-  auto free_guard_condition_data = rcpputils::make_scope_exit(
-    [graph_guard_condition, allocator]() {
-      allocator->deallocate(graph_guard_condition->data, allocator->state);
-    });
-  RMW_TRY_PLACEMENT_NEW(
-    graph_guard_condition->data,
-    graph_guard_condition->data,
-    return RMW_RET_BAD_ALLOC,
-    rmw_zenoh_cpp::GuardCondition);
-  auto destruct_guard_condition_data = rcpputils::make_scope_exit(
-    [graph_guard_condition]() {
-      auto gc_data =
-      static_cast<rmw_zenoh_cpp::GuardCondition *>(graph_guard_condition->data);
-      RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(
-        gc_data->~GuardCondition(),
-        rmw_zenoh_cpp::GuardCondition);
-    });
-
-
   // Create the context impl.
   context->impl = static_cast<rmw_context_impl_t *>(
     allocator->zero_allocate(1, sizeof(rmw_context_impl_t), allocator->state));
@@ -242,19 +114,11 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
     rmw_context_impl_t,
     allocator,
     context->actual_domain_id,
-    std::string(options->enclave),
-    std::move(session),
-    std::move(shm_manager),
-    graph_guard_condition
+    std::string(options->enclave)
   );
 
-  close_session.cancel();
-  destruct_guard_condition_data.cancel();
-  free_guard_condition_data.cancel();
-  free_guard_condition.cancel();
   free_options.cancel();
   free_impl.cancel();
-  free_shm_manager.cancel();
   restore_context.cancel();
 
   return RMW_RET_OK;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1485,7 +1485,7 @@ rmw_create_subscription(
     }
     // Register the querying subscriber with the graph cache to get latest
     // messages from publishers that were discovered after their first publication.
-    context_impl->graph_cache->set_querying_subscriber_callback(
+    context_impl->set_querying_subscriber_callback(
       sub_data->entity->topic_info()->topic_keyexpr_,
       [sub_data](const std::string & queryable_prefix) -> void
       {
@@ -2849,7 +2849,7 @@ rmw_create_service(
       context_impl->get_next_entity_id()),
     rmw_zenoh_cpp::liveliness::EntityType::Service,
     rmw_zenoh_cpp::liveliness::NodeInfo{
-      node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave},
+      node->context->actual_domain_id, node->namespace_, node->name, context_impl->enclave()},
     rmw_zenoh_cpp::liveliness::TopicInfo{
       node->context->actual_domain_id,
       rmw_service->service_name,

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1013,7 +1013,7 @@ rmw_publisher_count_matched_subscriptions(
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(pub_data->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
 
-  return context_impl->publisher_count_matched_subscriptions(
+  return context_impl->graph_cache()->publisher_count_matched_subscriptions(
     publisher, subscription_count);
 }
 
@@ -1485,7 +1485,7 @@ rmw_create_subscription(
     }
     // Register the querying subscriber with the graph cache to get latest
     // messages from publishers that were discovered after their first publication.
-    context_impl->set_querying_subscriber_callback(
+    context_impl->graph_cache()->set_querying_subscriber_callback(
       sub_data->entity->topic_info()->topic_keyexpr_,
       [sub_data](const std::string & queryable_prefix) -> void
       {
@@ -1653,7 +1653,7 @@ rmw_subscription_count_matched_publishers(
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(sub_data->context->impl);
   RMW_CHECK_ARGUMENT_FOR_NULL(context_impl, RMW_RET_INVALID_ARGUMENT);
 
-  return context_impl->subscription_count_matched_publishers(
+  return context_impl->graph_cache()->subscription_count_matched_publishers(
     subscription, publisher_count);
 }
 
@@ -3649,7 +3649,7 @@ rmw_get_node_names(
   rcutils_allocator_t * allocator = &node->context->options.allocator;
   RMW_CHECK_ARGUMENT_FOR_NULL(allocator, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->get_node_names(
+  return node->context->impl->graph_cache()->get_node_names(
     node_names, node_namespaces, nullptr, allocator);
 }
 
@@ -3672,7 +3672,7 @@ rmw_get_node_names_with_enclaves(
   rcutils_allocator_t * allocator = &node->context->options.allocator;
   RMW_CHECK_ARGUMENT_FOR_NULL(allocator, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->get_node_names(
+  return node->context->impl->graph_cache()->get_node_names(
     node_names, node_namespaces, enclaves, allocator);
 }
 
@@ -3703,7 +3703,7 @@ rmw_count_publishers(
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->count_publishers(topic_name, count);
+  return node->context->impl->graph_cache()->count_publishers(topic_name, count);
 }
 
 //==============================================================================
@@ -3733,7 +3733,7 @@ rmw_count_subscribers(
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->count_subscriptions(topic_name, count);
+  return node->context->impl->graph_cache()->count_subscriptions(topic_name, count);
 }
 
 //==============================================================================
@@ -3763,7 +3763,7 @@ rmw_count_clients(
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->count_clients(service_name, count);
+  return node->context->impl->graph_cache()->count_clients(service_name, count);
 }
 
 //==============================================================================
@@ -3793,7 +3793,7 @@ rmw_count_services(
   }
   RMW_CHECK_ARGUMENT_FOR_NULL(count, RMW_RET_INVALID_ARGUMENT);
 
-  return node->context->impl->count_services(service_name, count);
+  return node->context->impl->graph_cache()->count_services(service_name, count);
 }
 
 //==============================================================================
@@ -3893,7 +3893,7 @@ rmw_service_server_is_available(
     return RMW_RET_INVALID_ARGUMENT;
   }
 
-  return node->context->impl->service_server_is_available(
+  return node->context->impl->graph_cache()->service_server_is_available(
     client->service_name, service_type.c_str(), is_available);
 }
 


### PR DESCRIPTION
Step 1 in addressing #249.

This PR updates the `rmw_context_impl_s` class to accurately manage the lifetime of its members while ensure thread-safe data access. For starters, it ensures that the Graph Cache updates and lookups are thread safe.

In subsequent PRs, I will update the `rmw_context_impl_s` class to store `rmw_publisher_data_t`, etc with member functions to manage/access their functionalities.
