### PR TITLE
Do not include service/client tracepoints for Jazzy

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -72,6 +72,22 @@ target_link_libraries(rmw_zenoh_cpp
     zenohcxx::zenohc
 )
 
+# Get distro from ros_environment and create config header
+set(ROS_DISTRO "$ENV{ROS_DISTRO}")
+set(ROS_DISTRO_JAZZY OFF)
+set(ROS_DISTRO_ROLLING OFF)
+if(ROS_DISTRO STREQUAL "jazzy")
+  set(ROS_DISTRO_JAZZY ON)
+elseif(ROS_DISTRO STREQUAL "rolling")
+  set(ROS_DISTRO_ROLLING ON)
+else()
+  message(WARNING "Unexpected ROS_DISTRO: ${ROS_DISTRO}")
+endif()
+configure_file(include/${PROJECT_NAME}/distro.hpp.in include/${PROJECT_NAME}/distro.hpp)
+target_include_directories(rmw_zenoh_cpp PRIVATE
+  "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>"
+)
+
 configure_rmw_library(rmw_zenoh_cpp)
 
 target_compile_definitions(rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/include/rmw_zenoh_cpp/distro.hpp.in
+++ b/rmw_zenoh_cpp/include/rmw_zenoh_cpp/distro.hpp.in
@@ -1,0 +1,21 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RMW_ZENOH_CPP_DISTRO_HPP_
+#define RMW_ZENOH_CPP_DISTRO_HPP_
+
+#cmakedefine ROS_DISTRO_JAZZY
+#cmakedefine ROS_DISTRO_ROLLING
+
+#endif  // RMW_ZENOH_CPP_DISTRO_HPP_

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>ros_environment</build_depend>
   <build_depend>zenoh_cpp_vendor</build_depend>
   <build_export_depend>zenoh_cpp_vendor</build_export_depend>
 

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -37,6 +37,7 @@
 #include "message_type_support.hpp"
 #include "qos.hpp"
 #include "rmw_context_impl_s.hpp"
+#include "rmw_zenoh_cpp/distro.hpp"
 
 #include "rcpputils/scope_exit.hpp"
 
@@ -365,11 +366,13 @@ rmw_ret_t ClientData::send_request(
   size_t data_length = ser.get_serialized_data_length();
   *sequence_id = sequence_number_++;
 
+#ifndef ROS_DISTRO_JAZZY
   TRACETOOLS_TRACEPOINT(
     rmw_send_request,
     static_cast<const void *>(rmw_client_),
     static_cast<const void *>(ros_request),
     *sequence_id);
+#endif
 
   // Send request
   zenoh::Session::GetOptions opts = zenoh::Session::GetOptions::create_default();

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -33,6 +33,7 @@
 #include "message_type_support.hpp"
 #include "logging_macros.hpp"
 #include "qos.hpp"
+#include "rmw_zenoh_cpp/distro.hpp"
 
 #include "rcpputils/scope_exit.hpp"
 
@@ -460,6 +461,7 @@ rmw_ret_t ServiceData::send_response(
     return RMW_RET_ERROR;
   }
 
+#ifndef ROS_DISTRO_JAZZY
   TRACETOOLS_TRACEPOINT(
     rmw_send_response,
     static_cast<const void *>(rmw_service_),
@@ -467,6 +469,7 @@ rmw_ret_t ServiceData::send_response(
     request_id->writer_guid,
     request_id->sequence_number,
     source_timestamp);
+#endif
   loaned_query.reply(service_ke, std::move(payload), std::move(options), &result);
   if (result != Z_OK) {
     RMW_SET_ERROR_MSG("unable to reply");

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -39,6 +39,7 @@
 #include "detail/serialization_format.hpp"
 #include "detail/type_support_common.hpp"
 #include "detail/zenoh_utils.hpp"
+#include "rmw_zenoh_cpp/distro.hpp"
 
 #include "rcpputils/scope_exit.hpp"
 
@@ -1509,10 +1510,12 @@ rmw_create_client(
   free_rmw_client.cancel();
   free_service_name.cancel();
 
+#ifndef ROS_DISTRO_JAZZY
   TRACETOOLS_TRACEPOINT(
     rmw_client_init,
     static_cast<const void *>(rmw_client),
     client_data->copy_gid().data());
+#endif
   return rmw_client;
 }
 
@@ -1609,6 +1612,7 @@ rmw_take_response(
   RMW_CHECK_ARGUMENT_FOR_NULL(request_header, RMW_RET_INVALID_ARGUMENT);
 
   rmw_ret_t ret = client_data->take_response(request_header, ros_response, taken);
+#ifndef ROS_DISTRO_JAZZY
   TRACETOOLS_TRACEPOINT(
     rmw_take_response,
     static_cast<const void *>(client),
@@ -1616,6 +1620,7 @@ rmw_take_response(
     request_header->request_id.sequence_number,
     request_header->source_timestamp,
     *taken);
+#endif
   return ret;
 }
 
@@ -1838,6 +1843,7 @@ rmw_take_request(
     request_header,
     ros_request,
     taken);
+#ifndef ROS_DISTRO_JAZZY
   TRACETOOLS_TRACEPOINT(
     rmw_take_request,
     static_cast<const void *>(service),
@@ -1845,6 +1851,7 @@ rmw_take_request(
     request_header->request_id.writer_guid,
     request_header->request_id.sequence_number,
     *taken);
+#endif
   return ret;
 }
 


### PR DESCRIPTION
Follow-up to #294

As reported on that PR (https://github.com/ros2/rmw_zenoh/pull/294#issuecomment-2557968743), Jazzy builds are broken, because the service/client tracepoints do not exist on Jazzy: `rmw_client_init`, `rmw_send_request`, `rmw_take_request`, `rmw_send_response`, `rmw_take_response` (added in Rolling in https://github.com/ros2/ros2_tracing/pull/145).

I added a generated header with some distro-specific `#define`s based on `ros_environment`, and then used it to exclude the service/client tracepoints on Jazzy.