### PR TITLE
Remove `gid_hash_` from `AttachmentData`

### DIFF
--- a/rmw_zenoh_cpp/src/detail/attachment_helpers.cpp
+++ b/rmw_zenoh_cpp/src/detail/attachment_helpers.cpp
@@ -35,14 +35,12 @@ AttachmentData::AttachmentData(
   const std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid)
 : sequence_number_(sequence_number),
   source_timestamp_(source_timestamp),
-  source_gid_(source_gid),
-  gid_hash_(hash_gid(source_gid))
+  source_gid_(source_gid)
 {
 }
 
 AttachmentData::AttachmentData(AttachmentData && data)
 {
-  gid_hash_ = std::move(data.gid_hash_);
   sequence_number_ = std::move(data.sequence_number_);
   source_timestamp_ = std::move(data.source_timestamp_);
   source_gid_ = data.source_gid_;
@@ -64,12 +62,6 @@ int64_t AttachmentData::source_timestamp() const
 std::array<uint8_t, RMW_GID_STORAGE_SIZE> AttachmentData::copy_gid() const
 {
   return source_gid_;
-}
-
-///=============================================================================
-size_t AttachmentData::gid_hash() const
-{
-  return gid_hash_;
 }
 
 zenoh::Bytes AttachmentData::serialize_to_zbytes()
@@ -104,6 +96,5 @@ AttachmentData::AttachmentData(const zenoh::Bytes & bytes)
     throw std::runtime_error("source_gid is not found in the attachment.");
   }
   this->source_gid_ = deserializer.deserialize<std::array<uint8_t, RMW_GID_STORAGE_SIZE>>();
-  gid_hash_ = hash_gid(this->source_gid_);
 }
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/attachment_helpers.hpp
+++ b/rmw_zenoh_cpp/src/detail/attachment_helpers.hpp
@@ -39,7 +39,6 @@ public:
   int64_t sequence_number() const;
   int64_t source_timestamp() const;
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
-  size_t gid_hash() const;
 
   zenoh::Bytes serialize_to_zbytes();
 
@@ -47,7 +46,6 @@ private:
   int64_t sequence_number_;
   int64_t source_timestamp_;
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid_;
-  size_t gid_hash_;
 };
 }  // namespace rmw_zenoh_cpp
 


### PR DESCRIPTION
This member is computed in the constructor which is in turn called in `rmw_publish`. This hash is not serialized as part of the attachment.

I noticed this when profiling the multi-process iRobot benchmark, where `hash_gid` was taking around 23% of the running time of `rmw_publish`.