### PR TITLE
Skip liveliness parts for qos elements with default values

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -113,10 +113,11 @@ install(
 )
 
 add_executable(rmw_zenohd
-  src/zenohd/main.cpp
-  src/detail/zenoh_config.cpp
   src/detail/liveliness_utils.cpp
   src/detail/logging.cpp
+  src/detail/qos.cpp
+  src/detail/zenoh_config.cpp
+  src/zenohd/main.cpp
 )
 
 target_link_libraries(rmw_zenohd

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -178,12 +178,11 @@ std::optional<T> str_to_size_t(const std::string & str, const T default_value)
   }
   errno = 0;
   char * endptr;
-  // TODO(Yadunund): strtoul and strtol both return long int and not size_t so we
-  // should consider fixing this implementation if this function is moved to
-  // a header file and will be used by other parts of the codebase.
-  size_t num = std::is_signed<decltype(default_value)>::value ?
-    strtol(str.c_str(), &endptr, 10) :
-    strtoul(str.c_str(), &endptr, 10);
+  // TODO(Yadunund): strtoul returns an unsigned long, not size_t.
+  // Depending on the architecture and platform, these may not be the same size.
+  // Further, if the incoming str is a signed integer, storing it in a size_t is incorrect.
+  // We should fix this piece of code to deal with both of those situations.
+  size_t num = strtoul(str.c_str(), &endptr, 10);
   if (endptr == str.c_str()) {
     // No values were converted, this is an error
     RMW_SET_ERROR_MSG("no valid numbers available");

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "logging_macros.hpp"
+#include "qos.hpp"
 
 #include "rcpputils/scope_exit.hpp"
 
@@ -171,36 +172,65 @@ std::vector<std::string> split_keyexpr(
 
 ///=============================================================================
 // TODO(Yadunund): Rely on maps to retrieve strings.
-std::string qos_to_keyexpr(rmw_qos_profile_t qos)
+std::string qos_to_keyexpr(const rmw_qos_profile_t & qos)
 {
   std::string keyexpr = "";
+  const rmw_qos_profile_t & default_qos = QoS::get().default_qos();
+
   // Reliability.
-  keyexpr += std::to_string(qos.reliability);
+  if (qos.reliability != default_qos.reliability) {
+    keyexpr += std::to_string(qos.reliability);
+  }
   keyexpr += QOS_DELIMITER;
+
   // Durability.
-  keyexpr += std::to_string(qos.durability);
+  if (qos.durability != default_qos.durability) {
+    keyexpr += std::to_string(qos.durability);
+  }
   keyexpr += QOS_DELIMITER;
+
   // History.
-  keyexpr += std::to_string(qos.history);
+  if (qos.history != default_qos.history) {
+    keyexpr += std::to_string(qos.history);
+  }
   keyexpr += QOS_COMPONENT_DELIMITER;
-  keyexpr += std::to_string(qos.depth);
+  if (qos.depth != default_qos.depth) {
+    keyexpr += std::to_string(qos.depth);
+  }
   keyexpr += QOS_DELIMITER;
+
   // Deadline.
-  keyexpr += std::to_string(qos.deadline.sec);
+  if (qos.deadline.sec != default_qos.deadline.sec) {
+    keyexpr += std::to_string(qos.deadline.sec);
+  }
   keyexpr += QOS_COMPONENT_DELIMITER;
-  keyexpr += std::to_string(qos.deadline.nsec);
+  if (qos.deadline.nsec != default_qos.deadline.nsec) {
+    keyexpr += std::to_string(qos.deadline.nsec);
+  }
   keyexpr += QOS_DELIMITER;
+
   // Lifespan.
-  keyexpr += std::to_string(qos.lifespan.sec);
+  if (qos.lifespan.sec != default_qos.lifespan.sec) {
+    keyexpr += std::to_string(qos.lifespan.sec);
+  }
   keyexpr += QOS_COMPONENT_DELIMITER;
-  keyexpr += std::to_string(qos.lifespan.nsec);
+  if (qos.lifespan.nsec != default_qos.lifespan.nsec) {
+    keyexpr += std::to_string(qos.lifespan.nsec);
+  }
   keyexpr += QOS_DELIMITER;
+
   // Liveliness.
-  keyexpr += std::to_string(qos.liveliness);
+  if (qos.liveliness != default_qos.liveliness) {
+    keyexpr += std::to_string(qos.liveliness);
+  }
   keyexpr += QOS_COMPONENT_DELIMITER;
-  keyexpr += std::to_string(qos.liveliness_lease_duration.sec);
+  if (qos.liveliness_lease_duration.sec != default_qos.liveliness_lease_duration.sec) {
+    keyexpr += std::to_string(qos.liveliness_lease_duration.sec);
+  }
   keyexpr += QOS_COMPONENT_DELIMITER;
-  keyexpr += std::to_string(qos.liveliness_lease_duration.nsec);
+  if (qos.liveliness_lease_duration.nsec != default_qos.liveliness_lease_duration.nsec) {
+    keyexpr += std::to_string(qos.liveliness_lease_duration.nsec);
+  }
 
   return keyexpr;
 }
@@ -208,7 +238,9 @@ std::string qos_to_keyexpr(rmw_qos_profile_t qos)
 ///=============================================================================
 std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr)
 {
+  const rmw_qos_profile_t & default_qos = QoS::get().default_qos();
   rmw_qos_profile_t qos;
+
   const std::vector<std::string> parts = split_keyexpr(keyexpr, QOS_DELIMITER);
   if (parts.size() < 6) {
     return std::nullopt;
@@ -232,10 +264,14 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr)
   }
 
   try {
-    qos.history = str_to_qos_history.at(history_parts[0]);
-    qos.reliability = str_to_qos_reliability.at(parts[0]);
-    qos.durability = str_to_qos_durability.at(parts[1]);
-    qos.liveliness = str_to_qos_liveliness.at(liveliness_parts[0]);
+    qos.history = history_parts[0].empty() ? default_qos.history : str_to_qos_history.at(
+      history_parts[0]);
+    qos.reliability = parts[0].empty() ? default_qos.reliability : str_to_qos_reliability.at(
+      parts[0]);
+    qos.durability = parts[1].empty() ? default_qos.durability : str_to_qos_durability.at(parts[1]);
+    qos.liveliness =
+      liveliness_parts[0].empty() ? default_qos.liveliness : str_to_qos_liveliness.at(
+      liveliness_parts[0]);
   } catch (const std::exception & e) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("Error setting QoS values from strings: %s", e.what());
     return std::nullopt;
@@ -243,8 +279,11 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr)
 
   // Helper function to convert string to size_t.
   auto str_to_size_t =
