### PR TITLE
Bump Zenoh to commit id 3bbf6af (1.2.1 + few commits)

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -136,6 +136,19 @@
       /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer", "router" and/or "client".
       autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
+      /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+      /// Possible options are:
+      /// - "always": always attempt to autoconnect, may result in redundant connections.
+      /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+      ///   If both nodes use this strategy, only one will attempt the connection.
+      ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+      ///   because of a private IP.
+      /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+      /// or different values for router and/or peer depending on the type of node detected
+      /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+      /// or different values for router or peer mode
+      /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+      autoconnect_strategy: { router: { to_router: "always", to_peer: "always" } },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },
@@ -161,6 +174,19 @@
       /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer" and/or "router".
       autoconnect: { router: [], peer: ["router", "peer"] },
+      /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+      /// Possible options are:
+      /// - "always": always attempt to autoconnect, may result in redundant connections.
+      /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+      ///   If both nodes use this strategy, only one will attempt the connection.
+      ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+      ///   because of a private IP.
+      /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+      /// or different values for router and/or peer depending on the type of node detected
+      /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+      /// or different values for router or peer mode
+      /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+      autoconnect_strategy: { router: { to_router: "always", to_peer: "always" } },
     },
   },
 

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -141,6 +141,21 @@
       /// or different values for router, peer and client (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer", "router" and/or "client".
       autoconnect: { router: [], peer: ["router", "peer"], client: ["router"] },
+      /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+      /// Possible options are:
+      /// - "always": always attempt to autoconnect, may result in redundant connections.
+      /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+      ///   If both nodes use this strategy, only one will attempt the connection.
+      ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+      ///   because of a private IP.
+      /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+      /// or different values for router and/or peer depending on the type of node detected
+      /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+      /// or different values for router or peer mode
+      /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+      /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
+      ///              messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+      autoconnect_strategy: { peer: { to_router: "always", to_peer: "greater-zid" } },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },
@@ -159,13 +174,29 @@
       /// or different values for router or peer mode (e.g. target: { router: ["router", "peer"], peer: ["router"] }).
       /// Each value is a list of "peer" and/or "router".
       /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
-      ///               messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
+      ///              messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
       target: { router: ["router", "peer"], peer: ["router"]},
       /// Which type of Zenoh instances to automatically establish sessions with upon discovery on gossip.
       /// Accepts a single value (e.g. autoconnect: ["router", "peer"])
       /// or different values for router or peer mode (e.g. autoconnect: { router: [], peer: ["router", "peer"] }).
       /// Each value is a list of: "peer" and/or "router".
       autoconnect: { router: [], peer: ["router", "peer"] },
+      /// Strategy for autoconnection, mainly to avoid nodes connecting to each other redundantly.
+      /// Possible options are:
+      /// - "always": always attempt to autoconnect, may result in redundant connections.
+      /// - "greater-zid": attempt to connect to another node only if its own zid is greater than the other's.
+      ///   If both nodes use this strategy, only one will attempt the connection.
+      ///   This strategy may not be suited if one of the nodes is not reachable by the other one, for example
+      ///   because of a private IP.
+      /// Accepts a single value (e.g. autoconnect: "always") which applies whatever node would be auto-connected to,
+      /// or different values for router and/or peer depending on the type of node detected
+      /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
+      /// or different values for router or peer mode
+      /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
+      /// ROS setting: as by default all peers will interconnect to each other over the loopback interface,
+      ///              they are all reachable to each other. Hence using "greater-zid" for peers connecting to
+      ///              other peers is sufficient and avoids unecessary double connections between peers at startup.
+      autoconnect_strategy: { peer: { to_router: "always", to_peer: "greater-zid" } },
     },
   },
 

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -18,13 +18,13 @@ find_package(ament_cmake_vendor_package REQUIRED)
 set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memory zenoh/transport_compression zenoh/transport_tcp zenoh/transport_tls")
 
 # Set VCS_VERSION to include latest changes from zenoh/zenoh-c/zenoh-cpp to benefit from :
-# - https://github.com/eclipse-zenoh/zenoh/pull/173 (Improve config to support priorities range in locators)
-# - https://github.com/eclipse-zenoh/zenoh/pull/1736, https://github.com/eclipse-zenoh/zenoh/pull/1735,
-#   https://github.com/eclipse-zenoh/zenoh/pull/1744, https://github.com/eclipse-zenoh/zenoh/pull/1749,
-#   https://github.com/eclipse-zenoh/zenoh/pull/1751 (Improve performance of a large number of peers)
+# - https://github.com/eclipse-zenoh/zenoh/pull/1742, https://github.com/eclipse-zenoh/zenoh/pull/1765
+#    (Add autoconnect_strategy config allowing to optimize peers interconnections)
+# - https://github.com/eclipse-zenoh/zenoh/pull/1753
+#    (Improve AdvancedSub for faster delivery of first receveived data)
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 5fce7fb1d397e016ad02a50bde4262007d755424
+  VCS_VERSION 63a24e5137569ba02959d4952a9751a75ed3e796
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
@@ -35,7 +35,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION bd4d741c6c4fa6509d8d745e22c3c50b4306bd65
+  VCS_VERSION 1ad141509f6bcfe9194759a47a656dedf6334fc8
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )


### PR DESCRIPTION
This PR makes the following changes of commit ids:

- zenoh-cpp: [bd4d741](https://github.com/eclipse-zenoh/zenoh-cpp/commit/bd4d741c6c4fa6509d8d745e22c3c50b4306bd65) -> [1ad1415](https://github.com/eclipse-zenoh/zenoh-cpp/commit/1ad141509f6bcfe9194759a47a656dedf6334fc8) -  [diff](https://github.com/eclipse-zenoh/zenoh-cpp/compare/bd4d741c6c4fa6509d8d745e22c3c50b4306bd65...1ad141509f6bcfe9194759a47a656dedf6334fc8)
- zenoh-c: [5fce7fb](https://github.com/eclipse-zenoh/zenoh-c/commit/5fce7fb1d397e016ad02a50bde4262007d755424) -> [63a24e5](https://github.com/eclipse-zenoh/zenoh-c/commit/63a24e5137569ba02959d4952a9751a75ed3e796) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/5fce7fb1d397e016ad02a50bde4262007d755424...63a24e5137569ba02959d4952a9751a75ed3e796)
- zenoh: [e4ea6f0](https://github.com/eclipse-zenoh/zenoh/commit/e4ea6f04c0c15908612a7ac81af9aaa9b0dc3d11) -> [3bbf6af](https://github.com/eclipse-zenoh/zenoh/commit/3bbf6af729e38cc28769fc6869c293bfaa062326) - [diff](https://github.com/eclipse-zenoh/zenoh/compare/e4ea6f04c0c15908612a7ac81af9aaa9b0dc3d11...3bbf6af729e38cc28769fc6869c293bfaa062326)

It includes those notable changes:

- Add `autoconnect_strategy` config allowing to optimize peers interconnections:
    - <https://github.com/eclipse-zenoh/zenoh/pull/1742>
    - <https://github.com/eclipse-zenoh/zenoh/pull/1765>
    - For ROS 2 Nodes, in `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5`, the `autoconnect_strategy.peer.to_peer` config in is set to `"greater-zid"`. This ensures that 2 Nodes will establish only 1 TCP connection with each other, avoiding unecessary burden at launch time and in memory usage.
- Improve AdvancedSub for faster delivery of first receveived data:
  - <https://github.com/eclipse-zenoh/zenoh/pull/1753>
  - This will be used only when #368 is merged
     and it will likely solve #326 
