### PR TITLE
Fix calculation of current_count_change when event status is updated

### DIFF
--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -187,7 +187,7 @@ void EventsManager::update_event_status(
     status_to_update.total_count += std::max(0, current_count_change);
     status_to_update.total_count_change += std::max(0, current_count_change);
     status_to_update.current_count += current_count_change;
-    status_to_update.current_count_change = current_count_change;
+    status_to_update.current_count_change += current_count_change;
     status_to_update.changed = true;
   }
 


### PR DESCRIPTION
This PR fixes `test_rmw_implementation/test_event__rmw_zenoh_cpp`

Usual CI is passing with the usual flakes.