### PR TITLE
Fail creation of entities if qos contains unknown settings

### DIFF
--- a/rmw_zenoh_cpp/src/detail/qos.cpp
+++ b/rmw_zenoh_cpp/src/detail/qos.cpp
@@ -74,7 +74,6 @@ bool QoS::is_supported(const rmw_qos_profile_t & qos_profile)
   return true;
 }
 
-
 ///=============================================================================
 rmw_ret_t QoS::best_available_qos(
   const rmw_node_t * node,

--- a/rmw_zenoh_cpp/src/detail/qos.cpp
+++ b/rmw_zenoh_cpp/src/detail/qos.cpp
@@ -61,6 +61,20 @@ const rmw_qos_profile_t & QoS::default_qos() const
 }
 
 ///=============================================================================
+bool QoS::is_supported(const rmw_qos_profile_t & qos_profile)
+{
+  if (qos_profile.history == RMW_QOS_POLICY_HISTORY_UNKNOWN ||
+    qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_UNKNOWN ||
+    qos_profile.durability == RMW_QOS_POLICY_DURABILITY_UNKNOWN ||
+    qos_profile.liveliness == RMW_QOS_POLICY_LIVELINESS_UNKNOWN) {
+      return false;
+    }
+
+  return true;
+}
+
+
+///=============================================================================
 rmw_ret_t QoS::best_available_qos(
   const rmw_node_t * node,
   const char * topic_name,
@@ -77,6 +91,10 @@ rmw_ret_t QoS::best_available_qos(
   static_cast<void>(node);
   static_cast<void>(topic_name);
   static_cast<void>(get_endpoint_info_for_other);
+
+  if (!is_supported(*qos_profile)) {
+    return RMW_RET_UNSUPPORTED;
+  }
 
   switch (qos_profile->history) {
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:

--- a/rmw_zenoh_cpp/src/detail/qos.cpp
+++ b/rmw_zenoh_cpp/src/detail/qos.cpp
@@ -66,9 +66,10 @@ bool QoS::is_supported(const rmw_qos_profile_t & qos_profile)
   if (qos_profile.history == RMW_QOS_POLICY_HISTORY_UNKNOWN ||
     qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_UNKNOWN ||
     qos_profile.durability == RMW_QOS_POLICY_DURABILITY_UNKNOWN ||
-    qos_profile.liveliness == RMW_QOS_POLICY_LIVELINESS_UNKNOWN) {
-      return false;
-    }
+    qos_profile.liveliness == RMW_QOS_POLICY_LIVELINESS_UNKNOWN)
+  {
+    return false;
+  }
 
   return true;
 }

--- a/rmw_zenoh_cpp/src/detail/qos.hpp
+++ b/rmw_zenoh_cpp/src/detail/qos.hpp
@@ -40,6 +40,9 @@ public:
 
   const rmw_qos_profile_t & default_qos() const;
 
+  /// Returns true if the qos profile is supported by rmw_zenoh.
+  static bool is_supported(const rmw_qos_profile_t & qos_profile);
+
   rmw_ret_t best_available_qos(
     const rmw_node_t * node,
     const char * topic_name,

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -779,6 +779,9 @@ rmw_publisher_wait_for_all_acked(
   const rmw_publisher_t * publisher,
   rmw_time_t wait_timeout)
 {
+  RMW_CHECK_FOR_NULL_WITH_MSG(
+    publisher, "publisher handle is null",
+    return RMW_RET_INVALID_ARGUMENT);
   static_cast<void>(publisher);
   static_cast<void>(wait_timeout);
 


### PR DESCRIPTION
Partially addresses some of the failing tests in #481, Specifically those that expect creation of pub/sub/client/service to fail if the qos profile has unknown settings. The changes here make test_service__rmw_zenoh_cpp pass.

This works because QoS::get().best_available_qos() is invoked within all make() functions of these entities which will now return nullptr if qos_profile contains unknown settings.