### PR TITLE
Use rustup dependency instead of cargo

### DIFF
--- a/zenoh_cpp_vendor/package.xml
+++ b/zenoh_cpp_vendor/package.xml
@@ -10,7 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_vendor_package</buildtool_depend>
 
-  <build_depend>cargo</build_depend>
+  <build_depend>rustup</build_depend>
   <build_depend>clang</build_depend>
   <build_depend>git</build_depend>
 


### PR DESCRIPTION
Depends on https://github.com/eclipse-zenoh/zenoh/pull/1803 and https://github.com/ros/rosdistro/pull/44640.

Once they are merged, the [commit id](https://github.com/ros2/rmw_zenoh/blob/4fc36b75606911c2bbd2467667827f04edc7254f/zenoh_cpp_vendor/CMakeLists.txt#L29) of zenoh-c and zenoh-cpp should be updated.  