-    [](const std::string & str) -> std::optional<size_t>
+    [](const std::string & str, const std::size_t default_value) -> std::optional<size_t>
     {
+      if (str.empty()) {
+        return default_value;
+      }
       errno = 0;
       char * endptr;
       size_t num = strtoul(str.c_str(), &endptr, 10);
@@ -265,13 +304,17 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr)
       return num;
     };
 
-  const auto maybe_depth = str_to_size_t(history_parts[1]);
-  const auto maybe_deadline_s = str_to_size_t(deadline_parts[0]);
-  const auto maybe_deadline_ns = str_to_size_t(deadline_parts[1]);
-  const auto maybe_lifespan_s = str_to_size_t(lifespan_parts[0]);
-  const auto maybe_lifespan_ns = str_to_size_t(lifespan_parts[1]);
-  const auto maybe_liveliness_s = str_to_size_t(liveliness_parts[1]);
-  const auto maybe_liveliness_ns = str_to_size_t(liveliness_parts[2]);
+  const auto maybe_depth = str_to_size_t(history_parts[1], default_qos.depth);
+  const auto maybe_deadline_s = str_to_size_t(deadline_parts[0], default_qos.deadline.sec);
+  const auto maybe_deadline_ns = str_to_size_t(deadline_parts[1], default_qos.deadline.nsec);
+  const auto maybe_lifespan_s = str_to_size_t(lifespan_parts[0], default_qos.lifespan.sec);
+  const auto maybe_lifespan_ns = str_to_size_t(lifespan_parts[1], default_qos.lifespan.nsec);
+  const auto maybe_liveliness_s = str_to_size_t(
+    liveliness_parts[1],
+    default_qos.liveliness_lease_duration.sec);
+  const auto maybe_liveliness_ns = str_to_size_t(
+    liveliness_parts[2],
+    default_qos.liveliness_lease_duration.nsec);
   if (maybe_depth == std::nullopt ||
     maybe_deadline_s == std::nullopt ||
     maybe_deadline_ns == std::nullopt ||

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -24,9 +24,12 @@
 #include <utility>
 #include <vector>
 
+#include "logging_macros.hpp"
 #include "qos.hpp"
 
 #include "rcpputils/scope_exit.hpp"
+
+#include "rmw/error_handling.h"
 
 namespace rmw_zenoh_cpp
 {

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -19,8 +19,8 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <type_traits>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -23,12 +23,9 @@
 #include <utility>
 #include <vector>
 
-#include "logging_macros.hpp"
 #include "qos.hpp"
 
 #include "rcpputils/scope_exit.hpp"
-
-#include "rmw/error_handling.h"
 
 namespace rmw_zenoh_cpp
 {
@@ -276,34 +273,6 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr)
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("Error setting QoS values from strings: %s", e.what());
     return std::nullopt;
   }
-
-  // Helper function to convert string to size_t.
-  auto str_to_size_t =
-    [](const std::string & str, const std::size_t default_value) -> std::optional<size_t>
-    {
-      if (str.empty()) {
-        return default_value;
-      }
-      errno = 0;
-      char * endptr;
-      size_t num = strtoul(str.c_str(), &endptr, 10);
-      if (endptr == str.c_str()) {
-        // No values were converted, this is an error
-        RMW_SET_ERROR_MSG("no valid numbers available");
-        return std::nullopt;
-      } else if (*endptr != '\0') {
-        // There was junk after the number
-        RMW_SET_ERROR_MSG("non-numeric values");
-        return std::nullopt;
-      } else if (errno != 0) {
-        // Some other error occurred, which may include overflow or underflow
-        RMW_SET_ERROR_MSG(
-          "an undefined error occurred while getting the number, this may be an overflow");
-        return std::nullopt;
-      }
-      return num;
-    };
-
   const auto maybe_depth = str_to_size_t(history_parts[1], default_qos.depth);
   const auto maybe_deadline_s = str_to_size_t(deadline_parts[0], default_qos.deadline.sec);
   const auto maybe_deadline_ns = str_to_size_t(deadline_parts[1], default_qos.deadline.nsec);

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -218,7 +218,7 @@ std::string demangle_name(const std::string & input);
  *
  * See rmw/types.h for the values of each policy enum.
  */
-std::string qos_to_keyexpr(rmw_qos_profile_t qos);
+std::string qos_to_keyexpr(const rmw_qos_profile_t & qos);
 
 ///=============================================================================
 /// Convert a rmw_qos_profile_t from a keyexpr. Return std::nullopt if invalid.

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -230,35 +230,6 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr);
 ///=============================================================================
 /// Convert a Zenoh id to a string.
 std::string zid_to_str(const z_id_t & id);
