### PR TITLE
Router config: set `peers_failover_brokering` to false

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -157,7 +157,9 @@
       /// directly connected to it if it detects that those peers are not
       /// connected to each other.
       /// The failover brokering only works if gossip discovery is enabled.
-      peers_failover_brokering: true,
+      /// ROS setting: disabled by default because it serves no purpose when each peer connects directly to all others,
+      ///              and it introduces additional management overhead and extra messages during system startup.
+      peers_failover_brokering: false,
     },
     /// The routing strategy to use in peers and it's configuration.
     peer: {


### PR DESCRIPTION
In Zenoh, the `routing.router.peers_failover_brokering` configuration is by default set to `true`.

This setting makes a router to route the messages between 2 peers, until it detects (via gossip scouting) that they are directly inter-connected with each other. For other use cases than ROS, it makes sense to have this configuration enabled by default in case some peers cannot establish direct connections.

But in ROS default configuration, all Nodes are running on the same host and will establish direct connections with each other. If some Nodes are running on a distinct hosts, they could:
- either rely on a co-localized router to communicate with the robot's nodes (peer-router-router-peer connection)
- either be configured in "client" mode connected to the robot's router (client-router-peer connection, e.g. for RViz)

Thus, for ROS having `peers_failover_brokering: true` serves no purpose and has some drawbacks related to the additional management overhead by the router and extra messages during the Nodes startup.
