### PR TITLE
Rename guid in liveliness_utils to keyexpr_hash.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -179,24 +179,24 @@ public:
   /// Set a qos event callback for an entity from the current session.
   /// @note The callback will be removed when the entity is removed from the graph.
   void set_qos_event_callback(
-    std::size_t entity_guid,
+    std::size_t entity_keyexpr_hash,
     const rmw_zenoh_event_type_t & event_type,
     GraphCacheEventCallback callback);
 
   /// Remove all qos event callbacks for an entity.
-  void remove_qos_event_callbacks(std::size_t entity_guid);
+  void remove_qos_event_callbacks(std::size_t entity_keyexpr_hash);
 
   /// Returns true if the entity is a publisher or client. False otherwise.
   static bool is_entity_pub(const liveliness::Entity & entity);
 
   void set_querying_subscriber_callback(
     const std::string & sub_keyexpr,
-    const std::size_t sub_guid,
+    const std::size_t sub_keyexpr_hash,
     QueryingSubscriberCallback cb);
 
   void remove_querying_subscriber_callback(
     const std::string & sub_keyexpr,
-    const std::size_t sub_guid);
+    const std::size_t sub_keyexpr_hash);
 
 private:
   // Helper function to convert an Entity into a GraphNode.
@@ -287,7 +287,7 @@ private:
   GraphNode::TopicMap graph_services_ = {};
 
   using GraphEventCallbacks = std::unordered_map<rmw_zenoh_event_type_t, GraphCacheEventCallback>;
-  // Map an entity's guid to a map of event callbacks.
+  // Map an entity's keyexpr_hash to a map of event callbacks.
   // Note: Since we use unordered_map, we will only store a single callback for an
   // entity string. So we do not support the case where a node create a duplicate
   // pub/sub with the exact same topic, type & QoS but registers a different callback
@@ -296,7 +296,7 @@ private:
   using GraphEventCallbackMap = std::unordered_map<std::size_t, GraphEventCallbacks>;
   // EventCallbackMap for each type of event we support in rmw_zenoh_cpp.
   GraphEventCallbackMap event_callbacks_;
-  // Map key expressions to a map of sub guid and QueryingSubscriberCallback.
+  // Map key expressions to a map of sub keyexpr_hash and QueryingSubscriberCallback.
   std::unordered_map<std::string, std::unordered_map<std::size_t,
     QueryingSubscriberCallback>> querying_subs_cbs_;
   // Counters to track changes to event statues for each topic.

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -441,7 +441,7 @@ Entity::Entity(
     // Append the delimiter unless it is the last component.
     this->liveliness_keyexpr_ += KEYEXPR_DELIMITER;
   }
-  this->guid_ = std::hash<std::string>{}(this->liveliness_keyexpr_);
+  this->keyexpr_hash_ = std::hash<std::string>{}(this->liveliness_keyexpr_);
 }
 
 ///=============================================================================
@@ -585,9 +585,9 @@ std::string Entity::id() const
 }
 
 ///=============================================================================
-std::size_t Entity::guid() const
+std::size_t Entity::keyexpr_hash() const
 {
-  return this->guid_;
+  return this->keyexpr_hash_;
 }
 
 ///=============================================================================
@@ -632,9 +632,7 @@ std::string Entity::liveliness_keyexpr() const
 ///=============================================================================
 bool Entity::operator==(const Entity & other) const
 {
-  // TODO(Yadunund): If we decide to directly store the guid as a
-  // rmw_gid_t type, we should rely on rmw_compare_gids_equal() instead.
-  return other.guid() == guid_;
+  return other.keyexpr_hash() == keyexpr_hash_;
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -145,13 +145,11 @@ public:
   std::string nid() const;
 
   // Get the id of the entity local to a zenoh session.
-  // Use guid() to retrieve a globally unique id.
+  // Use keyexpr_hash() to retrieve a globally unique id.
   std::string id() const;
 
   // Interim method to get a globally unique id for this entity which is the hash of the keyexpr.
-  // TODO(Yadunund): Should this return a rmw_gid_t?
-  // This is named guid and not gid to remain distinct as it is not of type rmw_gid_t.
-  std::size_t guid() const;
+  std::size_t keyexpr_hash() const;
 
   /// Get the entity type.
   EntityType type() const;
@@ -171,7 +169,7 @@ public:
   /// Get the liveliness keyexpr for this entity.
   std::string liveliness_keyexpr() const;
 
-  // Two entities are equal if their guids are equal.
+  // Two entities are equal if their keyexpr_hash are equal.
   bool operator==(const Entity & other) const;
 
 private:
@@ -186,7 +184,7 @@ private:
   std::string zid_;
   std::string nid_;
   std::string id_;
-  std::size_t guid_;
+  std::size_t keyexpr_hash_;
   EntityType type_;
   NodeInfo node_info_;
   std::optional<TopicInfo> topic_info_;
@@ -254,7 +252,7 @@ struct hash<rmw_zenoh_cpp::liveliness::Entity>
 {
   auto operator()(const rmw_zenoh_cpp::liveliness::Entity & entity) const -> size_t
   {
-    return entity.guid();
+    return entity.keyexpr_hash();
   }
 };
 
@@ -263,7 +261,7 @@ struct hash<rmw_zenoh_cpp::liveliness::ConstEntityPtr>
 {
   auto operator()(const rmw_zenoh_cpp::liveliness::ConstEntityPtr & entity) const -> size_t
   {
-    return entity->guid();
+    return entity->keyexpr_hash();
   }
 };
 
@@ -274,7 +272,7 @@ struct equal_to<rmw_zenoh_cpp::liveliness::ConstEntityPtr>
     const rmw_zenoh_cpp::liveliness::ConstEntityPtr & lhs,
     const rmw_zenoh_cpp::liveliness::ConstEntityPtr & rhs) const -> bool
   {
-    return lhs->guid() == rhs->guid();
+    return lhs->keyexpr_hash() == rhs->keyexpr_hash();
   }
 };
 }  // namespace std

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -410,10 +410,10 @@ rmw_ret_t PublisherData::publish_serialized_message(
 }
 
 ///=============================================================================
