### PR TITLE
Revamp of rmw_context_impl_s

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -56,7 +56,6 @@ struct Data : public std::enable_shared_from_this<Data>
     domain_id_(std::move(domain_id)),
     session_(std::move(session)),
     shm_manager_(std::move(shm_manager)),
-    liveliness_str_(std::move(liveliness_str)),
     graph_cache_(std::move(graph_cache)),
     is_shutdown_(false),
     next_entity_id_(0),
@@ -83,7 +82,7 @@ struct Data : public std::enable_shared_from_this<Data>
       graph_sub_data_handler, nullptr, this);
     graph_subscriber_ = zc_liveliness_declare_subscriber(
       z_loan(session_),
-      z_keyexpr(liveliness_str_.c_str()),
+      z_keyexpr(liveliness_str.c_str()),
       z_move(callback),
       &sub_options);
     zc_liveliness_subscriber_options_drop(z_move(sub_options));
@@ -153,8 +152,6 @@ struct Data : public std::enable_shared_from_this<Data>
   // An optional SHM manager that is initialized of SHM is enabled in the
   // zenoh session config.
   std::optional<zc_owned_shm_manager_t> shm_manager_;
-  // Liveliness keyexpr string to subscribe to for ROS graph changes.
-  std::string liveliness_str_;
   // Graph cache.
   std::shared_ptr<rmw_zenoh_cpp::GraphCache> graph_cache_;
   // ROS graph liveliness subscriber.

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -45,14 +45,14 @@
 // to lookup the pointer, and gain a reference to a shared_ptr if it exists.
 // This guarantees that the Data object will not be destroyed while we are using it.
 static std::mutex data_to_data_shared_ptr_map_mutex;
-static std::unordered_map<Data *, std::shared_ptr<Data>> data_to_data_shared_ptr_map;
+static std::unordered_map<rmw_context_impl_s::Data *, std::shared_ptr<rmw_context_impl_s::Data>> data_to_data_shared_ptr_map;
 
 static void graph_sub_data_handler(const z_sample_t * sample, void * data);
 
 // Bundle all class members into a data struct which can be passed as a
 // weak ptr to various threads for thread-safe access without capturing
 // "this" ptr by reference.
-class Data final
+class rmw_context_impl_s::Data final
 {
 public:
   // Constructor.
@@ -440,7 +440,7 @@ static void graph_sub_data_handler(const z_sample_t * sample, void * data)
       z_drop(z_move(keystr));
     });
 
