### PR TITLE
Inform users that peers will not discover and communicate with one another until the router is started

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -108,9 +108,17 @@ public:
           RMW_ZENOH_LOG_WARN_NAMED(
             "rmw_zenoh_cpp",
             "Unable to connect to a Zenoh router. "
-            "Have you started a router with `ros2 run rmw_zenoh_cpp rmw_zenohd`?");
+            "Have you started a router with `ros2 run rmw_zenoh_cpp rmw_zenohd`? "
+            "You may also increase the number of attempts to check for a router "
+            "but setting the ZENOH_ROUTER_CHECK_ATTEMPTS environment variable.");
         }
         if (++connection_attempts >= configured_connection_attempts.value()) {
+          RMW_ZENOH_LOG_WARN_NAMED(
+            "rmw_zenoh_cpp",
+            "Unable to connect to a Zenoh router after %zu attempt(s). "
+            "Proceeding with initialization but other peers will not discover "
+            "or receive data from peers in this session until the router is started.",
+            configured_connection_attempts.value());
           break;
         }
         std::this_thread::sleep_for(sleep_time);

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -108,16 +108,17 @@ public:
           RMW_ZENOH_LOG_WARN_NAMED(
             "rmw_zenoh_cpp",
             "Unable to connect to a Zenoh router. "
-            "Have you started a router with `ros2 run rmw_zenoh_cpp rmw_zenohd`? "
-            "You may also increase the number of attempts to check for a router "
-            "but setting the ZENOH_ROUTER_CHECK_ATTEMPTS environment variable.");
+            "Have you started a router with `ros2 run rmw_zenoh_cpp rmw_zenohd`?");
         }
         if (++connection_attempts >= configured_connection_attempts.value()) {
           RMW_ZENOH_LOG_WARN_NAMED(
             "rmw_zenoh_cpp",
             "Unable to connect to a Zenoh router after %zu attempt(s). "
+            "Please ensure that a Zenoh router is running and can be reached. "
+            "You may increase the number of attempts to check for a router by "
+            "setting the ZENOH_ROUTER_CHECK_ATTEMPTS environment variable. "
             "Proceeding with initialization but other peers will not discover "
-            "or receive data from peers in this session until the router is started.",
+            "or receive data from peers in this session until a router is started.",
             configured_connection_attempts.value());
           break;
         }


### PR DESCRIPTION
Address ambiguity from https://github.com/ros2/rmw_zenoh/issues/439