### PR TITLE
fix: use the right commit to bump zenoh to v1.3.2

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -36,7 +36,7 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 #    - https://github.com/eclipse-zenoh/zenoh/pull/1844
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION ffa4bddc947f7ed6c0e3b4546205dd1b73e7df81
+  VCS_VERSION c87e3128229fae6df497650c97767dd3c4dac1db
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -36,7 +36,7 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 #    - https://github.com/eclipse-zenoh/zenoh/pull/1844
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION c87e3128229fae6df497650c97767dd3c4dac1db
+  VCS_VERSION f60bbaba51417256b267f59f909a48eb99f1833b
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"


### PR DESCRIPTION
In the previous [PR](#591), the Zenoh version was unexpectedly set to 1.3.1 rather than 1.3.2 (affected by the version set in the zenoh-c/Cargo.toml.in).
Therefore it did not include the regression reversion and led to https://github.com/evshary/autoware_rmw_zenoh/issues/7.

This PR correctly update zenoh from 7425cc7 to 94e91794, bumping the version from 1.3.1 to 1.3.2.
The only changes included are the version bump and the regression reversion.

Diff: https://github.com/eclipse-zenoh/zenoh/compare/7425cc7..94e91794
