### PR TITLE
Ignore local publications if specified

### DIFF
--- a/rmw_zenoh_cpp/src/detail/attachment_helpers.hpp
+++ b/rmw_zenoh_cpp/src/detail/attachment_helpers.hpp
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <cstdint>
+#include <string>
 
 #include <zenoh.hxx>
 
@@ -28,10 +29,16 @@ namespace rmw_zenoh_cpp
 class AttachmentData final
 {
 public:
+  /// @brief Constructor.
+  /// @param sequence_number A monotonically increasing count.
+  /// @param source_timestamp The time when the attachment was originally created.
+  /// @param source_gid GID of the entity that originally created this attachment.
+  /// @param zid The zenoh session id of the entity that originally created this attachment.
   AttachmentData(
     const int64_t sequence_number,
     const int64_t source_timestamp,
-    const std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid);
+    const std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid,
+    const std::string & zid);
 
   explicit AttachmentData(const zenoh::Bytes & bytes);
   explicit AttachmentData(AttachmentData && data);
@@ -39,6 +46,7 @@ public:
   int64_t sequence_number() const;
   int64_t source_timestamp() const;
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
+  std::string zid() const;
 
   zenoh::Bytes serialize_to_zbytes();
 
@@ -46,6 +54,7 @@ private:
   int64_t sequence_number_;
   int64_t source_timestamp_;
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> source_gid_;
+  std::string zid_;
 };
 }  // namespace rmw_zenoh_cpp
 

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -374,7 +374,10 @@ rmw_ret_t ClientData::send_request(
   zenoh::Session::GetOptions opts = zenoh::Session::GetOptions::create_default();
   int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   opts.attachment = rmw_zenoh_cpp::AttachmentData(
-    *sequence_id, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
+    *sequence_id,
+    source_timestamp,
+    entity_->copy_gid(),
+    entity_->zid()).serialize_to_zbytes();
   opts.target = Z_QUERY_TARGET_ALL_COMPLETE;
   // The default timeout for a z_get query is 10 seconds and if a response is not received within
   // this window, the queryable will return an invalid reply. However, it is common for actions,

--- a/rmw_zenoh_cpp/src/detail/rmw_node_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_node_data.cpp
@@ -190,7 +190,8 @@ bool NodeData::create_sub_data(
   std::size_t id,
   const std::string & topic_name,
   const rosidl_message_type_support_t * type_support,
-  const rmw_qos_profile_t * qos_profile)
+  const rmw_qos_profile_t * qos_profile,
+  const rmw_subscription_options_t & sub_options)
 {
   std::lock_guard<std::recursive_mutex> lock_guard(mutex_);
   if (is_shutdown_) {
@@ -216,7 +217,8 @@ bool NodeData::create_sub_data(
     std::move(id),
     std::move(topic_name),
     type_support,
-    qos_profile);
+    qos_profile,
+    sub_options);
   if (sub_data == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",

--- a/rmw_zenoh_cpp/src/detail/rmw_node_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_node_data.hpp
@@ -75,7 +75,8 @@ public:
     std::size_t id,
     const std::string & topic_name,
     const rosidl_message_type_support_t * type_support,
-    const rmw_qos_profile_t * qos_profile);
+    const rmw_qos_profile_t * qos_profile,
+    const rmw_subscription_options_t & sub_options);
 
   // Retrieve the SubscriptionData for a given rmw_subscription_t if present.
   SubscriptionDataPtr get_sub_data(const rmw_subscription_t * const subscription);

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -249,7 +249,10 @@ rmw_ret_t PublisherData::publish(
   int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   auto opts = zenoh::ext::AdvancedPublisher::PutOptions::create_default();
   opts.put_options.attachment = rmw_zenoh_cpp::AttachmentData(
-    sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
+    sequence_number_++,
+    source_timestamp,
+    entity_->copy_gid(),
+    entity_->zid()).serialize_to_zbytes();
 
   // TODO(ahcorde): shmbuf
   std::vector<uint8_t> raw_data(
@@ -297,7 +300,10 @@ rmw_ret_t PublisherData::publish_serialized_message(
   int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   auto opts = zenoh::ext::AdvancedPublisher::PutOptions::create_default();
   opts.put_options.attachment = rmw_zenoh_cpp::AttachmentData(
-    sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
+    sequence_number_++,
+    source_timestamp,
+    entity_->copy_gid(),
+    entity_->zid()).serialize_to_zbytes();
 
   std::vector<uint8_t> raw_data(
     serialized_message->buffer,

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -443,7 +443,10 @@ rmw_ret_t ServiceData::send_response(
   memcpy(writer_gid.data(), request_id->writer_guid, RMW_GID_STORAGE_SIZE);
   int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   options.attachment = rmw_zenoh_cpp::AttachmentData(
-    request_id->sequence_number, source_timestamp, writer_gid).serialize_to_zbytes();
+    request_id->sequence_number,
+    source_timestamp,
+    writer_gid,
+    entity_->zid()).serialize_to_zbytes();
 
   std::vector<uint8_t> raw_bytes(
     reinterpret_cast<const uint8_t *>(response_bytes),

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -71,7 +71,8 @@ public:
     std::size_t Subscription_id,
     const std::string & topic_name,
     const rosidl_message_type_support_t * type_support,
-    const rmw_qos_profile_t * qos_profile);
+    const rmw_qos_profile_t * qos_profile,
+    const rmw_subscription_options_t & sub_options);
 
   // Get a copy of the keyexpr_hash of this SubscriptionData's liveliness::Entity.
   std::size_t keyexpr_hash() const;
@@ -124,7 +125,8 @@ private:
     std::shared_ptr<liveliness::Entity> entity,
     std::shared_ptr<zenoh::Session> session,
     const void * type_support_impl,
-    std::unique_ptr<MessageTypeSupport> type_support);
+    std::unique_ptr<MessageTypeSupport> type_support,
+    rmw_subscription_options_t sub_options);
 
   bool init();
 
@@ -145,6 +147,8 @@ private:
   // Type support fields
   const void * type_support_impl_;
   std::unique_ptr<MessageTypeSupport> type_support_;
+  // Subscription options.
+  rmw_subscription_options_t sub_options_;
   std::deque<std::unique_ptr<Message>> message_queue_;
   // Map GID of a subscription to the sequence number of the message it published.
   std::unordered_map<size_t, int64_t> last_known_published_msg_;

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -985,7 +985,8 @@ rmw_create_subscription(
       context_impl->get_next_entity_id(),
       topic_name,
       type_support,
-      qos_profile))
+      qos_profile,
+      *subscription_options))
   {
     // Error already handled.
     return nullptr;


### PR DESCRIPTION
Fix #496 

This PR
- Updates `AttachmentData` to also store the zenoh session id (zid) of the entity creating the attachment.
- Updates publishers (and other entities) to append their `zid` to the attachment they fill in.
- Updates the `SubscriptionData` to accept `rmw_subscriptions_options_t`
-  Updates the sample cb in `SubscriptionData` to ignore any received samples with an attachment having zid matching the zid of the subscription if `ignore_local_publications` is set to `true`.