### PR TITLE
Remove jazzy CI from rolling branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,8 +20,8 @@ jobs:
           # Rolling (source)
           - ROS_DISTRO: rolling
             BUILD_TYPE: source
-          # Jazzy (binary)
-          - ROS_DISTRO: jazzy
+          # Rolling (binary)
+          - ROS_DISTRO: rolling
             BUILD_TYPE: binary
     env:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos'

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ['jazzy', 'rolling']
+        distro: ['rolling']
     container:
       image: ros:${{ matrix.distro }}-ros-base
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ A ROS 2 RMW implementation based on Zenoh that is written using the zenoh-c bind
 For information about the Design please visit [design](docs/design.md) page.
 
 ## Requirements
-- [ROS 2](https://docs.ros.org): Rolling/Jazzy/Iron
+- [ROS 2](https://docs.ros.org)
 
+> Note: See available distro branches, eg. `jazzy`, for supported ROS 2 distributions.
 
 ## Setup
 
@@ -22,11 +23,12 @@ The `ZENOHC_CARGO_FLAGS` CMake argument may be overwritten with other features i
 See [zenoh_cpp_vendor/CMakeLists.txt](./zenoh_cpp_vendor/CMakeLists.txt) for more details.
 
 ```bash
+# replace <DISTRO> with ROS 2 distro of choice
 mkdir ~/ws_rmw_zenoh/src -p && cd ~/ws_rmw_zenoh/src
-git clone https://github.com/ros2/rmw_zenoh.git
+git clone https://github.com/ros2/rmw_zenoh.git -b <DISTRO>
 cd ~/ws_rmw_zenoh
-rosdep install --from-paths src --ignore-src --rosdistro <DISTRO> -y # replace <DISTRO> with ROS 2 distro of choice
-source /opt/ros/<DISTRO>/setup.bash # replace <DISTRO> with ROS 2 distro of choice
+rosdep install --from-paths src --ignore-src --rosdistro <DISTRO> -y
+source /opt/ros/<DISTRO>/setup.bash
 colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 


### PR DESCRIPTION
Following #294, we've decided to create distro specific branches in this repo, eg. `jazzy` and `humble`.

This PR removes `jazzy` jobs from running on `rolling` branch.