-  auto data_ptr = static_cast<Data *>(data);
+  auto data_ptr = static_cast<rmw_context_impl_s::Data *>(data);
   if (data_ptr == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
@@ -451,7 +451,7 @@ static void graph_sub_data_handler(const z_sample_t * sample, void * data)
 
   // Look up the data shared_ptr in the global map.  If it is in there, use it.
   // If not, it is being shutdown so we can just ignore this update.
-  std::shared_ptr<Data> data_shared_ptr{nullptr};
+  std::shared_ptr<rmw_context_impl_s::Data> data_shared_ptr{nullptr};
   {
     std::lock_guard<std::mutex> lk(data_to_data_shared_ptr_map_mutex);
     if (data_to_data_shared_ptr_map.count(data_ptr) == 0) {
@@ -475,6 +475,7 @@ rmw_context_impl_s::rmw_context_impl_s(
   data_to_data_shared_ptr_map.emplace(data_.get(), data_);
 }
 
+///=============================================================================
 rmw_context_impl_s::~rmw_context_impl_s()
 {
   this->shutdown();

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -42,7 +42,7 @@ static void graph_sub_data_handler(const z_sample_t * sample, void * data);
 // Bundle all class members into a data struct which can be passed as a
 // weak ptr to various threads for thread-safe access without capturing
 // "this" ptr by reference.
-struct Data : public std::enable_shared_from_this<Data>
+struct Data final
 {
   // Constructor.
   Data(

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -144,8 +144,6 @@ struct Data : public std::enable_shared_from_this<Data>
 
   // Mutex to lock when accessing members.
   mutable std::recursive_mutex mutex_;
-  // RMW allocator.
-  const rcutils_allocator_t * allocator_;
   // Enclave, name used to find security artifacts in a sros2 keystore.
   std::string enclave_;
   // The ROS domain id of this context.

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -14,16 +14,21 @@
 
 #include "rmw_context_impl_s.hpp"
 
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <utility>
 
 #include "graph_cache.hpp"
 #include "guard_condition.hpp"
 #include "identifier.hpp"
-#include "liveliness_utils.hpp"
 #include "logging_macros.hpp"
 #include "rmw_node_data.hpp"
 #include "zenoh_config.hpp"
@@ -31,7 +36,6 @@
 
 #include "rcpputils/scope_exit.hpp"
 #include "rmw/error_handling.h"
-#include "rmw/impl/cpp/macros.hpp"
 
 // Megabytes of SHM to reserve.
 // TODO(clalancette): Make this configurable, or get it from the configuration

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -45,7 +45,8 @@
 // to lookup the pointer, and gain a reference to a shared_ptr if it exists.
 // This guarantees that the Data object will not be destroyed while we are using it.
 static std::mutex data_to_data_shared_ptr_map_mutex;
-static std::unordered_map<rmw_context_impl_s::Data *, std::shared_ptr<rmw_context_impl_s::Data>> data_to_data_shared_ptr_map;
+static std::unordered_map<rmw_context_impl_s::Data *,
+  std::shared_ptr<rmw_context_impl_s::Data>> data_to_data_shared_ptr_map;
 
 static void graph_sub_data_handler(const z_sample_t * sample, void * data);
 

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -60,7 +60,6 @@ struct Data : public std::enable_shared_from_this<Data>
     graph_cache_(std::move(graph_cache)),
     is_shutdown_(false),
     next_entity_id_(0),
-    is_initialized_(false),
     nodes_({})
   {
     graph_guard_condition_ = std::make_unique<rmw_guard_condition_t>();
@@ -98,8 +97,6 @@ struct Data : public std::enable_shared_from_this<Data>
     }
 
     undeclare_z_sub.cancel();
-
-    is_initialized_ = true;
   }
 
   // Shutdown the Zenoh session.
@@ -173,8 +170,6 @@ struct Data : public std::enable_shared_from_this<Data>
   bool is_shutdown_;
   // A counter to assign a local id for every entity created in this session.
   std::size_t next_entity_id_;
-  // True once graph subscriber is initialized.
-  bool is_initialized_;
   // Nodes created from this context.
   std::unordered_map<const rmw_node_t *, std::shared_ptr<rmw_zenoh_cpp::NodeData>> nodes_;
 };

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -28,9 +28,6 @@
 #include "rmw/ret_types.h"
 #include "rmw/types.h"
 
-// Forward declaration
-struct Data;
-
 ///=============================================================================
 class rmw_context_impl_s final
 {
@@ -93,6 +90,9 @@ public:
 
   /// Delete the NodeData for a given rmw_node_t if present.
   void delete_node_data(const rmw_node_t * const node);
+
+  // Forward declaration
+  class Data;
 
 private:
   std::shared_ptr<Data> data_{nullptr};

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -17,20 +17,16 @@
 
 #include <zenoh.h>
 
-# include <cstddef>
+#include <cstddef>
 #include <memory>
-#include <mutex>
 #include <optional>
 #include <string>
-#include <unordered_map>
 
 #include "graph_cache.hpp"
-#include "guard_condition.hpp"
-#include "liveliness_utils.hpp"
 #include "rmw_node_data.hpp"
 
-#include "rcutils/types.h"
-#include "rmw/rmw.h"
+#include "rmw/ret_types.h"
+#include "rmw/types.h"
 
 // Forward declaration
 struct Data;

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.hpp
@@ -49,6 +49,8 @@ public:
     const std::size_t domain_id,
     const std::string & enclave);
 
+  ~rmw_context_impl_s();
+
   // Get a copy of the enclave.
   std::string enclave() const;
 


### PR DESCRIPTION
This PR is an attempt to fix two particular issues surrounding rmw_context_impl_s:

1.  It could be the case that a `graph_sub_data_handler` call could attempt to access a `Data` pointer that had already been freed.
2.  Sometimes on shutdown, we would end up in a deadlock situation where `graph_sub_data_handler` was being called by Zenoh while `Data::shutdown` was trying to destroy the session.  This would end up in an AB/BA deadlock.

It's probably best to review this PR patch-by-patch, as this will show you how I got to this solution, but in short:
1.  We first make rmw_context_impl_s::Data private within rmw_context_impl_s.cpp.  This isn't strictly required, but it does form more of a PIMPL pattern and is tidier.
2.  We remove the unnecessary `Data::subscribe_to_ros_graph` method and just put the code inline.
3.  We remove the unused `Data::is_initialized_` member.
4.  We remove the unused `Data::allocator_` member.
5.  We stop storing `Data::liveliness_str_`; we only need it during the constructor.
6.  We mark the Data structure as `final`, and remove `enable_shared_from_this` (we don't currently need it).
7.  We keep a global map of Data structure pointers to Data structure shared_ptr.  We give the Data structure pointer as a "key" to `graph_sub_data_handler`, but it is strictly used as a key to look up the shared_ptr.  Once we have the shared_ptr, we are guaranteed that the structure will not be deleted while we are using it.
8.  Possibly most controversially, we move all work on the Data members within Data, mark Data as a class (rather than a structure), and mark all of the member variables private.  This makes it crystal-clear which entity is responsible for which.  With this in place, `rmw_context_impl_s` is a thin wrapper over Data, that really only passes through calls and manages the addition and removal of Data from the global map.

With all of this in place, I can no longer reproduce the crash that I was seeing locally.  Also, with this and with https://github.com/ros2/rclpy/pull/1353 in place, I am down to a single reproducible failing test across [`rcl`, `rcl_action`, `rcl_lifecycle`, `rclcpp`, `rclcpp_action`, `rclcpp_lifecycle`, `rclpy`, `test_rclcpp`, `test_communication`].