### PR TITLE
Updates to the C++ code

### DIFF
--- a/rmw_zenoh_cpp/src/detail/attachment_helpers.cpp
+++ b/rmw_zenoh_cpp/src/detail/attachment_helpers.cpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <cstdlib>
 #include <cstring>
 #include <stdexcept>
 #include <string>
-#include <string_view>
 #include <utility>
-#include <vector>
 
 #include <zenoh.hxx>
 
@@ -33,7 +32,7 @@ namespace rmw_zenoh_cpp
 AttachmentData::AttachmentData(
   const int64_t sequence_number,
   const int64_t source_timestamp,
-  const std::vector<uint8_t> source_gid)
+  const std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid)
 : sequence_number_(sequence_number),
   source_timestamp_(source_timestamp),
   source_gid_(source_gid),
@@ -62,7 +61,7 @@ int64_t AttachmentData::source_timestamp() const
 }
 
 ///=============================================================================
-std::vector<uint8_t> AttachmentData::copy_gid() const
+std::array<uint8_t, RMW_GID_STORAGE_SIZE> AttachmentData::copy_gid() const
 {
   return source_gid_;
 }
@@ -104,7 +103,7 @@ AttachmentData::AttachmentData(const zenoh::Bytes & bytes)
   if (source_gid_str != "source_gid") {
     throw std::runtime_error("source_gid is not found in the attachment.");
   }
-  this->source_gid_ = deserializer.deserialize<std::vector<uint8_t>>();
+  this->source_gid_ = deserializer.deserialize<std::array<uint8_t, RMW_GID_STORAGE_SIZE>>();
   gid_hash_ = hash_gid(this->source_gid_);
 }
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/attachment_helpers.hpp
+++ b/rmw_zenoh_cpp/src/detail/attachment_helpers.hpp
@@ -15,8 +15,8 @@
 #ifndef DETAIL__ATTACHMENT_HELPERS_HPP_
 #define DETAIL__ATTACHMENT_HELPERS_HPP_
 
+#include <array>
 #include <cstdint>
-#include <vector>
 
 #include <zenoh.hxx>
 
@@ -31,14 +31,14 @@ public:
   AttachmentData(
     const int64_t sequence_number,
     const int64_t source_timestamp,
-    const std::vector<uint8_t> source_gid);
+    const std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid);
 
   explicit AttachmentData(const zenoh::Bytes & bytes);
   explicit AttachmentData(AttachmentData && data);
 
   int64_t sequence_number() const;
   int64_t source_timestamp() const;
-  std::vector<uint8_t> copy_gid() const;
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
   size_t gid_hash() const;
 
   zenoh::Bytes serialize_to_zbytes();
@@ -46,7 +46,7 @@ public:
 private:
   int64_t sequence_number_;
   int64_t source_timestamp_;
-  std::vector<uint8_t> source_gid_;
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid_;
   size_t gid_hash_;
 };
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1168,7 +1168,6 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
           }
         }
 
-        memset(ep.endpoint_gid, 0, RMW_GID_STORAGE_SIZE);
         memcpy(ep.endpoint_gid, entity->copy_gid().data(), RMW_GID_STORAGE_SIZE);
 
         endpoints.push_back(ep);

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -437,7 +437,6 @@ Entity::Entity(
   // returned to the RMW layer as necessary.
   simplified_XXH128_hash_t keyexpr_gid =
     simplified_XXH3_128bits(this->liveliness_keyexpr_.c_str(), this->liveliness_keyexpr_.length());
-  this->gid_.resize(RMW_GID_STORAGE_SIZE);
   memcpy(this->gid_.data(), &keyexpr_gid.low64, sizeof(keyexpr_gid.low64));
   memcpy(this->gid_.data() + sizeof(keyexpr_gid.low64), &keyexpr_gid.high64,
         sizeof(keyexpr_gid.high64));
@@ -632,7 +631,7 @@ std::string Entity::liveliness_keyexpr() const
 }
 
 ///=============================================================================
