### PR TITLE
build: bump zenoh-cpp from 8ad67f6 to 8bbb016, zenoh-c from e6a1971 to 67e3d8a, and zenoh from b661454 to c2c5f3e.

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,30 +198,7 @@ Error opening Session!\n[ros2run]: Process exited with failure 1
 To resolve this, either run the router on a system with IPv6 support, or update the `listen.endpoints` list in the Zenoh configuration and replace `"tcp/[::]:7447"` with `"tcp/0.0.0.0:7447"` (ie: make the router listen on IPv4 `ANY`).
 Note: the existing entry must be *replaced*, it's not sufficient to just *add* the IPv4 entry (as that would make the router attempt to listen on both IPv4 and IPv6 `ANY` and still not work).
 
-### Crash when program terminates
-
-When a program terminates, global and static objects are destructed in the reverse order of their
-construction.
-The `Thread Local Storage` is one such entity which the `tokio` runtime in Zenoh uses.
-If the Zenoh session is closed after this entity is cleared, it causes a panic like seen below.
-
-```
-thread '<unnamed>' panicked at /rustc/aedd173a2c086e558c2b66d3743b344f977621a7/library/std/src/thread/local.rs:262:26:
-cannot access a Thread Local Storage value during or after destruction: AccessError
-```
-
-This can happen with `rmw_zenoh` if the ROS 2 `Context` is not shutdown explicitly before the
-program terminates.
-In this scenario, the `Context` will be shutdown inside the `Context`'s destructor which then closes the Zenoh session.
-Since the ordering of global/static objects is not defined, this often leads to the above panic.
-
-The recommendation is to ensure the `Context` is shutdown before a program terminates.
-One way to ensure this is to call `rclcpp::shutdown()` when the program exits.
-Note that composable nodes should *never* call `rclcpp::shutdown()`, as the composable node container will automatically do this.
-
-For more details, see https://github.com/ros2/rmw_zenoh/issues/170.
-
-### rmw_zenoh is incompatible between Humble and newer distributions. 
+### rmw_zenoh is incompatible between Humble and newer distributions.
 
 Since Iron, ROS 2 introduced type hashes for messages and `rmw_zenoh` includes these type hashes in the Zenoh keyexpressions it constructs for data exchange. While participants will be discoverable, communication between Humble and newer distributions will fail, resulting in messages being silently dropped.
 

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -269,6 +269,9 @@
   //          "lo0",
   //          "en0",
   //        ],
+  //        /// Optional list of link protocols. Transports with at least one of these links will have their qos overwritten.
+  //        /// If absent, the overwrite will be applied to all transports. An empty list is invalid.
+  //        link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //        /// List of message types to apply to.
   //        messages: [
   //          "put", // put publications
@@ -320,8 +323,11 @@
   //      /// Optional Id, has to be unique
   //      "id": "wlan0egress",
   //      /// Optional list of network interfaces messages will be processed on, the rest will be passed as is.
-  //      /// If absent, the rules will be applied to all interfaces, in case of an empty list it means that they will not be applied to any.
+  //      /// If absent, the rules will be applied to all interfaces. An empty list is invalid.
   //      interfaces: [ "wlan0" ],
+  //      /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+  //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the rules will be applied to both flows.
   //      flow: ["ingress", "egress"],
@@ -420,6 +426,12 @@
   //       "id": "subject3",
   //       /// An empty subject combination is a wildcard
   //     },
+  //     {
+  //       "id": "subject4",
+  //      /// link protocols can also be used to identify transports to filter messages on.
+  //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+  //     },
   //   ],
   //   /// The policies list associates rules to subjects
   //   "policies":
@@ -434,7 +446,7 @@
   //      },
   //      {
   //         "rules": ["rule2"],
-  //         "subjects": ["subject3"],
+  //         "subjects": ["subject3", "subject4"],
   //      },
   //   ]
   //},

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -257,6 +257,39 @@
   //        },
   //      },
   //    ],
+  //    /// Overwrite QoS options for messages sent and received from/to the network
+  //    /// This allows more fine grained rules (per network card, etc...) but is
+  //    /// less performant than the publication option above.
+  //    network: [
+  //      {
+  //        /// Optional Id, has to be unique.
+  //        id: "lo0_en0_qos_overwrite",
+  //        // Optional list of interfaces, if not specified, will be applied to all interfaces.
+  //        interfaces: [
+  //          "lo0",
+  //          "en0",
+  //        ],
+  //        /// List of message types to apply to.
+  //        messages: [
+  //          "put", // put publications
+  //          "delete" // delete publications
+  //          "query", // get queries
+  //          "reply", // replies to queries
+  //        ],
+  //        /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+  //        /// If absent, the rules will be applied to both flows.
+  //        flows: ["egress", "ingress"],
+  //        key_exprs: ["test/demo"],
+  //        overwrite: {
+  //          /// Optional new priority value, if not specified priority of the messages will stay unchanged.
+  //          priority: "real_time",
+  //          /// Optional new congestion control value, if not specified congestion control of the messages will stay unchanged.
+  //          congestion_control: "block",
+  //          /// Optional new express value, if not specified express flag of the messages will stay unchanged.
+  //          express: true
+  //        },
+  //      },
+  //    ],
   //  },
 
   //  /// The declarations aggregation strategy.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -265,6 +265,39 @@
   //        },
   //      },
   //    ],
