### PR TITLE
Fix `ZENOH_ROUTER_CHECK_ATTEMPTS` which was not respected

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,15 @@ The `ZENOH_ROUTER_CHECK_ATTEMPTS` environment variable can be used to configure 
 The behavior is explained in the table below.
 
 
-| ZENOH_ROUTER_CHECK_ATTEMPTS |                                                 Session behavior                                                 |
-|:---------------------------:|:----------------------------------------------------------------------------------------------------------------:|
-|            unset or 0           |                                                             Indefinitely waits for connection to a Zenoh router. |
-|             < 0            |                                                                                        Skips Zenoh router check. |
+| ZENOH_ROUTER_CHECK_ATTEMPTS |                                                 Session behavior                                                   |
+|:---------------------------:|:------------------------------------------------------------------------------------------------------------------:|
+|               0             |                                                             Indefinitely waits for connection to a Zenoh router.   |
+|             < 0             |                                                                                        Skips Zenoh router check.   |
 |             > 0             | Attempts to connect to a Zenoh router in `ZENOH_ROUTER_CHECK_ATTEMPTS` attempts with 1 second wait between checks. |
+|            unset            |                                                                    Equivalent to `1`: the check is made only once. |
+
+If after the configured number of attempts the Node is still not connected to a `Zenoh router`, the initialisation goes on anyway.  
+If a `Zenoh router` is started after initialization phase, the Node will automatically connect to it, and autoconnect to other Nodes if gossip scouting is enabled (true with default configuratiuon).
 
 ### Session and Router configs
 `rmw_zenoh` relies on separate configurations files to configure the `Zenoh router` and `Zenoh session` respectively.

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -100,8 +100,8 @@ public:
       constexpr int64_t ticks_between_print(std::chrono::milliseconds(1000) / sleep_time);
       do {
         zenoh::ZResult result;
-        this->session_->get_routers_z_id(&result);
-        if (result == Z_OK) {
+        const auto zids = this->session_->get_routers_z_id(&result);
+        if (result == Z_OK && !zids.empty()) {
           break;
         }
         if ((connection_attempts % ticks_between_print) == 0) {


### PR DESCRIPTION
Fix #426

1. The call to `std::vector<Id> Session::get_routers_z_id(ZResult*)` was checking the `ZResult`, but not the size of the returned vector.
2. in #308 the default value of `ZENOH_ROUTER_CHECK_ATTEMPTS` was changed from `0` to `1`. This PR updates the README to reflect this change, and clarify the behaviour after the checks complete.