### PR TITLE
Sleep for a shorter duration between router checks

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -220,7 +220,7 @@ rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
       if ((ret = rmw_zenoh_cpp::zenoh_router_check(z_loan(context->impl->session))) != RMW_RET_OK) {
         ++connection_attempts;
       }
-      std::this_thread::sleep_for(std::chrono::seconds(1));
+      std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
     if (ret != RMW_RET_OK) {
       RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(


### PR DESCRIPTION
Reduce the sleep to `100ms`.

Addresses https://github.com/ros2/rmw_zenoh/issues/277 and helps reduce the completion time for some tests.