### PR TITLE
Bump Zenoh to commit id e4ea6f0 (1.2.0 + few commits)

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -149,6 +149,13 @@
       /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
       /// direct connectivity with each other.
       multihop: false,
+      /// Which type of Zenoh instances to send gossip messages to.
+      /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
+      /// or different values for router, peer or client mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of: "peer", "router" and/or "client".
+      /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+      ///               messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+      target: { router: ["router", "peer"], peer: ["router"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
       /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -358,11 +358,11 @@
       open_timeout: 10000,
       /// Timeout in milliseconds when accepting a link
       accept_timeout: 10000,
-      /// Maximum number of zenoh session in pending state while accepting
+      /// Maximum number of links in pending state while performing the handshake for accepting it
       accept_pending: 100,
-      /// Maximum number of sessions that can be simultaneously alive
+      /// Maximum number of transports that can be simultaneously alive for a single zenoh sessions
       max_sessions: 1000,
-      /// Maximum number of incoming links that are admitted per session
+      /// Maximum number of incoming links that are admitted per transport
       max_links: 1,
       /// Enables the LowLatency transport
       /// This option does not make LowLatency transport mandatory, the actual implementation of transport

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -198,6 +198,14 @@
       /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
       mode: "peer_to_peer",
     },
+    /// The interests-based routing configuration.
+    /// This configuration applies regardless of the mode (router, peer or client).
+    interests: {
+      /// The timeout to wait for incoming interests declarations in milliseconds.
+      /// The expiration of this timeout implies that the discovery protocol might be incomplete,
+      /// leading to potential loss of messages, queries or liveliness tokens.
+      timeout: 10000,
+    },
   },
 
   //  /// Overwrite QoS options for Zenoh messages by key expression (ignores Zenoh API QoS config for overwritten values)

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -479,6 +479,12 @@
             /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
             time_limit: 1,
           },
+          allocation: {
+            /// Mode for memory allocation of batches in the priority queues. 
+            /// - "init": batches are allocated at queue initialization time. 
+            /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
+            mode: "init",
+          },
         },
       },
       /// Configure the zenoh RX parameters of a link

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -135,11 +135,11 @@
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
       /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer", "router" and/or "client".
-      autoconnect: { router: [], peer: ["router", "peer"] },
+      autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },
-    /// The gossip scouting configuration.
+    /// The gossip scouting configuration. Note that instances in "client" mode do not participate in gossip.
     gossip: {
       /// Whether gossip scouting is enabled or not
       enabled: true,
@@ -151,15 +151,15 @@
       multihop: false,
       /// Which type of Zenoh instances to send gossip messages to.
       /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
-      /// or different values for router, peer or client mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
-      /// Each value is a list of: "peer", "router" and/or "client".
+      /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of "peer" and/or "router".
       /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
       ///               messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
       target: { router: ["router", "peer"], peer: ["router"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
-      /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
-      /// Each value is a list of: "peer", "router" and/or "client".
+      /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+      /// Each value is a list of: "peer" and/or "router".
       autoconnect: { router: [], peer: ["router", "peer"] },
     },
   },

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -444,14 +444,14 @@
           /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.
           /// If qos is false, then only the DATA priority will be allocated.
           size: {
-            control: 1,
-            real_time: 1,
-            interactive_high: 1,
-            interactive_low: 1,
+            control: 2,
+            real_time: 2,
+            interactive_high: 2,
+            interactive_low: 2,
             data_high: 2,
-            data: 4,
-            data_low: 4,
-            background: 4,
+            data: 2,
+            data_low: 2,
+            background: 2,
           },
           /// Congestion occurs when the queue is empty (no available batch).
           congestion_control: {
@@ -483,7 +483,7 @@
             /// Mode for memory allocation of batches in the priority queues. 
             /// - "init": batches are allocated at queue initialization time. 
             /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
-            mode: "init",
+            mode: "lazy",
           },
         },
       },

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -154,6 +154,13 @@
       /// It mostly makes sense when using "linkstate" routing mode where all nodes in the subsystem don't have
       /// direct connectivity with each other.
       multihop: false,
+      /// Which type of Zenoh instances to send gossip messages to.
+      /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
+      /// or different values for router, peer or client mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of: "peer", "router" and/or "client".
+      /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+      ///               messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+      target: { router: ["router", "peer"], peer: ["router"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
       /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -361,11 +361,11 @@
       open_timeout: 10000,
       /// Timeout in milliseconds when accepting a link
       accept_timeout: 10000,
-      /// Maximum number of zenoh session in pending state while accepting
+      /// Maximum number of links in pending state while performing the handshake for accepting it
       accept_pending: 100,
-      /// Maximum number of sessions that can be simultaneously alive
+      /// Maximum number of transports that can be simultaneously alive for a single zenoh sessions
       max_sessions: 1000,
