### PR TITLE
Replace `hash_gid` with FNV-1a

### DIFF
--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -442,7 +442,7 @@ Entity::Entity(
         sizeof(keyexpr_gid.high64));
 
   // We also hash the liveliness keyexpression into a size_t that we use to index into our maps.
-  this->keyexpr_hash_ = hash_gid(this->gid_);
+  this->keyexpr_hash_ = std::hash<Gid>{}(this->gid_);
 }
 
 ///=============================================================================
@@ -670,15 +670,4 @@ std::string demangle_name(const std::string & input)
   return output;
 }
 }  // namespace liveliness
-
-///=============================================================================
-size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid)
-{
-  std::stringstream hash_str;
-  hash_str << std::hex;
-  for (const auto & g : gid) {
-    hash_str << static_cast<int>(g);
-  }
-  return std::hash<std::string>{}(hash_str.str());
-}
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -289,7 +289,7 @@ struct hash<rmw_zenoh_cpp::Gid>
       hash ^= byte;
       hash *= FNV_PRIME_64;
     }
-    return hash;
+    return static_cast<std::size_t>(hash);
   }
 };
 }  // namespace std

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -275,8 +275,9 @@ struct hash<rmw_zenoh_cpp::Gid>
 {
   std::size_t operator()(const rmw_zenoh_cpp::Gid & gid) const noexcept
   {
-    // This function implemented FNV-1a 64-bit as the GID is small enough (e.g. as of commit db4d05e
-    // of ros2/rmw RMW_GID_STORAGE_SIZE is set to 16) and FNV is known to be efficient in such cases.
+    // This function implemented FNV-1a 64-bit as the GID is small enough
+    // (e.g. as of commit db4d05e of ros2/rmw RMW_GID_STORAGE_SIZE is set to 16)
+    // and FNV is known to be efficient in such cases.
     //
     // See https://github.com/ros2/rmw/blob/db4d05e/rmw/include/rmw/types.h#L44
     // and https://datatracker.ietf.org/doc/html/draft-eastlake-fnv-17.html

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -234,8 +234,7 @@ std::string qos_to_keyexpr(const rmw_qos_profile_t & qos);
 std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr);
 }  // namespace liveliness
 
-///=============================================================================
-size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid);
+using Gid = std::array<uint8_t, RMW_GID_STORAGE_SIZE>;
 }  // namespace rmw_zenoh_cpp
 
 ///=============================================================================
@@ -268,6 +267,28 @@ struct equal_to<rmw_zenoh_cpp::liveliness::ConstEntityPtr>
     const rmw_zenoh_cpp::liveliness::ConstEntityPtr & rhs) const -> bool
   {
     return lhs->keyexpr_hash() == rhs->keyexpr_hash();
+  }
+};
+
+template<>
+struct hash<rmw_zenoh_cpp::Gid>
+{
+  std::size_t operator()(const rmw_zenoh_cpp::Gid & gid) const noexcept
+  {
+    // This function implemented FNV-1a 64-bit as the GID is small enough (e.g. as of commit db4d05e
+    // of ros2/rmw RMW_GID_STORAGE_SIZE is set to 16) and FNV is known to be efficient in such cases.
+    //
+    // See https://github.com/ros2/rmw/blob/db4d05e/rmw/include/rmw/types.h#L44
+    // and https://datatracker.ietf.org/doc/html/draft-eastlake-fnv-17.html
+    static constexpr uint64_t FNV_OFFSET_BASIS_64 = 0x00000100000001b3;
+    static constexpr uint64_t FNV_PRIME_64 = 0xcbf29ce484222325;
+
+    uint64_t hash = FNV_OFFSET_BASIS_64;
+    for (const uint8_t & byte : gid) {
+      hash ^= byte;
+      hash *= FNV_PRIME_64;
+    }
+    return hash;
   }
 };
 }  // namespace std

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
@@ -149,7 +149,7 @@ private:
   std::deque<std::unique_ptr<ZenohQuery>> query_queue_;
   // Map to store the sequence_number (as given by the client) -> ZenohQuery
   using SequenceToQuery = std::unordered_map<int64_t, std::unique_ptr<ZenohQuery>>;
-  std::unordered_map<size_t, SequenceToQuery> sequence_to_query_map_;
+  std::unordered_map<Gid, SequenceToQuery> sequence_to_query_map_;
   // Wait set data.
   rmw_wait_set_data_t * wait_set_data_;
   // Data callback manager.

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -610,8 +610,8 @@ void SubscriptionData::add_new_message(
   }
 
   // Check for messages lost if the new sequence number is not monotonically increasing.
-  const size_t gid_hash = hash_gid(msg->attachment.copy_gid());
-  auto last_known_pub_it = last_known_published_msg_.find(gid_hash);
+  const Gid gid = msg->attachment.copy_gid();
+  auto last_known_pub_it = last_known_published_msg_.find(gid);
   if (last_known_pub_it != last_known_published_msg_.end()) {
     const int64_t seq_increment = std::abs(
       msg->attachment.sequence_number() -
@@ -624,7 +624,7 @@ void SubscriptionData::add_new_message(
     }
   }
   // Always update the last known sequence number for the publisher.
-  last_known_published_msg_[gid_hash] = msg->attachment.sequence_number();
+  last_known_published_msg_[gid] = msg->attachment.sequence_number();
 
   message_queue_.emplace_back(std::move(msg));
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -147,7 +147,7 @@ private:
   std::unique_ptr<MessageTypeSupport> type_support_;
   std::deque<std::unique_ptr<Message>> message_queue_;
   // Map GID of a subscription to the sequence number of the message it published.
-  std::unordered_map<size_t, int64_t> last_known_published_msg_;
+  std::unordered_map<Gid, int64_t> last_known_published_msg_;
   // Wait set data.
   rmw_wait_set_data_t * wait_set_data_;
   // Callback managers.


### PR DESCRIPTION
`hash_gid` is called on Zenoh subscriber callbacks and shows up when profiling as a hot function. The use of `std::stringstream` seems to be relatively inefficient. A significant portion of `hash_gid`'s running time is spend allocating & deallocating the `std::stringstream`.

<img width="1166" alt="Screenshot 2025-01-15 at 17 39 31" src="https://github.com/user-attachments/assets/6ec616c5-a061-44a1-9c38-44c95685971e" />
