### PR TITLE
Fix binary build CI job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
       if: ${{ matrix.BUILD_TYPE == 'source' }}
     - name: Install Coverage Tools
       if: ${{ matrix.BUILD_TYPE == 'binary' }}
-      run: sudo apt update && sudo apt install -y python3-colcon-coveragepy-result python3-colcon-lcov-result lcov
+      run: sudo apt update && sudo apt upgrade -y && sudo apt install -y python3-colcon-coveragepy-result python3-colcon-lcov-result lcov
     - name: Build and run tests
       id: action-ros-ci
       uses: ros-tooling/action-ros-ci@v0.3


### PR DESCRIPTION
Rolling binaries of the latest `ros2_tracing` have been synced but the `ros:rolling-ros-base` container has not been rebuilt. Hence we update installed binaries in the CI.