### PR TITLE
Adapt the QueryingSubscriber's initial query to the new queryable_prefix

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1468,6 +1468,8 @@ rmw_create_subscription(
     // This allows us to selectively query certain PublicationCaches when defining the
     // set_querying_subscriber_callback below.
     sub_options.query_accept_replies = ZCU_REPLY_KEYEXPR_ANY;
+    // As this initial query is now using a "*", the query target is not COMPLETE.
+    sub_options.query_target = Z_QUERY_TARGET_ALL;
     // We set consolidation to none as we need to receive transient local messages
     // from a number of publishers. Eg: To receive TF data published over /tf_static
     // by various publishers.

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1461,7 +1461,7 @@ rmw_create_subscription(
     // Make the initial query to hit all the PublicationCaches, using a query_selector with
     // '*' in place of the queryable_prefix of each PublicationCache
     const std::string selector = "*/" +
-        sub_data->entity->topic_info()->topic_keyexpr_;
+      sub_data->entity->topic_info()->topic_keyexpr_;
     sub_options.query_selector = z_keyexpr(selector.c_str());
     // Tell the PublicationCache's Queryable that the query accepts any key expression as a reply.
     // By default a query accepts only replies that matches its query selector.

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1458,13 +1458,16 @@ rmw_create_subscription(
 
   if (sub_data->adapted_qos_profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
     ze_querying_subscriber_options_t sub_options = ze_querying_subscriber_options_default();
+    // Make the initial query to hit all the PublicationCaches, using a query_selector with
+    // '*' in place of the queryable_prefix of each PublicationCache
+    const std::string selector = "*/" +
+        sub_data->entity->topic_info()->topic_keyexpr_;
+    sub_options.query_selector = z_keyexpr(selector.c_str());
     // Tell the PublicationCache's Queryable that the query accepts any key expression as a reply.
     // By default a query accepts only replies that matches its query selector.
     // This allows us to selectively query certain PublicationCaches when defining the
     // set_querying_subscriber_callback below.
     sub_options.query_accept_replies = ZCU_REPLY_KEYEXPR_ANY;
-    // Target all complete publication caches which are queryables.
-    sub_options.query_target = Z_QUERY_TARGET_ALL_COMPLETE;
     // We set consolidation to none as we need to receive transient local messages
     // from a number of publishers. Eg: To receive TF data published over /tf_static
     // by various publishers.


### PR DESCRIPTION
This PR fixes the issue reported with Nav2 in https://github.com/ros2/rmw_zenoh/pull/269#issuecomment-2314220213 .

As the PublicationCache has changed by adding the `zid` as a prefix to it's queryable, all the QueryingSubscriber queries must be adapted to take this prefix in account:
- on PublicationCache's LivelinessToken discovery, setting the discovered `zid` for call to `ze_querying_subscriber_get`.  
  That's already done.
- on QueryingSubscriber creation since it performs an initial query to all possibly existing PublicationCaches that have not been discovered yet, using `"*"` in key expression in place of `zid`.  
  That was missing and fixed by this PR
  
Also, as this initial query is now using a `"*"`, the query target can't any longer be `COMPLETE`. No PublicationCache can be complete with such a query.