### PR TITLE
Fix target branch for style CI

### DIFF
--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -2,7 +2,7 @@ name: style
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [ rolling ]
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Style CI badge in the README reflects status of actions running on PRs and not the action that runs on `rolling` when a PR is merged.
<img width="267" alt="image" src="https://github.com/user-attachments/assets/ba76c210-d5ae-4581-852c-65e79a9489b8">
