### PR TITLE
Switch to using get_system_time_in_ns() function everywhere.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -17,7 +17,6 @@
 #include <fastcdr/FastBuffer.h>
 
 #include <array>
-#include <chrono>
 #include <cinttypes>
 #include <limits>
 #include <memory>
@@ -422,10 +421,8 @@ rmw_ret_t ClientData::send_request(
         return;
       }
 
-      std::chrono::time_point<std::chrono::system_clock> now = std::chrono::system_clock::now();
-
       sub_data->add_new_reply(
-        std::make_unique<rmw_zenoh_cpp::ZenohReply>(reply, now.time_since_epoch().count()));
+        std::make_unique<rmw_zenoh_cpp::ZenohReply>(reply, get_system_time_in_ns()));
     },
     zenoh::closures::none,
     std::move(opts),

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -165,10 +165,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
         return;
       }
 
-      std::chrono::nanoseconds::rep received_timestamp =
-      std::chrono::system_clock::now().time_since_epoch().count();
-
-      sub_data->add_new_query(std::make_unique<ZenohQuery>(query, received_timestamp));
+      sub_data->add_new_query(std::make_unique<ZenohQuery>(query, get_system_time_in_ns()));
     },
     zenoh::closures::none,
     std::move(qable_options),

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -16,7 +16,6 @@
 
 #include <fastcdr/FastBuffer.h>
 
-#include <chrono>
 #include <cinttypes>
 #include <limits>
 #include <memory>
@@ -225,7 +224,7 @@ bool SubscriptionData::init()
         sub_data->add_new_message(
           std::make_unique<SubscriptionData::Message>(
             sample.get_payload(),
-            std::chrono::system_clock::now().time_since_epoch().count(),
+            get_system_time_in_ns(),
             std::move(attachment_data)),
           std::string(sample.get_keyexpr().as_string_view()));
       },
@@ -308,7 +307,7 @@ bool SubscriptionData::init()
         sub_data->add_new_message(
           std::make_unique<SubscriptionData::Message>(
             sample.get_payload(),
-            std::chrono::system_clock::now().time_since_epoch().count(),
+            get_system_time_in_ns(),
             std::move(attachment_data)),
           std::string(sample.get_keyexpr().as_string_view()));
       },


### PR DESCRIPTION
That way we have just a single place where this is defined, and everywhere can be sure they are getting the correct value in nanoseconds.