-std::vector<uint8_t> Entity::copy_gid() const
+std::array<uint8_t, RMW_GID_STORAGE_SIZE> Entity::copy_gid() const
 {
   return gid_;
 }
@@ -673,7 +672,7 @@ std::string demangle_name(const std::string & input)
 }  // namespace liveliness
 
 ///=============================================================================
-size_t hash_gid(const std::vector<uint8_t> gid)
+size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid)
 {
   std::stringstream hash_str;
   hash_str << std::hex;

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef DETAIL__LIVELINESS_UTILS_HPP_
 #define DETAIL__LIVELINESS_UTILS_HPP_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -172,7 +173,7 @@ public:
   // Two entities are equal if their keyexpr_hash are equal.
   bool operator==(const Entity & other) const;
 
-  std::vector<uint8_t> copy_gid() const;
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
 
 private:
   Entity(
@@ -191,7 +192,7 @@ private:
   NodeInfo node_info_;
   std::optional<TopicInfo> topic_info_;
   std::string liveliness_keyexpr_;
-  std::vector<uint8_t> gid_;
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid_{};
 };
 
 ///=============================================================================
@@ -234,7 +235,7 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr);
 }  // namespace liveliness
 
 ///=============================================================================
-size_t hash_gid(const std::vector<uint8_t> gid);
+size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid);
 }  // namespace rmw_zenoh_cpp
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -16,6 +16,7 @@
 
 #include <fastcdr/FastBuffer.h>
 
+#include <array>
 #include <chrono>
 #include <cinttypes>
 #include <limits>
@@ -216,7 +217,7 @@ bool ClientData::liveliness_is_valid() const
 }
 
 ///=============================================================================
-std::vector<uint8_t> ClientData::copy_gid() const
+std::array<uint8_t, RMW_GID_STORAGE_SIZE> ClientData::copy_gid() const
 {
   return entity_->copy_gid();
 }
@@ -376,8 +377,7 @@ rmw_ret_t ClientData::send_request(
 
   // Send request
   zenoh::Session::GetOptions opts = zenoh::Session::GetOptions::create_default();
-  std::vector<uint8_t> local_gid;
-  local_gid = entity_->copy_gid();
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> local_gid = entity_->copy_gid();
   opts.attachment = rmw_zenoh_cpp::create_map_and_set_sequence_num(*sequence_id, local_gid);
   opts.target = Z_QUERY_TARGET_ALL_COMPLETE;
   // The default timeout for a z_get query is 10 seconds and if a response is not received within

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -142,11 +142,6 @@ std::shared_ptr<ClientData> ClientData::make(
       response_type_support
     });
 
-  if (!client_data->init()) {
-    // init() already set the error.
-    return nullptr;
-  }
-
   return client_data;
 }
 
@@ -173,12 +168,6 @@ ClientData::ClientData(
   is_shutdown_(false),
   initialized_(false)
 {
-  // Do nothing.
-}
-
-///=============================================================================
-bool ClientData::init()
-{
   std::string topic_keyexpr = this->entity_->topic_info().value().topic_keyexpr_;
   keyexpr_ = zenoh::KeyExpr(topic_keyexpr);
   std::string liveliness_keyexpr = this->entity_->liveliness_keyexpr();
@@ -191,12 +180,10 @@ bool ClientData::init()
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unable to create liveliness token for the client.");
-    return false;
+    throw std::runtime_error("Unable to create liveliness token for the client.");
   }
 
   initialized_ = true;
-
-  return true;
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
@@ -114,9 +114,6 @@ private:
     std::shared_ptr<RequestTypeSupport> request_type_support,
     std::shared_ptr<ResponseTypeSupport> response_type_support);
 
