### PR TITLE
Session config: set scouting/multicast/autoconnect_strategy/peer/to_peer=always

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -153,9 +153,10 @@
       /// (e.g. autoconnect_strategy : { to_router:  "always", to_peer: "greater-zid" }),
       /// or different values for router or peer mode
       /// (e.g. autoconnect_strategy : { peer: { to_router:  "always", to_peer: "greater-zid" } }).
-      /// ROS setting: by default all peers rely on the router to discover each other. Thus configuring the peer to send gossip
-      ///              messages only to the router is sufficient and avoids unecessary traffic between Nodes at launch time.
-      autoconnect_strategy: { peer: { to_router: "always", to_peer: "greater-zid" } },
+      /// ROS setting: until https://github.com/eclipse-zenoh/zenoh/issues/1890 is fixed, it's better
+      ///              to not use "greater-zid" with multicast scouting to avoid excessive interconnection delay.
+      ///              The risk of double connections is anyway smaller than with gossip scouting.
+      autoconnect_strategy: { peer: { to_router: "always", to_peer: "always" } },
       /// Whether or not to listen for scout messages on UDP multicast and reply to them.
       listen: true,
     },


### PR DESCRIPTION
As explained in https://github.com/eclipse-zenoh/zenoh/issues/1890, the combination of multicast scouting and `autoconnect_strategy=greater_zid` can lead to peer-to-peer connection establishment to take up to 8 seconds.

This causes issues in tests when configured with multicast, but could also cause timeout issues at launch time for users who want to use multicast scouting. Waiting for https://github.com/eclipse-zenoh/zenoh/issues/1890 to be fixed, I think it's preferable to set `scouting/multicast/autoconnect_strategy/peer/to_peer=always` in `DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5`.

This will fix #596 and possibly other tests when running with multicast scouting enabled.
But it won't change the current default behaviour for users relying on a router and gossip scouting.