### PR TITLE
Fix compile on OSX

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1316,8 +1316,8 @@ void GraphCache::set_querying_subscriber_callback(
     std::unordered_map<std::size_t, QueryingSubscriberCallback>
   >::iterator cb_it = querying_subs_cbs_.find(sub_keyexpr);
   if (cb_it == querying_subs_cbs_.end()) {
-    querying_subs_cbs_[sub_keyexpr] = std::move(
-      std::unordered_map<std::size_t, QueryingSubscriberCallback>{});
+    querying_subs_cbs_[sub_keyexpr] =
+      std::unordered_map<std::size_t, QueryingSubscriberCallback>{};
     cb_it = querying_subs_cbs_.find(sub_keyexpr);
   }
   cb_it->second.insert(std::make_pair(sub_keyxpr_hash, std::move(cb)));

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -141,7 +141,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unable to generate keyexpr for liveliness token for the service %s.",
-      service_name);
+      service_name.c_str());
     return nullptr;
   }
 

--- a/rmw_zenoh_cpp/src/rmw_init_options.cpp
+++ b/rmw_zenoh_cpp/src/rmw_init_options.cpp
@@ -98,7 +98,7 @@ rmw_init_options_copy(const rmw_init_options_t * src, rmw_init_options_t * dst)
     return ret;
   }
   auto free_discovery_options = rcpputils::make_scope_exit(
-    [&tmp, allocator]() {
+    [&tmp]() {
       rmw_ret_t tmp_ret = rmw_discovery_options_fini(&tmp.discovery_options);
       static_cast<void>(tmp_ret);
     });

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -1438,7 +1438,12 @@ rmw_create_client(
       allocator->deallocate(client_data, allocator->state);
     });
 
-  RMW_TRY_PLACEMENT_NEW(client_data, client_data, return nullptr, rmw_zenoh_cpp::rmw_client_data_t);
+  RMW_TRY_PLACEMENT_NEW(
+    client_data,
+    client_data,
+    return nullptr,
+    rmw_zenoh_cpp::rmw_client_data_t,
+  );
   auto destruct_client_data = rcpputils::make_scope_exit(
     [client_data]() {
       RMW_TRY_DESTRUCTOR_FROM_WITHIN_FAILURE(


### PR DESCRIPTION
Apple-clang catches a few more things. https://github.com/ros2/rmw_zenoh/commit/74a4c07fb18391de2bdb5124fb7db6e0832ed778 allows us to recompile on OSX. The rest of the commits each address a warning. 