### PR TITLE
fix: wrap a short-lived keyexpr in a `std::string`

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -161,7 +161,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
         RMW_ZENOH_LOG_ERROR_NAMED(
           "rmw_zenoh_cpp",
           "Unable to obtain ServiceData from data for %s.",
-          query.get_keyexpr().as_string_view());
+          std::string(query.get_keyexpr().as_string_view()).c_str());
         return;
       }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -208,7 +208,7 @@ bool SubscriptionData::init()
           RMW_ZENOH_LOG_ERROR_NAMED(
             "rmw_zenoh_cpp",
             "Unable to obtain SubscriptionData from data for %s.",
-            sample.get_keyexpr().as_string_view());
+            std::string(sample.get_keyexpr().as_string_view()).c_str());
           return;
         }
 


### PR DESCRIPTION
This PR fixes some segfault caught in #326.