-std::size_t PublisherData::guid() const
+std::size_t PublisherData::keyexpr_hash() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  return entity_->guid();
+  return entity_->keyexpr_hash();
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
@@ -64,8 +64,8 @@ public:
     const rmw_serialized_message_t * serialized_message,
     std::optional<zc_owned_shm_manager_t> & shm_manager);
 
-  // Get a copy of the GUID of this PublisherData's liveliness::Entity.
-  std::size_t guid() const;
+  // Get a copy of the keyexpr_hash of this PublisherData's liveliness::Entity.
+  std::size_t keyexpr_hash() const;
 
   // Get a copy of the TopicInfo of this PublisherData.
   liveliness::TopicInfo topic_info() const;

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -249,7 +249,7 @@ std::shared_ptr<SubscriptionData> SubscriptionData::make(
     std::weak_ptr<SubscriptionData> data_wp = sub_data;
     graph_cache->set_querying_subscriber_callback(
       sub_data->entity_->topic_info().value().topic_keyexpr_,
-      sub_data->entity_->guid(),
+      sub_data->entity_->keyexpr_hash(),
       [data_wp](const std::string & queryable_prefix) -> void
       {
         auto sub_data = data_wp.lock();
@@ -359,10 +359,10 @@ SubscriptionData::SubscriptionData(
 }
 
 ///=============================================================================
-std::size_t SubscriptionData::guid() const
+std::size_t SubscriptionData::keyexpr_hash() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  return entity_->guid();
+  return entity_->keyexpr_hash();
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -80,8 +80,8 @@ public:
     const void * ros_message,
     std::optional<zc_owned_shm_manager_t> & shm_manager);
 
-  // Get a copy of the GUID of this SubscriptionData's liveliness::Entity.
-  std::size_t guid() const;
+  // Get a copy of the keyexpr_hash of this SubscriptionData's liveliness::Entity.
+  std::size_t keyexpr_hash() const;
 
   // Get a copy of the TopicInfo of this SubscriptionData.
   liveliness::TopicInfo topic_info() const;

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -71,7 +71,7 @@ rmw_publisher_event_init(
   // Register the event with graph cache.
   std::weak_ptr<rmw_zenoh_cpp::PublisherData> data_wp = pub_data;
   context_impl->graph_cache()->set_qos_event_callback(
-    pub_data->guid(),
+    pub_data->keyexpr_hash(),
     zenoh_event_type,
     [data_wp,
     zenoh_event_type](std::unique_ptr<rmw_zenoh_cpp::rmw_zenoh_event_status_t> zenoh_event)
@@ -130,7 +130,7 @@ rmw_subscription_event_init(
 
   // std::weak_ptr<rmw_zenoh_cpp::SubscriptionData> data_wp = sub_data;
   sub_data->graph_cache()->set_qos_event_callback(
-    sub_data->guid(),
+    sub_data->keyexpr_hash(),
     zenoh_event_type,
     [sub_data,
     zenoh_event_type](std::unique_ptr<rmw_zenoh_cpp::rmw_zenoh_event_status_t> zenoh_event)

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -488,7 +488,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
     return RMW_RET_INVALID_ARGUMENT;
   }
   // Remove any event callbacks registered to this publisher.
-  context_impl->graph_cache()->remove_qos_event_callbacks(pub_data->guid());
+  context_impl->graph_cache()->remove_qos_event_callbacks(pub_data->keyexpr_hash());
   // Remove the PublisherData from NodeData.
   node_data->delete_pub_data(publisher);
 
@@ -1028,13 +1028,13 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
   // Remove the registered callback from the GraphCache if any.
-  const std::size_t guid = sub_data->guid();
+  const std::size_t keyexpr_hash = sub_data->keyexpr_hash();
   context_impl->graph_cache()->remove_querying_subscriber_callback(
     sub_data->topic_info().topic_keyexpr_,
-    guid
+    keyexpr_hash
   );
   // Remove any event callbacks registered to this subscription.
-  context_impl->graph_cache()->remove_qos_event_callbacks(guid);
+  context_impl->graph_cache()->remove_qos_event_callbacks(keyexpr_hash);
   // Finally remove the SubscriptionData from NodeData.
   node_data->delete_sub_data(subscription);
 


### PR DESCRIPTION
This more clearly reflect what it is, which is a
hash of the keyexpression that is used to index into various maps.

FYI @ahcorde and @Yadunund .  I think this more accurately reflects what this particular data is used for, and helps (at least in my mind) to clear up some confusion about the "real" GID that we need to return from [get_entities_info_by_topic](https://github.com/ros2/rmw_zenoh/blob/439d6dc6b0325811793533414dee89196cd72186/rmw_zenoh_cpp/src/detail/graph_cache.cpp#L1086-L1215).

Going forward, what I think we should do is the following:
1.  Close #148 , because there is really no direct relationship between those things.
2.  Close #291 (since it is attempting to implement #148).
3.  Fix #290 by getting the GID from https://github.com/ros2/rmw_zenoh/blob/rolling/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp#L74 in this [line](https://github.com/ros2/rmw_zenoh/blob/439d6dc6b0325811793533414dee89196cd72186/rmw_zenoh_cpp/src/detail/graph_cache.cpp#L1208) (there is probably some support work that needs to be done to enable access to that structure).

What do you think?  Does that make sense?