### PR TITLE
fix: use `std::unique_lock` to unlock correctly on Windows

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -322,7 +322,7 @@ rmw_ret_t ClientData::send_request(
   const void * ros_request,
   int64_t * sequence_id)
 {
-  std::lock_guard<std::recursive_mutex> lock(mutex_);
+  std::unique_lock<std::recursive_mutex> lock(mutex_);
   if (is_shutdown_) {
     return RMW_RET_OK;
   }
@@ -396,7 +396,7 @@ rmw_ret_t ClientData::send_request(
   std::string parameters;
   // We explicitly release the mutex here to avoid an ABBA deadlock as
   // documented in https://github.com/ros2/rmw_zenoh/issues/484.
-  mutex_.unlock();
+  lock.unlock();
   context_impl->session()->get(
     keyexpr_.value(),
     parameters,


### PR DESCRIPTION
Closes #564.