+  //    /// Overwrite QoS options for messages sent and received from/to the network
+  //    /// This allows more fine grained rules (per network card, etc...) but is
+  //    /// less performant than the publication option above.
+  //    network: [
+  //      {
+  //        /// Optional Id, has to be unique.
+  //        id: "lo0_en0_qos_overwrite",
+  //        // Optional list of interfaces, if not specified, will be applied to all interfaces.
+  //        interfaces: [
+  //          "lo0",
+  //          "en0",
+  //        ],
+  //        /// List of message types to apply to.
+  //        messages: [
+  //          "put", // put publications
+  //          "delete" // delete publications
+  //          "query", // get queries
+  //          "reply", // replies to queries
+  //        ],
+  //        /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+  //        /// If absent, the rules will be applied to both flows.
+  //        flows: ["egress", "ingress"],
+  //        key_exprs: ["test/demo"],
+  //        overwrite: {
+  //          /// Optional new priority value, if not specified priority of the messages will stay unchanged.
+  //          priority: "real_time",
+  //          /// Optional new congestion control value, if not specified congestion control of the messages will stay unchanged.
+  //          congestion_control: "block",
+  //          /// Optional new express value, if not specified express flag of the messages will stay unchanged.
+  //          express: true
+  //        },
+  //      },
+  //    ],
   //  },
 
   //  /// The declarations aggregation strategy.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -277,6 +277,9 @@
   //          "lo0",
   //          "en0",
   //        ],
+  //        /// Optional list of link protocols. Transports with at least one of these links will have their qos overwritten.
+  //        /// If absent, the overwrite will be applied to all transports. An empty list is invalid.
+  //        link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //        /// List of message types to apply to.
   //        messages: [
   //          "put", // put publications
@@ -328,8 +331,11 @@
   //      /// Optional Id, has to be unique
   //      "id": "wlan0egress",
   //      /// Optional list of network interfaces messages will be processed on, the rest will be passed as is.
-  //      /// If absent, the rules will be applied to all interfaces, in case of an empty list it means that they will not be applied to any.
+  //      /// If absent, the rules will be applied to all interfaces. An empty list is invalid.
   //      interfaces: [ "wlan0" ],
+  //      /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+  //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the rules will be applied to both flows.
   //      flow: ["ingress", "egress"],
@@ -428,6 +434,12 @@
   //       "id": "subject3",
   //       /// An empty subject combination is a wildcard
   //     },
+  //     {
+  //       "id": "subject4",
+  //      /// link protocols can also be used to identify transports to filter messages on.
+  //      /// If absent, the rules will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+  //     },
   //   ],
   //   /// The policies list associates rules to subjects
   //   "policies":
@@ -442,7 +454,7 @@
   //      },
   //      {
   //         "rules": ["rule2"],
-  //         "subjects": ["subject3"],
+  //         "subjects": ["subject3", "subject4"],
   //      },
   //   ]
   //},

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -37,9 +37,18 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 #   - https://github.com/eclipse-zenoh/zenoh/pull/1792
 # - Fix debug mode crash
 #  - https://github.com/eclipse-zenoh/zenoh-cpp/pull/432
+# - Avoid crashing when handling highly chunked keys
+#   - https://github.com/eclipse-zenoh/zenoh/pull/1826
+# - Add new non periodic last sample miss detection mechanism
+#   - https://github.com/eclipse-zenoh/zenoh/pull/1861
+# - Fix memory leak in shm segment cleanup
+#  - https://github.com/eclipse-zenoh/zenoh/pull/1867
+# - Resolve the shutdown issue
+#  - https://github.com/eclipse-zenoh/zenoh/pull/1632
+https://github.com/Yadunund/rmw_zenoh_shutdown_test.
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION e6a1971139f405f7887bf5bb54f0efe402123032
+  VCS_VERSION 67e3d8a3b0437f1555641ff29b4e89d4f7bb9dbb
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
@@ -50,7 +59,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 8ad67f6c7a9031acd437c8739bbc8ddab0ca8173
+  VCS_VERSION 8bbb0167bf25a8d4d5e15676d5a91a65d1d7855f
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -45,7 +45,6 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 #  - https://github.com/eclipse-zenoh/zenoh/pull/1867
 # - Resolve the shutdown issue
 #  - https://github.com/eclipse-zenoh/zenoh/pull/1632
-https://github.com/Yadunund/rmw_zenoh_shutdown_test.
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 67e3d8a3b0437f1555641ff29b4e89d4f7bb9dbb


### PR DESCRIPTION
This PR makes the following changes of commit ids:

- zenoh-cpp: https://github.com/eclipse-zenoh/zenoh-cpp/compare/8ad67f6..8bbb016
- zenoh-c: https://github.com/eclipse-zenoh/zenoh-c/compare/e6a1971..67e3d8a
- zenoh: https://github.com/eclipse-zenoh/zenoh/compare/b661454..c2c5f3e

It inherits these changes:

- Avoid crashing when handling highly chunked keys (https://github.com/eclipse-zenoh/zenoh/pull/1826)
- Add new non periodic last sample miss detection mechanism (https://github.com/eclipse-zenoh/zenoh/pull/1861).
This is planned to address the https://github.com/ros2/rmw_zenoh/issues/543 and will be implemented in rmw_zenoh once we completed more experiments.
- Fix memory leak in shm segment cleanup (https://github.com/eclipse-zenoh/zenoh/pull/1867)
- Resolve the shutdown issue (https://github.com/eclipse-zenoh/zenoh/pull/1632). This fixed https://github.com/ros2/rmw_zenoh/issues/170 and passed
https://github.com/Yadunund/rmw_zenoh_shutdown_test.

A quick run of the ROS 2 core tests showed no regressions.
