### PR TITLE
Remove unnecessary error reporting.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<ClientData> ClientData::make(
     *allocator,
     &type_hash_c_str);
   if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
-    RMW_SET_ERROR_MSG("Failed to allocate type_hash_c_str.");
+    // rosidl_stringify_type_hash already set the error
     return nullptr;
   }
   auto free_type_hash_c_str = rcpputils::make_scope_exit(

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -74,7 +74,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
     *allocator,
     &type_hash_c_str);
   if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
-    RMW_SET_ERROR_MSG("Failed to allocate type_hash_c_str.");
+    // rosidl_stringify_type_hash already set the error
     return nullptr;
   }
   auto always_free_type_hash_c_str = rcpputils::make_scope_exit(

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
     *allocator,
     &type_hash_c_str);
   if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
-    RMW_SET_ERROR_MSG("Failed to allocate type_hash_c_str.");
+    // rosidl_stringify_type_hash already set the error
     return nullptr;
   }
   auto free_type_hash_c_str = rcpputils::make_scope_exit(

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<SubscriptionData> SubscriptionData::make(
     *allocator,
     &type_hash_c_str);
   if (RCUTILS_RET_BAD_ALLOC == stringify_ret) {
-    RMW_SET_ERROR_MSG("Failed to allocate type_hash_c_str.");
+    // rosidl_stringify_type_hash already set the error
     return nullptr;
   }
   auto free_type_hash_c_str = rcpputils::make_scope_exit(


### PR DESCRIPTION
The rosidl_stringify_type_hash() function already sets the error when it fails, so we should not do it again (this leads to some ugly output).