### PR TITLE
feat: support zenoh config override

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,28 @@ For example, to set the path to a custom `Zenoh router` configuration file,
 export ZENOH_ROUTER_CONFIG_URI=$HOME/MY_ZENOH_ROUTER_CONFIG.json5
 ```
 
+`rmw_zenoh` allows you to override configuration fields using the `ZENOH_CONFIG_OVERRIDE` environment variable .
+These overrides apply to ROS2 nodes and the Zenoh router **after** the `ZENOH_SESSION_CONFIG_URI` or `ZENOH_ROUTER_CONFIG_URI` (if specified)
+has been processed.
+
+You can specify multiple key-value pairs using the following syntax:
+```bash
+export ZENOH_CONFIG_OVERRIDE="key/path/to/field1=value1;key/path/to/field2=value2"
+```
+
+#### Examples
+
+- Specify custom endpoints for listening and connecting:
+```bash
+export ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7448"];connect/endpoints=["tcp/192.168.0.1:7449", "tcp/192.168.0.2:7449"]'
+```
+This configuration sets the node to listen on
+
+- Enable multicast scouting (disabled by default) that allows ROS2 nodes to discover each other without requiring a Zenoh router:
+```bash
+export ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=true'
+```
+
 ### Connecting multiple hosts
 By default, all discovery & communication is restricted within a host, where a host is a machine running a `Zenoh router` along with various ROS 2 nodes with their default [configurations](rmw_zenoh_cpp/config/).
 To bridge communications across two or more hosts, the `Zenoh router` configuration for one of the hosts must be updated to connect to the other host's `Zenoh router` at startup.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ export ZENOH_ROUTER_CONFIG_URI=$HOME/MY_ZENOH_ROUTER_CONFIG.json5
 ```
 
 `rmw_zenoh` allows you to override configuration fields using the `ZENOH_CONFIG_OVERRIDE` environment variable .
-These overrides apply to ROS2 nodes and the Zenoh router **after** the `ZENOH_SESSION_CONFIG_URI` or `ZENOH_ROUTER_CONFIG_URI` (if specified)
+These overrides apply to ROS 2 nodes and the Zenoh router **after** the `ZENOH_SESSION_CONFIG_URI` or `ZENOH_ROUTER_CONFIG_URI` (if specified)
 has been processed.
 
 You can specify multiple key-value pairs using the following syntax:

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -17,6 +17,7 @@
 #include <rcutils/env.h>
 
 #include <limits>
+#include <sstream>
 #include <string>
 
 #include <zenoh.hxx>

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -44,8 +44,8 @@ static const std::unordered_map<ConfigurableEntity,
 
 static const char * router_check_attempts_envar = "ZENOH_ROUTER_CHECK_ATTEMPTS";
 /// Allow users to override the configuration using key-value pairs.
