### PR TITLE
document silent message dropping between humble and jazzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,6 @@ Note that composable nodes should *never* call `rclcpp::shutdown()`, as the comp
 
 For more details, see https://github.com/ros2/rmw_zenoh/issues/170.
 
-### Distros earlier than Iron (e.g. Humble) are incompatible with Jazzy and later.
+### rmw_zenoh is incompatible between Humble and newer distributions. 
 
 Since Iron, ROS 2 uses type hashes which means that messaging between Humble and later versions of ROS 2 [is not possible](https://github.com/ros2/rmw_zenoh/issues/425). Node and topic discovery will work, but messages [will be silently dropped](https://github.com/ros2/rmw_zenoh/issues/569).

--- a/README.md
+++ b/README.md
@@ -220,3 +220,7 @@ One way to ensure this is to call `rclcpp::shutdown()` when the program exits.
 Note that composable nodes should *never* call `rclcpp::shutdown()`, as the composable node container will automatically do this.
 
 For more details, see https://github.com/ros2/rmw_zenoh/issues/170.
+
+### Distros earlier than Iron (e.g. Humble) are incompatible with Jazzy and later.
+
+Since Iron, ROS 2 uses type hashes which means that messaging between Humble and later versions of ROS 2 [is not possible](https://github.com/ros2/rmw_zenoh/issues/425). Node and topic discovery will work, but messages [will be silently dropped](https://github.com/ros2/rmw_zenoh/issues/569).

--- a/README.md
+++ b/README.md
@@ -223,4 +223,6 @@ For more details, see https://github.com/ros2/rmw_zenoh/issues/170.
 
 ### rmw_zenoh is incompatible between Humble and newer distributions. 
 
-Since Iron, ROS 2 uses type hashes which means that messaging between Humble and later versions of ROS 2 [is not possible](https://github.com/ros2/rmw_zenoh/issues/425). Node and topic discovery will work, but messages [will be silently dropped](https://github.com/ros2/rmw_zenoh/issues/569).
+Since Iron, ROS 2 introduced type hashes for messages and `rmw_zenoh` includes these type hashes in the Zenoh keyexpressions it constructs for data exchange. While participants will be discoverable, communication between Humble and newer distributions will fail, resulting in messages being silently dropped.
+
+For more details, see https://github.com/ros2/rmw_zenoh/issues/569.


### PR DESCRIPTION
This PR documents the know issue of messages being silently dropped when attempting to communicate between Humble and Jazzy/Rolling.
See issues #425 and #569.