### PR TITLE
Cleanup SubscriptionData creation and destruction.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -212,7 +212,8 @@ SubscriptionData::SubscriptionData(
   last_known_published_msg_({}),
   total_messages_lost_(0),
   wait_set_data_(nullptr),
-  is_shutdown_(false)
+  is_shutdown_(false),
+  initialized_(false)
 {
   events_mgr_ = std::make_shared<EventsManager>();
 }
@@ -365,7 +366,7 @@ bool SubscriptionData::init()
   undeclare_z_sub.cancel();
   free_token.cancel();
 
-  initted_ = true;
+  initialized_ = true;
 
   return true;
 }
@@ -416,7 +417,7 @@ rmw_ret_t SubscriptionData::shutdown()
 {
   rmw_ret_t ret = RMW_RET_OK;
   std::lock_guard<std::mutex> lock(mutex_);
-  if (is_shutdown_ || !initted_) {
+  if (is_shutdown_ || !initialized_) {
     return ret;
   }
 
@@ -451,7 +452,7 @@ rmw_ret_t SubscriptionData::shutdown()
   }
 
   is_shutdown_ = true;
-  initted_ = false;
+  initialized_ = false;
   return ret;
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -42,7 +42,7 @@
 namespace rmw_zenoh_cpp
 {
 ///=============================================================================
-class SubscriptionData final
+class SubscriptionData final : public std::enable_shared_from_this<SubscriptionData>
 {
 public:
   struct Message
@@ -131,6 +131,10 @@ private:
     std::shared_ptr<liveliness::Entity> entity,
     const void * type_support_impl,
     std::unique_ptr<MessageTypeSupport> type_support);
+
+  bool init();
+
+  bool initted_{false};
 
   // Internal mutex.
   mutable std::mutex mutex_;

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -134,8 +134,6 @@ private:
 
   bool init();
 
-  bool initted_{false};
-
   // Internal mutex.
   mutable std::mutex mutex_;
   // The parent node.
@@ -162,6 +160,8 @@ private:
   std::shared_ptr<EventsManager> events_mgr_;
   // Shutdown flag.
   bool is_shutdown_;
+  // Whether the object has ever successfully been initialized.
+  bool initialized_;
 };
 using SubscriptionDataPtr = std::shared_ptr<SubscriptionData>;
 using SubscriptionDataConstPtr = std::shared_ptr<const SubscriptionData>;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1027,14 +1027,6 @@ rmw_destroy_subscription(rmw_node_t * node, rmw_subscription_t * subscription)
 
   rcutils_allocator_t * allocator = &node->context->options.allocator;
 
-  // Remove the registered callback from the GraphCache if any.
-  const std::size_t keyexpr_hash = sub_data->keyexpr_hash();
-  context_impl->graph_cache()->remove_querying_subscriber_callback(
-    sub_data->topic_info().topic_keyexpr_,
-    keyexpr_hash
-  );
-  // Remove any event callbacks registered to this subscription.
-  context_impl->graph_cache()->remove_qos_event_callbacks(keyexpr_hash);
   // Finally remove the SubscriptionData from NodeData.
   node_data->delete_sub_data(subscription);
 


### PR DESCRIPTION
In particular, make SubscriptionData::init/shutdown mirror images, in that they handle all of their internal data.  That means that rmw_destroy_subscription() really only calls delete_sub_data().

To achieve this, we had to split out SubscriptionData::init from construction, since we rely on shared pointers, but you can't use shared_from_this() in the constructor.