### PR TITLE
Remove ZenohSession since it's not used now.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
@@ -26,20 +26,6 @@
 
 namespace rmw_zenoh_cpp
 {
-/// Loan the zenoh session.
-///=============================================================================
-const z_loaned_session_t * ZenohSession::loan()
-{
-  return z_loan(inner_);
-}
-
-/// Close the zenoh session if destructed.
-///=============================================================================
-ZenohSession::~ZenohSession()
-{
-  z_close(z_loan_mut(inner_), NULL);
-}
-
 ///=============================================================================
 zenoh::Bytes create_map_and_set_sequence_num(
   int64_t sequence_number, std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid)

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
@@ -26,21 +26,6 @@
 
 namespace rmw_zenoh_cpp
 {
-
-/// A wrapped zenoh session with customized destruction.
-///=============================================================================
-class ZenohSession final
-{
-public:
-  ZenohSession(z_owned_session_t sess)
-  : inner_(sess) {}
-  const z_loaned_session_t * loan();
-  ~ZenohSession();
-
-private:
-  z_owned_session_t inner_;
-};
-
 ///=============================================================================
 zenoh::Bytes create_map_and_set_sequence_num(
   int64_t sequence_number, std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid);


### PR DESCRIPTION
Since we are using zenoh-cpp now, the class ZenohSession wrapper is not used anymore. I think it was missed while migrating.