### PR TITLE
Trigger qos event callback if there are changes before registration 

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1173,7 +1173,7 @@ rmw_ret_t GraphCache::service_server_is_available(
 
 ///=============================================================================
 void GraphCache::set_qos_event_callback(
-  std::size_t entity_keyexpr_hash,
+  std::size_t entity_gid_hash,
   const rmw_zenoh_event_type_t & event_type,
   GraphCacheEventCallback callback)
 {
@@ -1186,20 +1186,20 @@ void GraphCache::set_qos_event_callback(
     return;
   }
 
-  const GraphEventCallbackMap::iterator event_cb_it = event_callbacks_.find(entity_keyexpr_hash);
+  const GraphEventCallbackMap::iterator event_cb_it = event_callbacks_.find(entity_gid_hash);
   if (event_cb_it == event_callbacks_.end()) {
     // First time a callback is being set for this entity.
-    event_callbacks_[entity_keyexpr_hash] = {std::make_pair(event_type, std::move(callback))};
+    event_callbacks_[entity_gid_hash] = {std::make_pair(event_type, std::move(callback))};
   } else {
     event_cb_it->second[event_type] = std::move(callback);
   }
 
   // Check if there are any event changes for this event type before the callback was registered.
-  auto unregistered_event_changes_it = unregistered_event_changes_.find(entity_keyexpr_hash);
+  auto unregistered_event_changes_it = unregistered_event_changes_.find(entity_gid_hash);
   if (unregistered_event_changes_it != unregistered_event_changes_.end()) {
     auto event_changes_it = unregistered_event_changes_it->second.find(event_type);
     if (event_changes_it != unregistered_event_changes_it->second.end()) {
-      event_callbacks_[entity_keyexpr_hash][event_type](event_changes_it->second);
+      event_callbacks_[entity_gid_hash][event_type](event_changes_it->second);
       // Update bookkeeping for unregistered_event_changes_.
       unregistered_event_changes_it->second.erase(event_changes_it);
       if (unregistered_event_changes_it->second.empty()) {
@@ -1210,10 +1210,10 @@ void GraphCache::set_qos_event_callback(
 }
 
 ///=============================================================================
-void GraphCache::remove_qos_event_callbacks(std::size_t entity_keyexpr_hash)
+void GraphCache::remove_qos_event_callbacks(std::size_t entity_gid_hash)
 {
   std::lock_guard<std::mutex> lock(events_mutex_);
-  event_callbacks_.erase(entity_keyexpr_hash);
+  event_callbacks_.erase(entity_gid_hash);
 }
 
 ///=============================================================================
@@ -1253,9 +1253,9 @@ void GraphCache::update_event_counters(
   auto update_unregistered_event_changes =
     [&]()
     {
-      auto unregistered_event_changes_it = unregistered_event_changes_.find(entity->keyexpr_hash());
+      auto unregistered_event_changes_it = unregistered_event_changes_.find(entity->gid_hash());
       if (unregistered_event_changes_it == unregistered_event_changes_.end()) {
-        unregistered_event_changes_[entity->keyexpr_hash()] = {std::make_pair(event_id, change)};
+        unregistered_event_changes_[entity->gid_hash()] = {std::make_pair(event_id, change)};
       } else {
         unregistered_event_changes_it->second[event_id] = change;
       }
@@ -1263,7 +1263,7 @@ void GraphCache::update_event_counters(
 
   // Trigger callback set for this entity for the event type.
   GraphEventCallbackMap::const_iterator event_callbacks_it =
-    event_callbacks_.find(entity->keyexpr_hash());
+    event_callbacks_.find(entity->gid_hash());
   if (event_callbacks_it != event_callbacks_.end()) {
     GraphEventCallbacks::const_iterator callback_it =
       event_callbacks_it->second.find(event_id);

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1255,9 +1255,18 @@ void GraphCache::update_event_counters(
     {
       auto unregistered_event_changes_it = unregistered_event_changes_.find(entity->gid_hash());
       if (unregistered_event_changes_it == unregistered_event_changes_.end()) {
+        // First time this entity has changes for any events without a callback registered.
         unregistered_event_changes_[entity->gid_hash()] = {std::make_pair(event_id, change)};
       } else {
-        unregistered_event_changes_it->second[event_id] = change;
+        auto event_changes_it = unregistered_event_changes_it->second.find(event_id);
+        if (event_changes_it == unregistered_event_changes_it->second.end()) {
+          // First time this entity has changes for this specific event_id.
+          unregistered_event_changes_it->second[event_id] = change;
+        } else {
+          // There have been changes for this event_id in the past so we simply increment
+          // the changes.
+          unregistered_event_changes_it->second[event_id] += change;
+        }
       }
     };
 

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1190,9 +1190,23 @@ void GraphCache::set_qos_event_callback(
   if (event_cb_it == event_callbacks_.end()) {
     // First time a callback is being set for this entity.
     event_callbacks_[entity_keyexpr_hash] = {std::make_pair(event_type, std::move(callback))};
-    return;
+  } else {
+    event_cb_it->second[event_type] = std::move(callback);
   }
-  event_cb_it->second[event_type] = std::move(callback);
+
+  // Check if there are any event changes for this event type before the callback was registered.
+  auto unregistered_event_changes_it = unregistered_event_changes_.find(entity_keyexpr_hash);
+  if (unregistered_event_changes_it != unregistered_event_changes_.end()) {
+    auto event_changes_it = unregistered_event_changes_it->second.find(event_type);
+    if (event_changes_it != unregistered_event_changes_it->second.end()) {
+      event_callbacks_[entity_keyexpr_hash][event_type](event_changes_it->second);
+      // Update bookkeeping for unregistered_event_changes_.
+      unregistered_event_changes_it->second.erase(event_changes_it);
+      if (unregistered_event_changes_it->second.empty()) {
+        unregistered_event_changes_.erase(unregistered_event_changes_it);
+      }
+    }
+  }
 }
 
 ///=============================================================================
@@ -1234,6 +1248,19 @@ void GraphCache::update_event_counters(
 
   std::lock_guard<std::mutex> lock(events_mutex_);
 
+  // Lambda to add changes to unregistered_event_changes_ if a callback for the
+  // event_type is not yet registered.
+  auto update_unregistered_event_changes =
+    [&]()
+    {
+      auto unregistered_event_changes_it = unregistered_event_changes_.find(entity->keyexpr_hash());
+      if (unregistered_event_changes_it == unregistered_event_changes_.end()) {
+        unregistered_event_changes_[entity->keyexpr_hash()] = {std::make_pair(event_id, change)};
+      } else {
+        unregistered_event_changes_it->second[event_id] = change;
+      }
+    };
+
   // Trigger callback set for this entity for the event type.
   GraphEventCallbackMap::const_iterator event_callbacks_it =
     event_callbacks_.find(entity->keyexpr_hash());
@@ -1241,8 +1268,17 @@ void GraphCache::update_event_counters(
     GraphEventCallbacks::const_iterator callback_it =
       event_callbacks_it->second.find(event_id);
     if (callback_it != event_callbacks_it->second.end()) {
+      // Trigger the registered callback.
       callback_it->second(change);
+    } else {
+      // A callback for a different event_type has been registered for this entity.
+      // We add the change for the unregistered event_type to unregistered_event_changes_.
+      update_unregistered_event_changes();
     }
+  } else {
+      // No callbacks for any event type have been registered for this entity.
+      // We add the change for the unregistered event_type to unregistered_event_changes_.
+    update_unregistered_event_changes();
   }
 }
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -176,12 +176,12 @@ public:
   /// Set a qos event callback for an entity from the current session.
   /// @note The callback will be removed when the entity is removed from the graph.
   void set_qos_event_callback(
-    std::size_t entity_keyexpr_hash,
+    std::size_t entity_gid_hash,
     const rmw_zenoh_event_type_t & event_type,
     GraphCacheEventCallback callback);
 
   /// Remove all qos event callbacks for an entity.
-  void remove_qos_event_callbacks(std::size_t entity_keyexpr_hash);
+  void remove_qos_event_callbacks(std::size_t entity_gid_hash);
 
   /// Returns true if the entity is a publisher or client. False otherwise.
   static bool is_entity_pub(const liveliness::Entity & entity);
@@ -266,7 +266,7 @@ private:
   GraphNode::TopicMap graph_services_ = {};
 
   using GraphEventCallbacks = std::unordered_map<rmw_zenoh_event_type_t, GraphCacheEventCallback>;
-  // Map an entity's keyexpr_hash to a map of event callbacks.
+  // Map an entity's gid_hash to a map of event callbacks.
   // Note: Since we use unordered_map, we will only store a single callback for an
   // entity string. So we do not support the case where a node create a duplicate
   // pub/sub with the exact same topic, type & QoS but registers a different callback
@@ -275,7 +275,7 @@ private:
   using GraphEventCallbackMap = std::unordered_map<std::size_t, GraphEventCallbacks>;
   // EventCallbackMap for each type of event we support in rmw_zenoh_cpp.
   GraphEventCallbackMap event_callbacks_;
-  // Map an entity's keyexpr_hash to another map of event_types which map to the change in
+  // Map an entity's gid_hash to another map of event_types which map to the change in
   // number of events.
   // This map is used to track changes of events which do not have callbacks registered yet.
   // When a callback does get registered, we check for any change history and trigger the callback

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -275,6 +275,13 @@ private:
   using GraphEventCallbackMap = std::unordered_map<std::size_t, GraphEventCallbacks>;
   // EventCallbackMap for each type of event we support in rmw_zenoh_cpp.
   GraphEventCallbackMap event_callbacks_;
+  // Map an entity's keyexpr_hash to another map of event_types which map to the change in
+  // number of events.
+  // This map is used to track changes of events which do not have callbacks registered yet.
+  // When a callback does get registered, we check for any change history and trigger the callback
+  // immediately after which we reset this map accordingly.
+  std::unordered_map<std::size_t,
+    std::unordered_map<rmw_zenoh_event_type_t, int32_t>> unregistered_event_changes_;
   std::mutex events_mutex_;
 
   // Mutex to lock before modifying the members above.

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -442,7 +442,7 @@ Entity::Entity(
         sizeof(keyexpr_gid.high64));
 
   // We also hash the liveliness keyexpression into a size_t that we use to index into our maps.
-  this->keyexpr_hash_ = hash_gid(this->gid_);
+  this->gid_hash_ = hash_gid(this->gid_);
 }
 
 ///=============================================================================
@@ -586,9 +586,9 @@ std::string Entity::id() const
 }
 
 ///=============================================================================
-std::size_t Entity::keyexpr_hash() const
+std::size_t Entity::gid_hash() const
 {
-  return this->keyexpr_hash_;
+  return this->gid_hash_;
 }
 
 ///=============================================================================
@@ -639,7 +639,7 @@ std::array<uint8_t, RMW_GID_STORAGE_SIZE> Entity::copy_gid() const
 ///=============================================================================
 bool Entity::operator==(const Entity & other) const
 {
-  return other.keyexpr_hash() == keyexpr_hash_;
+  return other.gid_hash() == gid_hash_;
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -146,11 +146,11 @@ public:
   std::string nid() const;
 
   // Get the id of the entity local to a zenoh session.
-  // Use keyexpr_hash() to retrieve a globally unique id.
+  // Use gid_hash() to retrieve a globally unique id.
   std::string id() const;
 
   // Interim method to get a globally unique id for this entity which is the hash of the keyexpr.
-  std::size_t keyexpr_hash() const;
+  std::size_t gid_hash() const;
 
   /// Get the entity type.
   EntityType type() const;
@@ -170,7 +170,7 @@ public:
   /// Get the liveliness keyexpr for this entity.
   std::string liveliness_keyexpr() const;
 
-  // Two entities are equal if their keyexpr_hash are equal.
+  // Two entities are equal if their gid_hash are equal.
   bool operator==(const Entity & other) const;
 
   std::array<uint8_t, RMW_GID_STORAGE_SIZE> copy_gid() const;
@@ -187,7 +187,7 @@ private:
   std::string zid_;
   std::string nid_;
   std::string id_;
-  std::size_t keyexpr_hash_;
+  std::size_t gid_hash_;
   EntityType type_;
   NodeInfo node_info_;
   std::optional<TopicInfo> topic_info_;
@@ -247,7 +247,7 @@ struct hash<rmw_zenoh_cpp::liveliness::Entity>
 {
   auto operator()(const rmw_zenoh_cpp::liveliness::Entity & entity) const -> size_t
   {
-    return entity.keyexpr_hash();
+    return entity.gid_hash();
   }
 };
 
@@ -256,7 +256,7 @@ struct hash<rmw_zenoh_cpp::liveliness::ConstEntityPtr>
 {
   auto operator()(const rmw_zenoh_cpp::liveliness::ConstEntityPtr & entity) const -> size_t
   {
-    return entity->keyexpr_hash();
+    return entity->gid_hash();
   }
 };
 
@@ -267,7 +267,7 @@ struct equal_to<rmw_zenoh_cpp::liveliness::ConstEntityPtr>
     const rmw_zenoh_cpp::liveliness::ConstEntityPtr & lhs,
     const rmw_zenoh_cpp::liveliness::ConstEntityPtr & rhs) const -> bool
   {
-    return lhs->keyexpr_hash() == rhs->keyexpr_hash();
+    return lhs->gid_hash() == rhs->gid_hash();
   }
 };
 }  // namespace std

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -321,10 +321,10 @@ rmw_ret_t PublisherData::publish_serialized_message(
 }
 
 ///=============================================================================
-std::size_t PublisherData::keyexpr_hash() const
+std::size_t PublisherData::gid_hash() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  return entity_->keyexpr_hash();
+  return entity_->gid_hash();
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
@@ -64,8 +64,8 @@ public:
     const rmw_serialized_message_t * serialized_message,
     std::optional<zenoh::ShmProvider> & shm_provider);
 
-  // Get a copy of the keyexpr_hash of this PublisherData's liveliness::Entity.
-  std::size_t keyexpr_hash() const;
+  // Get a copy of the gid_hash of this PublisherData's liveliness::Entity.
+  std::size_t gid_hash() const;
 
   // Get a copy of the TopicInfo of this PublisherData.
   liveliness::TopicInfo topic_info() const;

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -256,10 +256,10 @@ bool SubscriptionData::init()
 }
 
 ///=============================================================================
-std::size_t SubscriptionData::keyexpr_hash() const
+std::size_t SubscriptionData::gid_hash() const
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  return entity_->keyexpr_hash();
+  return entity_->gid_hash();
 }
 
 ///=============================================================================
@@ -309,7 +309,7 @@ rmw_ret_t SubscriptionData::shutdown()
   }
 
   // Remove any event callbacks registered to this subscription.
-  graph_cache_->remove_qos_event_callbacks(entity_->keyexpr_hash());
+  graph_cache_->remove_qos_event_callbacks(entity_->gid_hash());
 
   // Unregister this subscription from the ROS graph.
   zenoh::ZResult result;

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -74,8 +74,8 @@ public:
     const rmw_qos_profile_t * qos_profile,
     const rmw_subscription_options_t & sub_options);
 
-  // Get a copy of the keyexpr_hash of this SubscriptionData's liveliness::Entity.
-  std::size_t keyexpr_hash() const;
+  // Get a copy of the gid_hash of this SubscriptionData's liveliness::Entity.
+  std::size_t gid_hash() const;
 
   // Get a copy of the TopicInfo of this SubscriptionData.
   liveliness::TopicInfo topic_info() const;

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -70,7 +70,7 @@ rmw_publisher_event_init(
   // Register the event with graph cache.
   std::weak_ptr<rmw_zenoh_cpp::PublisherData> data_wp = pub_data;
   context_impl->graph_cache()->set_qos_event_callback(
-    pub_data->keyexpr_hash(),
+    pub_data->gid_hash(),
     zenoh_event_type,
     [data_wp,
     zenoh_event_type](int32_t change)
@@ -129,7 +129,7 @@ rmw_subscription_event_init(
 
   // std::weak_ptr<rmw_zenoh_cpp::SubscriptionData> data_wp = sub_data;
   sub_data->graph_cache()->set_qos_event_callback(
-    sub_data->keyexpr_hash(),
+    sub_data->gid_hash(),
     zenoh_event_type,
     [sub_data,
     zenoh_event_type](int32_t change)

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -501,7 +501,7 @@ rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
     return RMW_RET_INVALID_ARGUMENT;
   }
   // Remove any event callbacks registered to this publisher.
-  context_impl->graph_cache()->remove_qos_event_callbacks(pub_data->keyexpr_hash());
+  context_impl->graph_cache()->remove_qos_event_callbacks(pub_data->gid_hash());
   // Remove the PublisherData from NodeData.
   node_data->delete_pub_data(publisher);
 


### PR DESCRIPTION
Fix #586 

Did some pritnf debugging for the test_events_exeuctor failure and here are my observations
1. ROS context is initialized and with it the GraphCache
2. Subscription is created with a matched_event callback.
  2.a. Subscription's liveliness token is published.
  2.b. The matched_event callback of this Subscription is registered with the GraphCache
3. Publisher is created with a matched_event callback.
  3.a Publisher's liveliness token is published.
  3.b The GraphCache receives this Publisher's liveliness token via the liveliness subscription,  and in the callback identifies that it's a matched event with a Subscription from the same context.
    3.b.i) The matched_event callback for the Subscriptions is looked up and executed.
    3.b.ii) No matched_event callback for the Publisher is found.
  3.c. The matched_event callback of this Publisher is registered with the GraphCache.


So The issue is that the liveliness callback for the new publisher executes even before the matched_event callback can be registered.  More specifically,
- The rmw_publisher_t is created here: https://github.com/ros2/rclpy/blob/a10ff3bc90e3743ae74182d6dc67ae4881d48d93/rclpy/rclpy/node.py#L1560
- And the event_callbacks are registered a few lines later: https://github.com/ros2/rclpy/blob/a10ff3bc90e3743ae74182d6dc67ae4881d48d93/rclpy/rclpy/node.py#L1568

This PR keeps track of qos event changes for events that do not have callbacks registered yet and when callbacks are registered, the callback is triggered immediately. 



## Summary of changes
- https://github.com/ros2/rmw_zenoh/pull/587/commits/30a97981d481d1a910a23f0b79c17d2e9ae9d81e applies the main fix by storing changes for events with unregistered callbacks into a map.
- https://github.com/ros2/rmw_zenoh/pull/587/commits/148bb95bdf72c3fb6867bf19a5f6b0402ec116cc is purely semantic/cosmetic and renames keyexpr_hash to gid_hash to more accurately reflect what it stores.