### PR TITLE
fix: to avoid the copy

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -770,7 +770,7 @@ rmw_ret_t fill_names_and_types(
     });
   // Fill topic names and types.
   std::size_t index = 0;
-  for (const std::pair<std::string, GraphNode::TopicTypeMap> & item : entity_map) {
+  for (const std::pair<const std::string, GraphNode::TopicTypeMap> & item : entity_map) {
     names_and_types->names.data[index] = rcutils_strdup(item.first.c_str(), *allocator);
     if (!names_and_types->names.data[index]) {
       return RMW_RET_BAD_ALLOC;


### PR DESCRIPTION
To address the warning in #546.


```console
--- stderr: rmw_zenoh_cpp
/workspace/ws-whole-rolling/src/rmw_zenoh/rmw_zenoh_cpp/src/detail/graph_cache.cpp: In function ‘rmw_ret_t rmw_zenoh_cpp::{anonymous}::fill_names_and_types(const rmw_zenoh_cpp::GraphNode::TopicMap&, rcutils_allocator_t*, rmw_names_and_types_t*)’:
/workspace/ws-whole-rolling/src/rmw_zenoh/rmw_zenoh_cpp/src/detail/graph_cache.cpp:773:64: warning: loop variable ‘item’ of type ‘const std::pair<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::shared_ptr<rmw_zenoh_cpp::TopicData> > > >&’ binds to a temporary constructed from type ‘const std::pair<const std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::shared_ptr<rmw_zenoh_cpp::TopicData> > > >’ [-Wrange-loop-construct]
  773 |   for (const std::pair<std::string, GraphNode::TopicTypeMap> & item : entity_map) {
      |                                                                ^~~~
/workspace/ws-whole-rolling/src/rmw_zenoh/rmw_zenoh_cpp/src/detail/graph_cache.cpp:773:64: note: use non-reference type ‘const std::pair<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::shared_ptr<rmw_zenoh_cpp::TopicData> > > >’ to make the copy explicit or ‘const std::pair<const std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::unordered_map<std::__cxx11::basic_string<char>, std::shared_ptr<rmw_zenoh_cpp::TopicData> > > >&’ to prevent copying
---
```
