### PR TITLE
Querying subs to query newly discovered publishers with publication caches

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -341,7 +341,7 @@ void GraphCache::parse_put(
   if (ignore_from_current_session && is_entity_local(*entity)) {
     RMW_ZENOH_LOG_DEBUG_NAMED(
       "rmw_zenoh_cpp",
-      "Ignoring parse_put for %s from the same session.\n", entity->keyexpr().c_str());
+      "Ignoring parse_put for %s from the same session.\n", entity->liveliness_keyexpr().c_str());
     return;
   }
 
@@ -559,7 +559,7 @@ void GraphCache::parse_del(
   if (ignore_from_current_session && is_entity_local(*entity)) {
     RMW_ZENOH_LOG_DEBUG_NAMED(
       "rmw_zenoh_cpp",
-      "Ignoring parse_del for %s from the same session.\n", entity->keyexpr().c_str());
+      "Ignoring parse_del for %s from the same session.\n", entity->liveliness_keyexpr().c_str());
     return;
   }
   // Lock the graph mutex before accessing the graph.
@@ -1315,4 +1315,20 @@ std::unique_ptr<rmw_zenoh_event_status_t> GraphCache::take_event_status(
   status_to_take.current_count_change = 0;
   return result;
 }
+
+///=============================================================================
+void GraphCache::set_querying_subscriber_callback(
+  const std::string & keyexpr,
+  QueryingSubscriberCallback cb)
+{
+  auto cb_it = querying_subs_cbs_.find(keyexpr);
+  if (cb_it == querying_subs_cbs_.end()) {
+    std::vector<QueryingSubscriberCallback> cbs = {};
+    cbs.push_back(std::move(cb));
+    querying_subs_cbs_[keyexpr] = std::move(cbs);
+    return;
+  }
+  cb_it->second.push_back(std::move(cb));
+}
+
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -406,7 +406,10 @@ void GraphCache::parse_put(
 
   // If the newly added entity is a publisher with transient_local qos durability,
   // we trigger any registered querying subscriber callbacks.
-  if (entity->topic_info().has_value() && entity->type() == liveliness::EntityType::Publisher) {
+  if (entity->type() == liveliness::EntityType::Publisher &&
+    entity->topic_info().has_value() &&
+    entity->topic_info()->qos_.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+  {
     auto sub_cbs_it = querying_subs_cbs_.find(entity->topic_info()->topic_keyexpr_);
     if (sub_cbs_it != querying_subs_cbs_.end()) {
       for (const auto & cb : sub_cbs_it->second) {

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -403,6 +403,17 @@ void GraphCache::parse_put(
   // Otherwise, the entity represents a node that already exists in the graph.
   // Update topic info if required below.
   update_topic_maps_for_put(node_it->second, entity);
+
+  // If the newly added entity is a publisher with transient_local qos durability,
+  // we trigger any registered querying subscriber callbacks.
+  if (entity->topic_info().has_value() && entity->type() == liveliness::EntityType::Publisher) {
+    auto sub_cbs_it = querying_subs_cbs_.find(entity->topic_info()->topic_keyexpr_);
+    if (sub_cbs_it != querying_subs_cbs_.end()) {
+      for (const auto & cb : sub_cbs_it->second) {
+        cb(entity->zid());
+      }
+    }
+  }
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1337,10 +1337,8 @@ void GraphCache::set_querying_subscriber_callback(
 {
   auto cb_it = querying_subs_cbs_.find(keyexpr);
   if (cb_it == querying_subs_cbs_.end()) {
-    std::vector<QueryingSubscriberCallback> cbs = {};
-    cbs.push_back(std::move(cb));
-    querying_subs_cbs_[keyexpr] = std::move(cbs);
-    return;
+    querying_subs_cbs_[keyexpr] = std::move(std::vector<QueryingSubscriberCallback>{});
+    cb_it = querying_subs_cbs_.find(keyexpr);
   }
   cb_it->second.push_back(std::move(cb));
 }

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -99,6 +99,12 @@ using GraphNodePtr = std::shared_ptr<GraphNode>;
 class GraphCache final
 {
 public:
+  /// @brief Signature for a function that will be invoked by the GraphCache when a QoS
+  ///   event is detected.
+  using GraphCacheEventCallback = std::function<void (std::unique_ptr<rmw_zenoh_event_status_t>)>;
+  /// Callback to be triggered when a publication cache is detected in the ROS Graph.
+  using QueryingSubscriberCallback = std::function<void (const std::string & queryable_prefix)>;
+
   /// @brief Constructor
   /// @param id The id of the zenoh session that is building the graph cache.
   ///   This is used to infer which entities originated from the current session
@@ -169,10 +175,6 @@ public:
     const char * service_type,
     bool * is_available) const;
 
-  /// @brief Signature for a function that will be invoked by the GraphCache when a QoS
-  ///   event is detected.
-  using GraphCacheEventCallback = std::function<void (std::unique_ptr<rmw_zenoh_event_status_t>)>;
-
   /// Set a qos event callback for an entity from the current session.
   /// @note The callback will be removed when the entity is removed from the graph.
   void set_qos_event_callback(
@@ -182,6 +184,10 @@ public:
 
   /// Returns true if the entity is a publisher or client. False otherwise.
   static bool is_entity_pub(const liveliness::Entity & entity);
+
+  void set_querying_subscriber_callback(
+    const std::string & keyexpr,
+    QueryingSubscriberCallback cb);
 
 private:
   // Helper function to convert an Entity into a GraphNode.
@@ -281,6 +287,8 @@ private:
   using GraphEventCallbackMap = std::unordered_map<liveliness::ConstEntityPtr, GraphEventCallbacks>;
   // EventCallbackMap for each type of event we support in rmw_zenoh_cpp.
   GraphEventCallbackMap event_callbacks_;
+  // Map keyexpressions to QueryingSubscriberCallback.
+  std::unordered_map<std::string, std::vector<QueryingSubscriberCallback>> querying_subs_cbs_;
   // Counters to track changes to event statues for each topic.
   std::unordered_map<std::string,
     std::array<rmw_zenoh_event_status_t, ZENOH_EVENT_ID_MAX + 1>> event_statuses_;

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -49,7 +49,8 @@ NodeInfo::NodeInfo(
   // Do nothing.
 }
 
-namespace {
+namespace
+{
 // Helper function to create a copy of a string after removing any
 // leading or trailing slashes.
 std::string strip_slashes(const std::string & str)
@@ -65,7 +66,7 @@ std::string strip_slashes(const std::string & str)
   }
   return ret.substr(start, end - start + 1);
 }
-}  // namespace anonymous
+}  // namespace
 ///=============================================================================
 TopicInfo::TopicInfo(
   std::size_t domain_id,

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -50,9 +50,11 @@ struct TopicInfo
   std::string name_;
   std::string type_;
   std::string type_hash_;
+  std::string topic_keyexpr_;
   rmw_qos_profile_t qos_;
 
   TopicInfo(
+    std::size_t domain_id,
     std::string name,
     std::string type,
     std::string type_hash,
@@ -162,7 +164,7 @@ public:
   std::optional<TopicInfo> topic_info() const;
 
   /// Get the liveliness keyexpr for this entity.
-  std::string keyexpr() const;
+  std::string liveliness_keyexpr() const;
 
   // Two entities are equal if their guids are equal.
   bool operator==(const Entity & other) const;
@@ -183,7 +185,7 @@ private:
   EntityType type_;
   NodeInfo node_info_;
   std::optional<TopicInfo> topic_info_;
-  std::string keyexpr_;
+  std::string liveliness_keyexpr_;
 };
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -263,7 +263,8 @@ rmw_create_node(
   if (node_data->entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to generate keyexpr for liveliness token for the node.");
+      "Unable to generate keyexpr for liveliness token for the node %s.",
+      name);
     return nullptr;
   }
   node_data->token = zc_liveliness_declare_token(
@@ -590,7 +591,8 @@ rmw_create_publisher(
   if (publisher_data->entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to generate keyexpr for liveliness token for the publisher.");
+      "Unable to generate keyexpr for liveliness token for the publisher %s.",
+      rmw_publisher->topic_name);
     return nullptr;
   }
   z_owned_keyexpr_t keyexpr = z_keyexpr_new(
@@ -1433,7 +1435,8 @@ rmw_create_subscription(
   if (sub_data->entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to generate keyexpr for liveliness token for the subscription.");
+      "Unable to generate keyexpr for liveliness token for the subscription %s.",
+      rmw_subscription->topic_name);
     return nullptr;
   }
   z_owned_closure_sample_t callback = z_closure(rmw_zenoh_cpp::sub_data_handler, nullptr, sub_data);
@@ -2292,7 +2295,8 @@ rmw_create_client(
   if (client_data->entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to generate keyexpr for liveliness token for the client.");
+      "Unable to generate keyexpr for liveliness token for the client %s.",
+      rmw_client->service_name);
     return nullptr;
   }
 
@@ -2868,7 +2872,8 @@ rmw_create_service(
   if (service_data->entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to generate keyexpr for liveliness token for the service.");
+      "Unable to generate keyexpr for liveliness token for the service %s.",
+      rmw_service->service_name);
     return nullptr;
   }
   service_data->keyexpr = z_keyexpr_new(service_data->entity->topic_info()->topic_keyexpr_.c_str());

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1500,10 +1500,10 @@ rmw_create_subscription(
           "QueryingSubscriberCallback triggered over %s.",
           selector.c_str()
         );
-        z_get_options_t opts = z_get_options_default();
-        opts.target = Z_QUERY_TARGET_ALL_COMPLETE;
-        opts.timeout_ms = std::numeric_limits<uint64_t>::max();
-        opts.consolidation = z_query_consolidation_latest();
+        ze_querying_subscriber_options_t opts = ze_querying_subscriber_options_default();;
+        opts.query_timeout_ms = std::numeric_limits<uint64_t>::max();
+        opts.query_consolidation = z_query_consolidation_latest();
+        opts.query_accept_replies = ZCU_REPLY_KEYEXPR_ANY;
         ze_querying_subscriber_get(
           z_loan(std::get<ze_owned_querying_subscriber_t>(sub_data->sub)),
           z_keyexpr(selector.c_str()),

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1494,13 +1494,12 @@ rmw_create_subscription(
         const std::string selector = queryable_prefix +
         "/" +
         sub_data->entity->topic_info()->topic_keyexpr_;
-        // TODO(Yadunund): Remove this printout before merging.
-        RMW_ZENOH_LOG_ERROR_NAMED(
+        RMW_ZENOH_LOG_DEBUG_NAMED(
           "rmw_zenoh_cpp",
           "QueryingSubscriberCallback triggered over %s.",
           selector.c_str()
         );
-        ze_querying_subscriber_options_t opts = ze_querying_subscriber_options_default();;
+        ze_querying_subscriber_options_t opts = ze_querying_subscriber_options_default();
         opts.query_timeout_ms = std::numeric_limits<uint64_t>::max();
         opts.query_consolidation = z_query_consolidation_latest();
         opts.query_accept_replies = ZCU_REPLY_KEYEXPR_ANY;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1499,10 +1499,10 @@ rmw_create_subscription(
           "QueryingSubscriberCallback triggered over %s.",
           selector.c_str()
         );
-        ze_querying_subscriber_options_t opts = ze_querying_subscriber_options_default();
-        opts.query_timeout_ms = std::numeric_limits<uint64_t>::max();
-        opts.query_consolidation = z_query_consolidation_latest();
-        opts.query_accept_replies = ZCU_REPLY_KEYEXPR_ANY;
+        z_get_options_t opts = z_get_options_default();
+        opts.timeout_ms = std::numeric_limits<uint64_t>::max();
+        opts.consolidation = z_query_consolidation_latest();
+        opts.accept_replies = ZCU_REPLY_KEYEXPR_ANY;
         ze_querying_subscriber_get(
           z_loan(std::get<ze_owned_querying_subscriber_t>(sub_data->sub)),
           z_keyexpr(selector.c_str()),

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -23,9 +23,10 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/shared
 # - https://github.com/eclipse-zenoh/zenoh/pull/1022 (fix empty messages received if payload >btach size)
 # - https://github.com/eclipse-zenoh/zenoh-c/pull/358 (fix debian packaging issue: https://github.com/jspricke/ros-deb-builder-action/issues/49)
 # - https://github.com/eclipse-zenoh/zenoh/pull/1150 (fix deadlock issue https://github.com/ros2/rmw_zenoh/issues/182)
+# - https://github.com/eclipse-zenoh/zenoh-c/pull/620 (fix ze_querying_subscriber_get API to query newly discovered publishers)
 ament_vendor(zenoh_c_vendor
-  VCS_URL https://github.com/ZettaScaleLabs/zenoh-c
-  VCS_VERSION d4df47382482b1bc7a5b64ca6879ff800779df7b
+  VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
+  VCS_VERSION 134dbfa06ca212def5fb51dd8e816734dfd8dff6
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
 )

--- a/zenoh_c_vendor/CMakeLists.txt
+++ b/zenoh_c_vendor/CMakeLists.txt
@@ -24,8 +24,8 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=zenoh/shared
 # - https://github.com/eclipse-zenoh/zenoh-c/pull/358 (fix debian packaging issue: https://github.com/jspricke/ros-deb-builder-action/issues/49)
 # - https://github.com/eclipse-zenoh/zenoh/pull/1150 (fix deadlock issue https://github.com/ros2/rmw_zenoh/issues/182)
 ament_vendor(zenoh_c_vendor
-  VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 548ee8dde0f53a58c06e68a2949949b31140c36c
+  VCS_URL https://github.com/ZettaScaleLabs/zenoh-c
+  VCS_VERSION d4df47382482b1bc7a5b64ca6879ff800779df7b
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
 )


### PR DESCRIPTION
Fix #263 

This PR:
* Renames `Entity::keyexpr()` to `Entity::liveliness_keyexpr()` to disambiguate between keyexpressions used for liveliness tokens and keyexpressions used for topic/service names.
* Adds `topic_keyexpr` string to `TopicInfo` stored within `Entity`. This way, entities constructed within `GraphCache` are aware of they topic keyexpressions.
* Adds an API to register callbacks to trigger when a Publisher with a PublicationCache is detected in the graph.
* Updates `rmw_create_subscription` to register a callback as described above that will call `ze_querying_subscriber_get` over the keyexpression. This requires the zenoh session ID as the "selector" to uniquely identify which PublicationCache to query.