-
-///=============================================================================
-// Helper function to convert string to size_t.
-// The function is templated to enable conversion to size_t or std::size_t.
-template<typename T>
-std::optional<T> str_to_size_t(const std::string & str, const T default_value)
-{
-  if (str.empty()) {
-    return default_value;
-  }
-  errno = 0;
-  char * endptr;
-  size_t num = strtoul(str.c_str(), &endptr, 10);
-  if (endptr == str.c_str()) {
-    // No values were converted, this is an error
-    RMW_SET_ERROR_MSG("no valid numbers available");
-    return std::nullopt;
-  } else if (*endptr != '\0') {
-    // There was junk after the number
-    RMW_SET_ERROR_MSG("non-numeric values");
-    return std::nullopt;
-  } else if (errno != 0) {
-    // Some other error occurred, which may include overflow or underflow
-    RMW_SET_ERROR_MSG(
-      "an undefined error occurred while getting the number, this may be an overflow");
-    return std::nullopt;
-  }
-  return num;
-}
 }  // namespace liveliness
 }  // namespace rmw_zenoh_cpp
 

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -23,9 +23,6 @@
 #include <string>
 #include <vector>
 
-#include "logging_macros.hpp"
-
-#include "rmw/error_handling.h"
 #include "rmw/types.h"
 
 namespace rmw_zenoh_cpp


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ros2/rmw_zenoh/pull/234. 

Instead of convering the qos value to a string and appending to the liveliness token's keyexpression, we only do so when the qos value deviates from the `QoS::default_qos()`. This reduces the number of bytes we need to pack into the liveliness tokens.

Prior to this PR, the publisher that spins when running `ros2 topic pub /chatter std_msgs/msg/String '{data: hello}' --qos-reliability reliable --qos-durability transient_local  --qos-depth 42  --qos-history keep_last`, the liveliness token would look like

```
@/liveliness/@ros2_lv/0/169ba0d08c2b76ba4f7e8f99cb450fe/0/4/MP/%/%/_ros2cli_42493/%chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18/1:1:1,42:9223372036,854775807:9223372036,854775807:1,9223372036,854775807
```

Now the token looks like
```
@/liveliness/@ros2_lv/0/5af83680cf352c29b0a98954d16a5470/0/4/MP/%/%/_ros2cli_43208/%chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18/::,:,:,:,,
```

The diff better highlights the differences

```diff
- @/liveliness/@ros2_lv/0/169ba0d08c2b76ba4f7e8f99cb450fe/0/4/MP/%/%/_ros2cli_42493/%chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18/1:1:1,42:9223372036,854775807:9223372036,854775807:1,9223372036,854775807
+ @/liveliness/@ros2_lv/0/169ba0d08c2b76ba4f7e8f99cb450fe/0/4/MP/%/%/_ros2cli_42493/%chatter/std_msgs::msg::dds_::String_/RIHS01_df668c740482bbd48fb39d76a70dfd4bd59db1288021743503259e948f6b1a18/::,:,:,:,,

```

I've tested this PR against the `rcl` tests and no new errors.