### PR TITLE
Fix minor typo in code comment

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -39,7 +39,7 @@
 extern "C"
 {
 //==============================================================================
-/// Initialize the middleware with the given options, and yielding an context.
+/// Initialize the middleware with the given options, and yielding a context.
 rmw_ret_t
 rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 {

--- a/rmw_zenoh_cpp/src/rmw_init.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init.cpp
@@ -39,7 +39,7 @@
 extern "C"
 {
 //==============================================================================
-/// Initialize the middleware with the given options, and yielding a context.
+/// Initialize the middleware with the given options, and yield a context.
 rmw_ret_t
 rmw_init(const rmw_init_options_t * options, rmw_context_t * context)
 {


### PR DESCRIPTION
Fixed just a minor typo in a code comment, no code changes.