### PR TITLE
fix: pin rust toolchain to v1.75.0

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -41,8 +41,7 @@ ament_vendor(zenoh_c_vendor
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
     "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
-  PATCH_COMMAND
-    git apply ${CMAKE_CURRENT_SOURCE_DIR}/pin-rust-1.75.0.patch
+  PATCHES ${CMAKE_CURRENT_SOURCE_DIR}/pin-rust-1.75.0.patch
 )
 
 ament_export_dependencies(zenohc)

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -41,6 +41,8 @@ ament_vendor(zenoh_c_vendor
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
     "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
+  PATCH_COMMAND
+    git apply ${CMAKE_CURRENT_SOURCE_DIR}/pin-rust-1.75.0.patch
 )
 
 ament_export_dependencies(zenohc)

--- a/zenoh_cpp_vendor/pin-rust-1.75.0.patch
+++ b/zenoh_cpp_vendor/pin-rust-1.75.0.patch
@@ -1,0 +1,8 @@
+diff --git a/rust-toolchain.toml b/rust-toolchain.toml
+index c1bc0a69..7897a24d 100644
+--- a/rust-toolchain.toml
++++ b/rust-toolchain.toml
+@@ -1,2 +1,2 @@
+ [toolchain]
+-channel = "1.85.0"
++channel = "1.75.0"


### PR DESCRIPTION
The latest Zenoh version bump causes zenoh-c to build with Rust toolchain 1.85.0. This PR adds a patch to pin the version back to 1.75.0.

NOTE: Regarding the compatibility, we have a CI checking the zenoh/zenoh-c against Rust 1.75.0.
