### PR TITLE
fix: use the default destructor that automatically drops the zenoh reply/query and hence sends the final signal

### DIFF
--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.cpp
@@ -42,9 +42,6 @@ std::chrono::nanoseconds::rep ZenohQuery::get_received_timestamp() const
 }
 
 ///=============================================================================
-ZenohQuery::~ZenohQuery() {}
-
-///=============================================================================
 const zenoh::Query & ZenohQuery::get_query() const {return query_;}
 
 ///=============================================================================
@@ -55,9 +52,6 @@ ZenohReply::ZenohReply(
   reply_ = reply.clone();
   received_timestamp_ = received_timestamp;
 }
-
-///=============================================================================
-ZenohReply::~ZenohReply() {}
 
 ///=============================================================================
 const zenoh::Reply & ZenohReply::get_sample() const

--- a/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_utils.hpp
@@ -36,7 +36,7 @@ class ZenohReply final
 public:
   ZenohReply(const zenoh::Reply & reply, std::chrono::nanoseconds::rep received_timestamp);
 
-  ~ZenohReply();
+  ~ZenohReply() = default;
 
   const zenoh::Reply & get_sample() const;
 
@@ -54,7 +54,7 @@ class ZenohQuery final
 public:
   ZenohQuery(const zenoh::Query & query, std::chrono::nanoseconds::rep received_timestamp);
 
-  ~ZenohQuery();
+  ~ZenohQuery() = default;
 
   const zenoh::Query & get_query() const;
 


### PR DESCRIPTION
Closes https://github.com/ZettaScaleLabs/rmw_zenoh/issues/53.

The lack of destruction of `ZenohQuery` and `ZenohReply` leads to a memory leak. Furthermore, a drop of zenoh query/reply can trigger sending the final signal to the remote.

No regression was found on the usual test checks like system_tests, rcl, rclcpp, etc.