### PR TITLE
Const qualify function to check if service is available

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1202,13 +1202,13 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
 rmw_ret_t GraphCache::service_server_is_available(
   const char * service_name,
   const char * service_type,
-  bool * is_available)
+  bool * is_available) const
 {
   *is_available = false;
   std::lock_guard<std::mutex> lock(graph_mutex_);
-  GraphNode::TopicMap::iterator service_it = graph_services_.find(service_name);
+  GraphNode::TopicMap::const_iterator service_it = graph_services_.find(service_name);
   if (service_it != graph_services_.end()) {
-    GraphNode::TopicTypeMap::iterator type_it = service_it.value().find(service_type);
+    GraphNode::TopicTypeMap::const_iterator type_it = service_it->second.find(service_type);
     if (type_it != service_it->second.end()) {
       for (const auto & [_, topic_data] : type_it->second) {
         if (topic_data->subs_.size() > 0) {

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -167,7 +167,7 @@ public:
   rmw_ret_t service_server_is_available(
     const char * service_name,
     const char * service_type,
-    bool * is_available);
+    bool * is_available) const;
 
   /// @brief Signature for a function that will be invoked by the GraphCache when a QoS
   ///   event is detected.


### PR DESCRIPTION
As long as we're not modifying the value stored in the `ordered_map`, we can access the elements with `->` and hence const qualify the `service_server_is_available` function.