-  // Initialize the Zenoh objects for this entity.
-  bool init();
-
   // Internal mutex.
   mutable std::recursive_mutex mutex_;
   // The parent node.

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
@@ -15,6 +15,7 @@
 #ifndef DETAIL__RMW_CLIENT_DATA_HPP_
 #define DETAIL__RMW_CLIENT_DATA_HPP_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <deque>
@@ -23,7 +24,6 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
-#include <vector>
 
 #include <zenoh.hxx>
 
@@ -65,7 +65,7 @@ public:
   bool liveliness_is_valid() const;
 
   // Copy the GID of this ClientData into an rmw_gid_t.
-  std::vector<uint8_t> copy_gid() const;
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
 
   // Add a new ZenohReply to the queue.
   void add_new_reply(std::unique_ptr<rmw_zenoh_cpp::ZenohReply> reply);

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -16,6 +16,7 @@
 
 #include <fastcdr/FastBuffer.h>
 
+#include <array>
 #include <cinttypes>
 #include <memory>
 #include <mutex>
@@ -326,7 +327,7 @@ liveliness::TopicInfo PublisherData::topic_info() const
   return entity_->topic_info().value();
 }
 
-std::vector<uint8_t> PublisherData::copy_gid() const
+std::array<uint8_t, RMW_GID_STORAGE_SIZE> PublisherData::copy_gid() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
   return entity_->copy_gid();

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
@@ -15,13 +15,13 @@
 #ifndef DETAIL__RMW_PUBLISHER_DATA_HPP_
 #define DETAIL__RMW_PUBLISHER_DATA_HPP_
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include <zenoh.hxx>
 
@@ -70,7 +70,7 @@ public:
   liveliness::TopicInfo topic_info() const;
 
   // Return a copy of the GID of this publisher.
-  std::vector<uint8_t> copy_gid() const;
+  std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
 
   // Returns true if liveliness token is still valid.
   bool liveliness_is_valid() const;

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -249,7 +249,7 @@ void ServiceData::add_new_query(std::unique_ptr<ZenohQuery> query)
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Query queue depth of %ld reached, discarding oldest Query "
-      "for service for %.*s",
+      "for service for %s",
       adapted_qos_profile.depth,
       keyexpr_.c_str());
     query_queue_.pop_front();

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
@@ -14,10 +14,10 @@
 
 #include "zenoh_utils.hpp"
 
+#include <array>
 #include <chrono>
 #include <cinttypes>
 #include <utility>
-#include <vector>
 
 #include "attachment_helpers.hpp"
 #include "rcpputils/scope_exit.hpp"
@@ -42,7 +42,7 @@ ZenohSession::~ZenohSession()
 
 ///=============================================================================
 zenoh::Bytes create_map_and_set_sequence_num(
-  int64_t sequence_number, std::vector<uint8_t> gid)
+  int64_t sequence_number, std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid)
 {
   auto now = std::chrono::system_clock::now().time_since_epoch();
   auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(now);

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
@@ -17,10 +17,10 @@
 
 #include <zenoh.hxx>
 
+#include <array>
 #include <chrono>
 #include <functional>
 #include <optional>
-#include <vector>
 
 #include "rmw/types.h"
 
@@ -43,7 +43,7 @@ private:
 
 ///=============================================================================
 zenoh::Bytes create_map_and_set_sequence_num(
-  int64_t sequence_number, std::vector<uint8_t> gid);
+  int64_t sequence_number, std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid);
 
 ///=============================================================================
 // A class to store the replies to service requests.


### PR DESCRIPTION
This is a series of relatively small updates to the zenoh-cpp port.  In particular:

1.  Change the storage of the GID from a std::vector to a std::array, since it is always a fixed size.
2.  Remove the now completely unnecessary ClientData init method; we can do all of the work in the constructor.
3.  Do a bunch of really small refactorings.
4.  Fix a bad string print in rmw_service_data.cpp
5.  Rewrite how we connect to the router so that it only prints when we fail.

With this in place, I'm now happy with the state of #327.  @ahcorde FYI