### PR TITLE
Add changelogs and bump version for Jazzy

### DIFF
--- a/rmw_zenoh_cpp/CHANGELOG.rst
+++ b/rmw_zenoh_cpp/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rmw_zenoh_cpp
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* An alternative middleware for ROS 2 based on Zenoh.
+* Contributors: Alejandro Hernández Cordero, Alex Day, Bernd Pfrommer, ChenYing Kuo (CY), Chris Lalancette, Christophe Bedard, CihatAltiparmak, Esteve Fernandez, Franco Cipollone, Geoffrey Biggs, Hans-Martin, James Mount, Julien Enoch, Morgan Quigley, Nate Koenig, Shivang Vijay, Yadunund, Yuyuan Yuan, methylDragon

--- a/rmw_zenoh_cpp/CHANGELOG.rst
+++ b/rmw_zenoh_cpp/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package rmw_zenoh_cpp
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.2.0 (2025-01-02)
+------------------
 * An alternative middleware for ROS 2 based on Zenoh.
 * Contributors: Alejandro Hernández Cordero, Alex Day, Bernd Pfrommer, ChenYing Kuo (CY), Chris Lalancette, Christophe Bedard, CihatAltiparmak, Esteve Fernandez, Franco Cipollone, Geoffrey Biggs, Hans-Martin, James Mount, Julien Enoch, Morgan Quigley, Nate Koenig, Shivang Vijay, Yadunund, Yuyuan Yuan, methylDragon

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>rmw_zenoh_cpp</name>
-  <version>0.0.1</version>
+  <version>0.2.0</version>
   <description>A ROS 2 middleware implementation using zenoh-cpp</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
 

--- a/zenoh_cpp_vendor/CHANGELOG.rst
+++ b/zenoh_cpp_vendor/CHANGELOG.rst
@@ -1,0 +1,8 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package zenoh_cpp_vendor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Vendors zenoh-cpp for rmw_zenoh.
+* Contributors: Alejandro Hernández Cordero, Chris Lalancette, Franco Cipollone, Julien Enoch, Yadunund, Yuyuan Yuan

--- a/zenoh_cpp_vendor/CHANGELOG.rst
+++ b/zenoh_cpp_vendor/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog for package zenoh_cpp_vendor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.2.0 (2025-01-02)
+------------------
 * Vendors zenoh-cpp for rmw_zenoh.
 * Contributors: Alejandro Hernández Cordero, Chris Lalancette, Franco Cipollone, Julien Enoch, Yadunund, Yuyuan Yuan

--- a/zenoh_cpp_vendor/package.xml
+++ b/zenoh_cpp_vendor/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>zenoh_cpp_vendor</name>
-  <version>0.0.1</version>
+  <version>0.2.0</version>
   <description>Vendor pkg to install zenoh-cpp</description>
   <maintainer email="yadunund@openrobotics.org">Yadunund</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
Once this is merged, I will tag `jazzy` as `0.2.0` and perform a bloom release.