-      /// Maximum number of incoming links that are admitted per session
+      /// Maximum number of incoming links that are admitted per transport
       max_links: 1,
       /// Enables the LowLatency transport
       /// This option does not make LowLatency transport mandatory, the actual implementation of transport

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -140,11 +140,11 @@
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
       /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer", "router" and/or "client".
-      autoconnect: { router: [], peer: ["router", "peer"] },
+      autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },
-    /// The gossip scouting configuration.
+    /// The gossip scouting configuration. Note that instances in "client" mode do not participate in gossip.
     gossip: {
       /// Whether gossip scouting is enabled or not
       enabled: true,
@@ -156,15 +156,15 @@
       multihop: false,
       /// Which type of Zenoh instances to send gossip messages to.
       /// Accepts a single value (e.g. target: ["router", "peer"]) which applies whatever the configured "mode" is,
-      /// or different values for router, peer or client mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
-      /// Each value is a list of: "peer", "router" and/or "client".
+      /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
+      /// Each value is a list of "peer" and/or "router".
       /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
       ///               messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
       target: { router: ["router", "peer"], peer: ["router"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
-      /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
-      /// Each value is a list of: "peer", "router" and/or "client".
+      /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
+      /// Each value is a list of: "peer" and/or "router".
       autoconnect: { router: [], peer: ["router", "peer"] },
     },
   },

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -482,6 +482,12 @@
             /// The maximum time limit (in ms) a message should be retained for batching when back-pressure happens.
             time_limit: 1,
           },
+          allocation: {
+            /// Mode for memory allocation of batches in the priority queues. 
+            /// - "init": batches are allocated at queue initialization time. 
+            /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
+            mode: "init",
+          },
         },
       },
       /// Configure the zenoh RX parameters of a link

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -447,14 +447,14 @@
           /// then amount of memory being allocated for each queue is SIZE_XXX * LINK_MTU.
           /// If qos is false, then only the DATA priority will be allocated.
           size: {
-            control: 1,
-            real_time: 1,
-            interactive_high: 1,
-            interactive_low: 1,
+            control: 2,
+            real_time: 2,
+            interactive_high: 2,
+            interactive_low: 2,
             data_high: 2,
-            data: 4,
-            data_low: 4,
-            background: 4,
+            data: 2,
+            data_low: 2,
+            background: 2,
           },
           /// Congestion occurs when the queue is empty (no available batch).
           congestion_control: {
@@ -486,7 +486,7 @@
             /// Mode for memory allocation of batches in the priority queues. 
             /// - "init": batches are allocated at queue initialization time. 
             /// - "lazy": batches are allocated when needed up to the maximum number of batches configured in the size configuration parameter.
-            mode: "init",
+            mode: "lazy",
           },
         },
       },

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -201,6 +201,14 @@
       /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
       mode: "peer_to_peer",
     },
+    /// The interests-based routing configuration.
+    /// This configuration applies regardless of the mode (router, peer or client).
+    interests: {
+      /// The timeout to wait for incoming interests declarations in milliseconds.
+      /// The expiration of this timeout implies that the discovery protocol might be incomplete,
+      /// leading to potential loss of messages, queries or liveliness tokens.
+      timeout: 10000,
+    },
   },
 
   //  /// Overwrite QoS options for Zenoh messages by key expression (ignores Zenoh API QoS config for overwritten values)

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -24,7 +24,7 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 # - https://github.com/eclipse-zenoh/zenoh/pull/1717 (Improve performance of a large number of peers)
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 15d56e1fb44eead6611cf847f503ef030aee5287
+  VCS_VERSION 5fce7fb1d397e016ad02a50bde4262007d755424
   CMAKE_ARGS
   "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
   "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -17,30 +17,27 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # when expanded.
 set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memory zenoh/transport_compression zenoh/transport_tcp zenoh/transport_tls")
 
-# Set VCS_VERSION to include latest changes from zenoh/zenoh-c to benefit from :
-# - https://github.com/eclipse-zenoh/zenoh/pull/1685 (Fix deadlock in advanced subscription undeclaration)
-# - https://github.com/eclipse-zenoh/zenoh/pull/1696 (Fix SHM Garbage Collection (GC) policy)
-# - https://github.com/eclipse-zenoh/zenoh/pull/1708 (Fix gossip with TLS endpoints)
-# - https://github.com/eclipse-zenoh/zenoh/pull/1717 (Improve performance of a large number of peers)
+# Set VCS_VERSION to include latest changes from zenoh/zenoh-c/zenoh-cpp to benefit from :
+# - https://github.com/eclipse-zenoh/zenoh/pull/173 (Improve config to support priorities range in locators)
+# - https://github.com/eclipse-zenoh/zenoh/pull/1736, https://github.com/eclipse-zenoh/zenoh/pull/1735,
+#   https://github.com/eclipse-zenoh/zenoh/pull/1744, https://github.com/eclipse-zenoh/zenoh/pull/1749,
+#   https://github.com/eclipse-zenoh/zenoh/pull/1751 (Improve performance of a large number of peers)
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 5fce7fb1d397e016ad02a50bde4262007d755424
   CMAKE_ARGS
