### PR TITLE
Support running zenohd without console access

### DIFF
--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -13,21 +13,14 @@
 // limitations under the License.
 
 #include <condition_variable>
-#include <chrono>
 #include <cstdio>
-#include <cstring>
-#include <memory>
 #include <mutex>
 #include <stdexcept>
-#include <string>
-#include <thread>
 
 #ifdef _WIN32
 #include <windows.h>
 #else
 #include <signal.h>
-#include <termios.h>
-#include <unistd.h>
 #endif
 
 #include <zenoh.h>
@@ -44,122 +37,6 @@
 static bool running = true;
 static std::mutex run_mutex;
 static std::condition_variable run_cv;
-
-class KeyboardReader final
-{
-public:
-  KeyboardReader()
-  {
-#ifdef _WIN32
-    hstdin_ = GetStdHandle(STD_INPUT_HANDLE);
-    if (hstdin_ == INVALID_HANDLE_VALUE) {
-      throw std::runtime_error("Failed to get stdin handle");
-    }
-    if (!GetConsoleMode(hstdin_, &old_mode_)) {
-      throw std::runtime_error("Failed to get old console mode");
-    }
-    DWORD new_mode = ENABLE_PROCESSED_INPUT;  // for Ctrl-C processing
-    if (!SetConsoleMode(hstdin_, new_mode)) {
-      throw std::runtime_error("Failed to set new console mode");
-    }
-#else
-    // get the console in raw mode
-    if (tcgetattr(0, &cooked_) < 0) {
-      throw std::runtime_error("Failed to get old console mode");
-    }
-    struct termios raw;
-    memcpy(&raw, &cooked_, sizeof(struct termios));
-    raw.c_lflag &= ~(ICANON | ECHO);
-    // Setting a new line, then end of file
-    raw.c_cc[VEOL] = 1;
-    raw.c_cc[VEOF] = 2;
-    raw.c_cc[VTIME] = 1;
-    raw.c_cc[VMIN] = 0;
-    if (tcsetattr(0, TCSANOW, &raw) < 0) {
-      throw std::runtime_error("Failed to set new console mode");
-    }
-#endif
-  }
-
-  char readOne()
-  {
-    char c = 0;
-
-#ifdef _WIN32
-    INPUT_RECORD record;
-    DWORD num_read;
-    switch (WaitForSingleObject(hstdin_, 100)) {
-      case WAIT_OBJECT_0:
-        if (!ReadConsoleInput(hstdin_, &record, 1, &num_read)) {
-          throw std::runtime_error("Read failed");
-        }
-
-        if (record.EventType != KEY_EVENT || !record.Event.KeyEvent.bKeyDown) {
-          break;
-        }
-
-        if (record.Event.KeyEvent.wVirtualKeyCode == VK_LEFT) {
-          c = KEYCODE_LEFT;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == VK_UP) {
-          c = KEYCODE_UP;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == VK_RIGHT) {
-          c = KEYCODE_RIGHT;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == VK_DOWN) {
-          c = KEYCODE_DOWN;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x42) {
-          c = KEYCODE_B;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x43) {
-          c = KEYCODE_C;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x44) {
-          c = KEYCODE_D;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x45) {
-          c = KEYCODE_E;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x46) {
-          c = KEYCODE_F;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x47) {
-          c = KEYCODE_G;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x51) {
-          c = KEYCODE_Q;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x52) {
-          c = KEYCODE_R;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x54) {
-          c = KEYCODE_T;
-        } else if (record.Event.KeyEvent.wVirtualKeyCode == 0x56) {
-          c = KEYCODE_V;
-        }
-        break;
-
-      case WAIT_TIMEOUT:
-        break;
-    }
-
-#else
-    int rc = read(0, &c, 1);
-    if (rc < 0) {
-      throw std::runtime_error("read failed");
-    }
-#endif
-
-    return c;
-  }
-
-  ~KeyboardReader()
-  {
-#ifdef _WIN32
-    SetConsoleMode(hstdin_, old_mode_);
-#else
-    tcsetattr(0, TCSANOW, &cooked_);
-#endif
-  }
-
-private:
-#ifdef _WIN32
-  HANDLE hstdin_;
-  DWORD old_mode_;
-#else
-  struct termios cooked_;
-#endif
-};
 
 #ifdef _WIN32
 BOOL WINAPI quit(DWORD ctrl_type)
@@ -223,55 +100,9 @@ int main(int argc, char ** argv)
   signal(SIGTERM, quit);
 #endif
 
-  std::unique_ptr<KeyboardReader> keyreader = nullptr;
-  try {
-    keyreader = std::make_unique<KeyboardReader>();
-  } catch (std::runtime_error & e) {
-    printf(
-      "Keyboard reader failed to start due to: %s.\n"
-      "Running without console input.", e.what());
-  }
-
-  std::thread key_reader_thread;
-  int result = 0;
-
-  if (keyreader) {
-    key_reader_thread = std::thread(
-      [&]() -> void {
-        char c = 0;
-
-        printf("Enter 'q' to quit...\n");
-        while (running) {
-          // get the next event from the keyboard
-          try {
-            c = keyreader->readOne();
-          } catch (const std::runtime_error &) {
-            perror("read():");
-            std::scoped_lock lock(run_mutex);
-            running = false;
-            result = -1;
-            run_cv.notify_one();
-            break;
-          }
-
-          if (c == 'q') {
-            std::scoped_lock lock(run_mutex);
-            running = false;
-            run_cv.notify_one();
-            break;
-          }
-          std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        }
-      });
-  }
-
   // Wait until it's time to exit.
   std::unique_lock lock(run_mutex);
   run_cv.wait(lock, []{return !running;});
 
-  if (key_reader_thread.joinable()) {
-    key_reader_thread.join();
-  }
-
-  return result;
+  return 0;
 }

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -100,7 +100,7 @@ int main(int argc, char ** argv)
 
   // Wait until it's time to exit.
   std::unique_lock lock(run_mutex);
-  run_cv.wait(lock, []{return !running;});
+  run_cv.wait(lock, [] {return !running;});
 
   return 0;
 }

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -42,7 +42,6 @@ static std::condition_variable run_cv;
 BOOL WINAPI quit(DWORD ctrl_type)
 {
   (void)ctrl_type;
-  std::scoped_lock lock(run_mutex);
   running = false;
   run_cv.notify_one();
   return true;

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -51,7 +51,6 @@ BOOL WINAPI quit(DWORD ctrl_type)
 void quit(int sig)
 {
   (void)sig;
-  std::scoped_lock lock(run_mutex);
   running = false;
   run_cv.notify_one();
 }


### PR DESCRIPTION
I was playing around with running `rmw_zenohd` in a launch file, and it was not happy because of the KeyboardReader's attempt to access the console.

So, I've essentially captured the runtime error, and continue running the zenoh router if the console is not available. 

I haven't tested this on windows, and I don't know if this would break something else or violate some design decision.