### PR TITLE
fix: update description to replace zenoh-c with zenoh-cpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![build](https://github.com/ros2/rmw_zenoh/actions/workflows/build.yaml/badge.svg)](https://github.com/ros2/rmw_zenoh/actions/workflows/build.yaml)
 [![style](https://github.com/ros2/rmw_zenoh/actions/workflows/style.yaml/badge.svg)](https://github.com/ros2/rmw_zenoh/actions/workflows/style.yaml)
 
-A ROS 2 RMW implementation based on Zenoh that is written using the zenoh-c bindings.
+A ROS 2 RMW implementation based on Zenoh that is written using the zenoh-cpp bindings.
 
 ## Design
 
@@ -17,7 +17,7 @@ For information about the Design please visit [design](docs/design.md) page.
 
 Build `rmw_zenoh_cpp`
 
->Note: By default, we vendor and compile `zenoh-c` with a subset of `zenoh` features.
+>Note: By default, we vendor and compile `zenoh-cpp` with a subset of `zenoh` features.
 The `ZENOHC_CARGO_FLAGS` CMake argument may be overwritten with other features included if required.
 See [zenoh_cpp_vendor/CMakeLists.txt](./zenoh_cpp_vendor/CMakeLists.txt) for more details.
 

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>rmw_zenoh_cpp</name>
   <version>0.0.1</version>
-  <description>A ROS 2 middleware implementation using zenoh-c</description>
+  <description>A ROS 2 middleware implementation using zenoh-cpp</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
 
   <license>Apache License 2.0</license>

--- a/zenoh_cpp_vendor/package.xml
+++ b/zenoh_cpp_vendor/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>zenoh_cpp_vendor</name>
   <version>0.0.1</version>
-  <description>Vendor pkg to install zenoh-c</description>
+  <description>Vendor pkg to install zenoh-cpp</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <license>Apache License 2.0</license>
 


### PR DESCRIPTION
As https://github.com/ros2/rmw_zenoh/pull/327#issuecomment-2559648078 said, we need to change the package name in the description.