-  "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
-  "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
-  "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
+    "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
+    "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
+    "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
 )
 
 ament_export_dependencies(zenohc)
 
-# Set VCS_VERSION to include latest changes from zenoh-cpp to benefit from :
-# - https://github.com/eclipse-zenoh/zenoh-cpp/pull/342 (Fix include what you use)
-# - https://github.com/eclipse-zenoh/zenoh-cpp/pull/363 (Fix memory leak in string deserialization)
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
   VCS_VERSION bd4d741c6c4fa6509d8d745e22c3c50b4306bd65
   CMAKE_ARGS
-  -DZENOHCXX_ZENOHC=OFF
+    -DZENOHCXX_ZENOHC=OFF
 )
 
 externalproject_add_stepdependencies(zenoh_cpp_vendor configure zenoh_c_vendor)

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -24,7 +24,7 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 # - https://github.com/eclipse-zenoh/zenoh/pull/1717 (Improve performance of a large number of peers)
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 9844b6988a0c11821c52874d56825058ac732a9f
+  VCS_VERSION 15d56e1fb44eead6611cf847f503ef030aee5287
   CMAKE_ARGS
   "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
   "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -24,11 +24,11 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 # - https://github.com/eclipse-zenoh/zenoh/pull/1717 (Improve performance of a large number of peers)
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 328736fe9bb9b654b1d9f47eecfc6d52f0d7d587
+  VCS_VERSION 9844b6988a0c11821c52874d56825058ac732a9f
   CMAKE_ARGS
-    "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
-    "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
-    "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
+  "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
+  "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
+  "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
 )
 
 ament_export_dependencies(zenohc)
@@ -38,9 +38,9 @@ ament_export_dependencies(zenohc)
 # - https://github.com/eclipse-zenoh/zenoh-cpp/pull/363 (Fix memory leak in string deserialization)
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION bbfef04e843289aae70b5aa060a925e8ee5b1b6f
+  VCS_VERSION bd4d741c6c4fa6509d8d745e22c3c50b4306bd65
   CMAKE_ARGS
-    -DZENOHCXX_ZENOHC=OFF
+  -DZENOHCXX_ZENOHC=OFF
 )
 
 externalproject_add_stepdependencies(zenoh_cpp_vendor configure zenoh_c_vendor)


### PR DESCRIPTION
This PR makes the following changes of commit ids:

- zenoh-cpp: [bbfef04](https://github.com/eclipse-zenoh/zenoh-cpp/commit/bbfef04e843289aae70b5aa060a925e8ee5b1b6f) -> [bd4d741](https://github.com/eclipse-zenoh/zenoh-cpp/commit/bd4d741c6c4fa6509d8d745e22c3c50b4306bd65) -  [diff](https://github.com/eclipse-zenoh/zenoh-cpp/compare/bbfef04e843289aae70b5aa060a925e8ee5b1b6f...bd4d741c6c4fa6509d8d745e22c3c50b4306bd65)
- zenoh-c: [328736f](https://github.com/eclipse-zenoh/zenoh-c/commit/328736fe9bb9b654b1d9f47eecfc6d52f0d7d587) -> [5fce7fb](https://github.com/eclipse-zenoh/zenoh-c/commit/5fce7fb1d397e016ad02a50bde4262007d755424) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/328736fe9bb9b654b1d9f47eecfc6d52f0d7d587...5fce7fb1d397e016ad02a50bde4262007d755424)
- zenoh: [4173948](https://github.com/eclipse-zenoh/zenoh/commit/41739485fa5e0b78c46dd03ae06d3abcc999acd8) -> [e4ea6f0](https://github.com/eclipse-zenoh/zenoh/commit/e4ea6f04c0c15908612a7ac81af9aaa9b0dc3d11) - [diff](https://github.com/eclipse-zenoh/zenoh/compare/41739485fa5e0b78c46dd03ae06d3abcc999acd8...e4ea6f04c0c15908612a7ac81af9aaa9b0dc3d11)

It includes those notable changes:

- Improve config to support priorities range in locators:
    <https://github.com/eclipse-zenoh/zenoh/pull/173>
- Performances improvements at launch time:
  - <https://github.com/eclipse-zenoh/zenoh/pull/1736> (reduce CPU usage)
  - <https://github.com/eclipse-zenoh/zenoh/pull/1735> (reduce CPU usage)
  - <https://github.com/eclipse-zenoh/zenoh/pull/1744> (reduce CPU usage)
  - <https://github.com/eclipse-zenoh/zenoh/pull/1749> (reduce memory consumption)
  - <https://github.com/eclipse-zenoh/zenoh/pull/1751> (reduce memory consumption)   

It also copies some addition and changes in the Zenoh config files, with ROS-specific customization wrt. the new `gossip.target` config set to `"router"` only:
by default with rmw_zenoh all peers rely on the router to discover each other. Thus configuring the peer to send gossip messages only to the router is sufficient and avoids unnecessary traffic between Nodes at launch time.