### PR TITLE
Implement rmw_test_fixture to start the Zenoh router

### DIFF
--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(rcutils REQUIRED)
 find_package(rosidl_typesupport_fastrtps_c REQUIRED)
 find_package(rosidl_typesupport_fastrtps_cpp REQUIRED)
 find_package(rmw REQUIRED)
+find_package(rmw_test_fixture REQUIRED)
 find_package(tracetools REQUIRED)
 find_package(zenoh_cpp_vendor REQUIRED)
 
@@ -81,6 +82,20 @@ target_compile_definitions(rmw_zenoh_cpp
     RMW_VERSION_PATCH=${rmw_VERSION_PATCH}
 )
 
+add_library(rmw_zenoh_cpp_test_fixture SHARED
+  src/detail/logging.cpp
+  src/detail/zenoh_config.cpp
+  src/rmw_test_fixture.cpp
+)
+
+target_link_libraries(rmw_zenoh_cpp_test_fixture
+  PRIVATE
+    ament_index_cpp::ament_index_cpp
+    rcpputils::rcpputils
+    rmw_test_fixture::rmw_test_fixture
+    zenohcxx::zenohc
+)
+
 ament_export_targets(export_rmw_zenoh_cpp)
 
 register_rmw_implementation(
@@ -102,7 +117,7 @@ if(BUILD_TESTING)
 endif()
 
 install(
-  TARGETS rmw_zenoh_cpp
+  TARGETS rmw_zenoh_cpp rmw_zenoh_cpp_test_fixture
   EXPORT export_rmw_zenoh_cpp
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -89,6 +89,10 @@ add_library(rmw_zenoh_cpp_test_fixture SHARED
   src/rmw_test_fixture.cpp
 )
 
+target_compile_definitions(rmw_zenoh_cpp_test_fixture PRIVATE
+  RMW_TEST_FIXTURE_BUILDING_DLL
+)
+
 target_link_libraries(rmw_zenoh_cpp_test_fixture
   PRIVATE
     ament_index_cpp::ament_index_cpp

--- a/rmw_zenoh_cpp/CMakeLists.txt
+++ b/rmw_zenoh_cpp/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(ament_cmake REQUIRED)
 
 find_package(ament_index_cpp REQUIRED)
 find_package(fastcdr CONFIG REQUIRED)
+find_package(nlohmann_json REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosidl_typesupport_fastrtps_c REQUIRED)
@@ -91,6 +92,7 @@ add_library(rmw_zenoh_cpp_test_fixture SHARED
 target_link_libraries(rmw_zenoh_cpp_test_fixture
   PRIVATE
     ament_index_cpp::ament_index_cpp
+    nlohmann_json::nlohmann_json
     rcpputils::rcpputils
     rmw_test_fixture::rmw_test_fixture
     zenohcxx::zenohc

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -14,6 +14,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <build_depend>nlohmann-json-dev</build_depend>
   <build_depend>zenoh_cpp_vendor</build_depend>
   <build_export_depend>zenoh_cpp_vendor</build_export_depend>
 

--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -24,12 +24,14 @@
   <depend>rosidl_typesupport_fastrtps_c</depend>
   <depend>rosidl_typesupport_fastrtps_cpp</depend>
   <depend>rmw</depend>
+  <depend>rmw_test_fixture</depend>
   <depend>tracetools</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
   <member_of_group>rmw_implementation_packages</member_of_group>
+  <member_of_group>rmw_test_fixture_implementation_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -15,8 +15,11 @@
 #include <rmw_test_fixture/rmw_test_fixture.h>
 
 #include <cstdlib>
+#include <iostream>
 #include <memory>
 #include <sstream>
+#include <string>
+#include <utility>
 
 #include <nlohmann/json.hpp>
 #include <rcpputils/env.hpp>
@@ -28,22 +31,55 @@
 static std::unique_ptr<zenoh::Session> g_session = nullptr;
 
 static
-std::string
+std::optional<std::string>
 get_endpoints(zenoh::Session & session)
 {
-  auto zid = session.get_zid();
-  auto keyexpr = zenoh::KeyExpr("@/" + zid.to_string() + "/router");
-  auto replies = session.get(keyexpr, "", zenoh::channels::FifoChannel(2));
+  const zenoh::Id zid = session.get_zid();
+  const zenoh::KeyExpr keyexpr("@/" + zid.to_string() + "/router");
 
-  auto reply = replies.recv();
-  const auto & sample = std::get<zenoh::Reply>(reply).get_ok();
-  auto parsed = nlohmann::json::parse(sample.get_payload().as_string());
+  zenoh::ZResult result;
+  const zenoh::channels::FifoChannel::HandlerType<zenoh::Reply> replies = session.get(
+    keyexpr,
+    "",
+    zenoh::channels::FifoChannel(2),
+    zenoh::Session::GetOptions::create_default(),
+    &result);
+  if (Z_OK != result) {
+    std::cerr << "Error calling get over keyexpr "
+              << std::string(keyexpr.as_string_view()) << std::endl;
+    return std::nullopt;
+  }
+
+  const std::variant<zenoh::Reply, zenoh::channels::RecvError> reply = replies.recv();
+  const zenoh::Sample & sample = std::get<zenoh::Reply>(reply).get_ok();
+  nlohmann::json parsed;
+
+  try {
+    parsed = nlohmann::json::parse(sample.get_payload().as_string());
+  } catch (nlohmann::json::exception & e) {
+    std::cerr << "Failed to parse admin space response: " << e.what() << std::endl;
+    return std::nullopt;
+  }
 
   return parsed["locators"].dump();
 }
 
 extern "C"
 {
+/// Isolate Zenoh communication using an ad-hoc router
+/**
+ * This fixture creates a new Zenoh router on a random unused port number for
+ * use by the current process. The router does not connect to other routers,
+ * but does respect other Zenoh configurations provided by configuration files
+ * and environment variables.
+ *
+ * After calling this function, the ZENOH_CONFIG_OVERRIDE environment variable
+ * for this process will configure Zenoh to use the ad-hoc router using the
+ * `connect/endpoints` configuration key, which is populated from the
+ * `listen/endpoints` configuration of the router.
+ *
+ * Calling `rmw_test_isolation_stop()` will gracefully shut down the router.
+ */
 rmw_ret_t
 rmw_test_isolation_start()
 {
@@ -80,9 +116,13 @@ rmw_test_isolation_start()
     return RMW_RET_ERROR;
   }
 
-  std::string endpoints = get_endpoints(*g_session);
+  std::optional<std::string> endpoints = get_endpoints(*g_session);
+  if (!endpoints.has_value()) {
+    // Error already logged.
+    return RMW_RET_ERROR;
+  }
 
-  std::string config_override = "connect/endpoints=" + endpoints;
+  std::string config_override = "connect/endpoints=" + endpoints.value();
   if (!rcpputils::set_env_var(
       "ZENOH_CONFIG_OVERRIDE",
       config_override.c_str()))

--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -107,6 +107,12 @@ rmw_test_isolation_start()
     return RMW_RET_ERROR;
   }
 
+  config->insert_json5("scouting/multicast/enabled", "false", &result);
+  if (result != Z_OK) {
+    std::cerr << "Error setting router multicast disabled" << std::endl;
+    return RMW_RET_ERROR;
+  }
+
   g_session = std::make_unique<zenoh::Session>(
     std::move(config.value()),
     zenoh::Session::SessionOptions::create_default(),

--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -18,6 +18,7 @@
 #include <memory>
 #include <sstream>
 
+#include <nlohmann/json.hpp>
 #include <rcpputils/env.hpp>
 #include <zenoh.hxx>
 #include <zenoh/api/session.hxx>
@@ -26,19 +27,26 @@
 
 static std::unique_ptr<zenoh::Session> g_session = nullptr;
 
+static
+std::string
+get_endpoints(zenoh::Session & session)
+{
+  auto zid = session.get_zid();
+  auto keyexpr = zenoh::KeyExpr("@/" + zid.to_string() + "/router");
+  auto replies = session.get(keyexpr, "", zenoh::channels::FifoChannel(2));
+
+  auto reply = replies.recv();
+  const auto & sample = std::get<zenoh::Reply>(reply).get_ok();
+  auto parsed = nlohmann::json::parse(sample.get_payload().as_string());
+
+  return parsed["locators"].dump();
+}
+
 extern "C"
 {
 rmw_ret_t
 rmw_test_isolation_start()
 {
-  // TODO(cottsay): Utility function to allocate a port number using the same
-  //       mechanism as domain_coordinator does in Python.
-  unsigned int seed = time(NULL);
-  unsigned int port = 32768 + (rand_r(&seed) % 32768);
-  std::ostringstream ss;
-  ss << "[\"tcp/127.0.0.1:" << port << "\"]";
-  std::string router_endpoint_config = ss.str();
-
   zenoh::ZResult result;
 
   zenoh::try_init_log_from_env();
@@ -51,7 +59,7 @@ rmw_test_isolation_start()
     return RMW_RET_ERROR;
   }
 
-  config->insert_json5("listen/endpoints", router_endpoint_config, &result);
+  config->insert_json5("listen/endpoints", "[\"tcp/127.0.0.1:0\"]", &result);
   if (result != Z_OK) {
     std::cerr << "Error setting router endpoint" << std::endl;
     return RMW_RET_ERROR;
@@ -66,7 +74,9 @@ rmw_test_isolation_start()
     return RMW_RET_ERROR;
   }
 
-  std::string config_override = "connect/endpoints=" + router_endpoint_config;
+  std::string endpoints = get_endpoints(*g_session);
+
+  std::string config_override = "connect/endpoints=" + endpoints;
   if (!rcpputils::set_env_var(
       "ZENOH_CONFIG_OVERRIDE",
       config_override.c_str()))

--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -65,6 +65,12 @@ rmw_test_isolation_start()
     return RMW_RET_ERROR;
   }
 
+  config->insert_json5("connect/endpoints", "[]", &result);
+  if (result != Z_OK) {
+    std::cerr << "Error setting router connect endpoints" << std::endl;
+    return RMW_RET_ERROR;
+  }
+
   g_session = std::make_unique<zenoh::Session>(
     std::move(config.value()),
     zenoh::Session::SessionOptions::create_default(),

--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -1,0 +1,95 @@
+// Copyright 2025 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rmw_test_fixture/rmw_test_fixture.h>
+
+#include <cstdlib>
+#include <memory>
+#include <sstream>
+
+#include <rcpputils/env.hpp>
+#include <zenoh.hxx>
+#include <zenoh/api/session.hxx>
+
+#include "detail/zenoh_config.hpp"
+
+static std::unique_ptr<zenoh::Session> g_session = nullptr;
+
+extern "C"
+{
+rmw_ret_t
+rmw_test_isolation_start()
+{
+  // TODO(cottsay): Utility function to allocate a port number using the same
+  //       mechanism as domain_coordinator does in Python.
+  unsigned int seed = time(NULL);
+  unsigned int port = 32768 + (rand_r(&seed) % 32768);
+  std::ostringstream ss;
+  ss << "[\"tcp/127.0.0.1:" << port << "\"]";
+  std::string router_endpoint_config = ss.str();
+
+  zenoh::ZResult result;
+
+  zenoh::try_init_log_from_env();
+
+  std::optional<zenoh::Config> config = rmw_zenoh_cpp::get_z_config(
+    rmw_zenoh_cpp::ConfigurableEntity::Router);
+
+  if (!config.has_value()) {
+    std::cerr << "Error configuring Zenoh router." << std::endl;
+    return RMW_RET_ERROR;
+  }
+
+  config->insert_json5("listen/endpoints", router_endpoint_config, &result);
+  if (result != Z_OK) {
+    std::cerr << "Error setting router endpoint" << std::endl;
+    return RMW_RET_ERROR;
+  }
+
+  g_session = std::make_unique<zenoh::Session>(
+    std::move(config.value()),
+    zenoh::Session::SessionOptions::create_default(),
+    &result);
+  if (result != Z_OK) {
+    std::cerr << "Error opening Session!" << std::endl;
+    return RMW_RET_ERROR;
+  }
+
+  std::string config_override = "connect/endpoints=" + router_endpoint_config;
+  if (!rcpputils::set_env_var(
+      "ZENOH_CONFIG_OVERRIDE",
+      config_override.c_str()))
+  {
+    std::cerr << "Failed to set ZENOH_CONFIG_OVERRIDE" << std::endl;
+    g_session->close();
+    g_session.reset();
+    return RMW_RET_ERROR;
+  }
+
+  return RMW_RET_OK;
+}
+
+rmw_ret_t
+rmw_test_isolation_stop()
+{
+  rcpputils::set_env_var("ZENOH_CONFIG_OVERRIDE", nullptr);
+
+  if(g_session) {
+    g_session->close();
+    g_session.reset();
+  }
+
+  return RMW_RET_OK;
+}
+}


### PR DESCRIPTION
It would probably be a good idea to merge the changes to `ZENOH_CONFIG_OVERRIDE` with any existing values, and also to restore the original state when the fixture stops.

Requires:
- ros2/ament_cmake_ros#21
- ros2/ros2#1666
- ros2/ci#810