### PR TITLE
Clear the error after rmw_serialized_message_resize()

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -809,6 +809,7 @@ rmw_serialize(
   auto data_length = tss.get_estimated_serialized_size(ros_message, callbacks);
   if (serialized_message->buffer_capacity < data_length) {
     if (rmw_serialized_message_resize(serialized_message, data_length) != RMW_RET_OK) {
+      rmw_reset_error();
       RMW_SET_ERROR_MSG("unable to dynamically resize serialized message");
       return RMW_RET_ERROR;
     }


### PR DESCRIPTION
It is actually an alias for rcutils_uint8_array_resize(), so the error message isn't useful.  Instead, reset the error and set a more useful one.