### PR TITLE
fix: resolve the memory leak in the subcription message

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -50,11 +50,6 @@ SubscriptionData::Message::Message(
 }
 
 ///=============================================================================
-SubscriptionData::Message::~Message()
-{
-}
-
-///=============================================================================
 std::shared_ptr<SubscriptionData> SubscriptionData::make(
   std::shared_ptr<zenoh::Session> session,
   std::shared_ptr<GraphCache> graph_cache,

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -54,7 +54,7 @@ public:
       uint64_t recv_ts,
       AttachmentData && attachment);
 
-    ~Message();
+    ~Message() = default;
 
     Payload payload;
     uint64_t recv_timestamp;


### PR DESCRIPTION
A memory leak was caught due to the memory leak in the subscription message. This PR addresses this by using the default destructor to drop the member `Payload` automatically.