### PR TITLE
fix: check the context validity before accessing the session

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -395,6 +395,10 @@ rmw_create_publisher(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  if (context_impl->is_shutdown()) {
+    RMW_SET_ERROR_MSG("context_impl is shutdown");
+    return nullptr;
+  }
   if (!context_impl->session_is_valid()) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -936,6 +940,10 @@ rmw_create_subscription(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  if (context_impl->is_shutdown()) {
+    RMW_SET_ERROR_MSG("context_impl is shutdown");
+    return nullptr;
+  }
   if (!context_impl->session_is_valid()) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -1439,6 +1447,10 @@ rmw_create_client(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  if (context_impl->is_shutdown()) {
+    RMW_SET_ERROR_MSG("context_impl is shutdown");
+    return nullptr;
+  }
   if (!context_impl->session_is_valid()) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;
@@ -1701,6 +1713,10 @@ rmw_create_service(
     context_impl,
     "unable to get rmw_context_impl_s",
     return nullptr);
+  if (context_impl->is_shutdown()) {
+    RMW_SET_ERROR_MSG("context_impl is shutdown");
+    return nullptr;
+  }
   if (!context_impl->session_is_valid()) {
     RMW_SET_ERROR_MSG("zenoh session is invalid");
     return nullptr;


### PR DESCRIPTION
This PR addresses the flaky failure in rclcpp/test_wait_for_message. The test sometimes behaves as a use-after-free, say use the session to create a subscription after the context is shut down. 