-/// The supporting syntax is "key1=value2;key2=value2;...".
-/// For example, ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7448"];scouting/multicast/enabled=true'
+/// The supporting syntax is "key1=value2;key2=value2;...". For instance,
+/// ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7448"];scouting/multicast/enabled=true'
 static const char * zenoh_config_override = "ZENOH_CONFIG_OVERRIDE";
 
 std::optional<zenoh::Config> _get_z_config(

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -79,8 +79,8 @@ std::optional<zenoh::Config> _get_z_config(
   if (NULL != rcutils_get_env(zenoh_config_override, &key_val_pairs_str)) {
     // NULL is returned if everything is ok.
     RMW_ZENOH_LOG_ERROR_NAMED(
-      "rmw_zenoh_cpp", "Envar %s cannot be read.", zenoh_config_override);
-    return std::nullopt;
+    "rmw_zenoh_cpp", "Envar %s cannot be read. Ignoring override...", zenoh_config_override);
+    return config;
   }
   if (key_val_pairs_str[0] != '\0') {
     std::stringstream ss(key_val_pairs_str);
@@ -91,10 +91,9 @@ std::optional<zenoh::Config> _get_z_config(
       if (std::getline(pair_stream, key, '=') && std::getline(pair_stream, val)) {
         config.insert_json5(key, val, &result);
         if (result != Z_OK) {
-          RMW_ZENOH_LOG_ERROR_NAMED(
+          RMW_ZENOH_LOG_WARN_NAMED(
             "rmw_zenoh_cpp",
-            "Invalid configuration key/value pair: (%s, %s)", key.c_str(), val.c_str());
-          return std::nullopt;
+            "Ignore the invalid configuration key-value pair: (%s, %s)", key.c_str(), val.c_str());
         }
       }
     }

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -43,6 +43,10 @@ static const std::unordered_map<ConfigurableEntity,
 };
 
 static const char * router_check_attempts_envar = "ZENOH_ROUTER_CHECK_ATTEMPTS";
+/// Allow users to override the configuration using key-value pairs.
+/// The supporting syntax is "key1=value2;key2=value2;...".
+/// For example, ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7448"];scouting/multicast/enabled=true'
+static const char * zenoh_config_override = "ZENOH_CONFIG_OVERRIDE";
 
 std::optional<zenoh::Config> _get_z_config(
   const char * envar_name,
@@ -69,6 +73,34 @@ std::optional<zenoh::Config> _get_z_config(
       "Invalid configuration file %s", configured_uri);
     return std::nullopt;
   }
+
+  // Override the zenoh config by key/value pairs.
+  const char * key_val_pairs_str;
+  if (NULL != rcutils_get_env(zenoh_config_override, &key_val_pairs_str)) {
+    // NULL is returned if everything is ok.
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp", "Envar %s cannot be read.", zenoh_config_override);
+    return std::nullopt;
+  }
+  if (key_val_pairs_str[0] != '\0') {
+    std::stringstream ss(key_val_pairs_str);
+    std::string pair;
+    while (std::getline(ss, pair, ';')) {
+      std::stringstream pair_stream(pair);
+      std::string key, val;
+      if (std::getline(pair_stream, key, '=') && std::getline(pair_stream, val)) {
+        std::cout << "[DBG] " << key << " = " << val << std::endl;
+        config.insert_json5(key, val, &result);
+        if (result != Z_OK) {
+          RMW_ZENOH_LOG_ERROR_NAMED(
+            "rmw_zenoh_cpp",
+            "Invalid configuration key/value pair: (%s, %s)", key.c_str(), val.c_str());
+          return std::nullopt;
+        }
+      }
+    }
+  }
+
   RMW_ZENOH_LOG_DEBUG_NAMED(
     "rmw_zenoh_cpp",
     "configured using configuration file %s", configured_uri);

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -89,7 +89,6 @@ std::optional<zenoh::Config> _get_z_config(
       std::stringstream pair_stream(pair);
       std::string key, val;
       if (std::getline(pair_stream, key, '=') && std::getline(pair_stream, val)) {
-        std::cout << "[DBG] " << key << " = " << val << std::endl;
         config.insert_json5(key, val, &result);
         if (result != Z_OK) {
           RMW_ZENOH_LOG_ERROR_NAMED(


### PR DESCRIPTION
This PR allows users to override the zenoh config via an environmental variable. 

For instance, we can easily change the port of ros2 nodes and the zenohd as below.

```bash
export ZENOH_CONFIG_OVERRIDE='connect/endpoints=["tcp/127.0.0.1:7448"]'
ros2 run demo_nodes_cpp listener

export ZENOH_CONFIG_OVERRIDE='listen/endpoints=["tcp/127.0.0.1:7448"]'
ros2 run rmw_zenoh_cpp rmw_zenohd
``` 

Enable multicast scouting without a zenohd router temporarily.
```bash
export ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=true'
ros2 run demo_nodes_cpp listener

export ZENOH_CONFIG_OVERRIDE='scouting/multicast/enabled=true'
ros2 run demo_nodes_cpp talker
```

Multiple key-value pairs are also supported through the syntax `ZENOH_CONFIG_OVERRIDE='k1=v1;k2=v2;...'`.
The config generation order is `ZENOH_CONFIG_URI` and then apply `ZENOH_CONFIG_OVERRIDE`.

