### PR TITLE
fix: unlock the mutex before making get

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -394,6 +394,7 @@ rmw_ret_t ClientData::send_request(
   std::weak_ptr<rmw_zenoh_cpp::ClientData> client_data = shared_from_this();
   zenoh::ZResult result;
   std::string parameters;
+  mutex_.unlock();
   context_impl->session()->get(
     keyexpr_.value(),
     parameters,


### PR DESCRIPTION
This PR aims to tackle #484. The validation on the ros2 tests will be attached later.