### PR TITLE
Bump Zenoh to 1.4.0

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -454,6 +454,35 @@
   //   ]
   //},
 
+  //  low_pass_filter: [
+  //    {
+  //      /// Optional Id, has to be unique
+  //      "id": "filter1",
+  //      /// Optional list of network interfaces messages will be processed on, the rest will not be filtered.
+  //      /// If absent, the filter will be applied to all interfaces.
+  //      interfaces: [ "wlan0" ],
+  //      /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+  //      /// If absent, the rule will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+  //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+  //      /// If absent, the filter will be applied to both flows.
+  //      flow: ["ingress", "egress"],
+  //      /// List of message type on which the filter will be applied. Must not be empty.
+  //      messages: [
+  //        "put",
+  //        "delete",
+  //        "query",
+  //        "reply"
+  //      ],
+  //      /// List of key_expressions which matching messages will be filtered
+  //      key_exprs: [
+  //        "demo/**",
+  //      ],
+  //      /// Inclusive max size of serialized payload + serialized attachment
+  //      size_limit: 8192,
+  //    },
+  //  ],
+
   /// Configure internal transport parameters
   transport: {
     unicast: {

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -22,6 +22,9 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
+  /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
+  //  Note!: Currently it is unsupported to specify both `bind` and `iface`. 
   connect: {
     /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -24,7 +24,10 @@
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
   /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
   /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
-  //  Note!: Currently it is unsupported to specify both `bind` and `iface`. 
+  ///  Note!: Currently it is unsupported to specify both `bind` and `iface`.
+  ///
+  /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+  /// E.g. tcp/192.168.0.1:7447#dscp=0x08
   connect: {
     /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)
@@ -71,6 +74,9 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  ///
+  /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+  /// E.g. tcp/192.168.0.1:7447#dscp=0x08
   listen: {
     /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -225,11 +225,34 @@
       /// ROS setting: disabled by default because it serves no purpose when each peer connects directly to all others,
       ///              and it introduces additional management overhead and extra messages during system startup.
       peers_failover_brokering: false,
+      /// Linkstate mode configuration.
+      linkstate: {
+        /// Weights of the outgoing transports in linkstate mode.
+        /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+        /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+        /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+ //        transport_weights: [
+ //          { dst_zid: "1", weight: "10" },
+ //          { dst_zid: "2", weight: "200" },
+ //        ]
+      }
     },
     /// The routing strategy to use in peers and it's configuration.
     peer: {
       /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
+      /// This option needs to be set to the same value in all peers and routers of the subsystem.
       mode: "peer_to_peer",
+        /// Linkstate mode configuration (only taken into account if mode == "linkstate").
+        linkstate: {
+        /// Weights of the outgoing transports in linkstate mode.
+        /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+        /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+        /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+ //        transport_weights: [
+ //          { dst_zid: "1", weight: "10" },
+ //          { dst_zid: "2", weight: "200" },
+ //        ]
+      }
     },
     /// The interests-based routing configuration.
     /// This configuration applies regardless of the mode (router, peer or client).

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -267,6 +267,8 @@
   //      {
   //        /// Optional Id, has to be unique.
   //        id: "lo0_en0_qos_overwrite",
+  //        // Optional list of ZIDs on which qos will be overwritten when communicating with.
+  //        // zids: ["38a4829bce9166ee"],
   //        // Optional list of interfaces, if not specified, will be applied to all interfaces.
   //        interfaces: [
   //          "lo0",

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -275,6 +275,8 @@
   //      {
   //        /// Optional Id, has to be unique.
   //        id: "lo0_en0_qos_overwrite",
+  //        // Optional list of ZIDs on which qos will be overwritten when communicating with.
+  //        // zids: ["38a4829bce9166ee"],
   //        // Optional list of interfaces, if not specified, will be applied to all interfaces.
   //        interfaces: [
   //          "lo0",

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -22,6 +22,9 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
+  /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
+  //  Note!: Currently it is unsupported to specify both `bind` and `iface`. 
   connect: {
     /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -233,11 +233,34 @@
       /// The failover brokering only works if gossip discovery is enabled
       /// and peers are configured with gossip target "router".
       peers_failover_brokering: true,
+      /// Linkstate mode configuration.
+      linkstate: {
+        /// Weights of the outgoing transports in linkstate mode.
+        /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+        /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+        /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+ //        transport_weights: [
+ //          { dst_zid: "1", weight: "10" },
+ //          { dst_zid: "2", weight: "200" },
+ //        ]
+      }
     },
     /// The routing strategy to use in peers and it's configuration.
     peer: {
       /// The routing strategy to use in peers. ("peer_to_peer" or "linkstate").
+      /// This option needs to be set to the same value in all peers and routers of the subsystem.
       mode: "peer_to_peer",
+        /// Linkstate mode configuration (only taken into account if mode == "linkstate").
+        linkstate: {
+        /// Weights of the outgoing transports in linkstate mode.
+        /// If none of the two endpoint nodes of a transport specifies its weight, a weight of 100 is applied.
+        /// If only one of the two endpoint nodes of a transport specifies its weight, the specified weight is applied.
+        /// If both endpoint nodes of a transport specify its weight, the greater weight is applied.
+ //        transport_weights: [
+ //          { dst_zid: "1", weight: "10" },
+ //          { dst_zid: "2", weight: "200" },
+ //        ]
+      }
     },
     /// The interests-based routing configuration.
     /// This configuration applies regardless of the mode (router, peer or client).

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -462,6 +462,35 @@
   //   ]
   //},
 
+  //  low_pass_filter: [
+  //    {
+  //      /// Optional Id, has to be unique
+  //      "id": "filter1",
+  //      /// Optional list of network interfaces messages will be processed on, the rest will not be filtered.
+  //      /// If absent, the filter will be applied to all interfaces.
+  //      interfaces: [ "wlan0" ],
+  //      /// Optional list of link protocols. Transports with at least one of these links will have their messages filtered.
+  //      /// If absent, the rule will be applied to all transports. An empty list is invalid.
+  //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
+  //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
+  //      /// If absent, the filter will be applied to both flows.
+  //      flow: ["ingress", "egress"],
+  //      /// List of message type on which the filter will be applied. Must not be empty.
+  //      messages: [
+  //        "put",
+  //        "delete",
+  //        "query",
+  //        "reply"
+  //      ],
+  //      /// List of key_expressions which matching messages will be filtered
+  //      key_exprs: [
+  //        "demo/**",
+  //      ],
+  //      /// Inclusive max size of serialized payload + serialized attachment
+  //      size_limit: 8192,
+  //    },
+  //  ],
+
   /// Configure internal transport parameters
   transport: {
     unicast: {

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -24,7 +24,10 @@
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
   /// For TCP, UDP, Quic and TLS links, it is possible to specify a `bind` address for the local socket:
   /// E.g. tcp/192.168.0.1:7447#bind=192.168.0.1:0
-  //  Note!: Currently it is unsupported to specify both `bind` and `iface`. 
+  ///  Note!: Currently it is unsupported to specify both `bind` and `iface`.
+  ///
+  /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+  /// E.g. tcp/192.168.0.1:7447#dscp=0x08
   connect: {
     /// timeout waiting for all endpoints connected (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)
@@ -73,6 +76,9 @@
   ///
   /// For TCP and TLS links, it is possible to specify the TCP buffer sizes:
   /// E.g. tcp/192.168.0.1:7447#so_sndbuf=65000;so_rcvbuf=65000
+  ///
+  /// For TCP/UDP links, it's possible to specify the DSCP field of the IP header:
+  /// E.g. tcp/192.168.0.1:7447#dscp=0x08
   listen: {
     /// timeout waiting for all listen endpoints (0: no retry, -1: infinite timeout)
     /// Accepts a single value (e.g. timeout_ms: 0)

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -36,7 +36,7 @@ set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memor
 #    - https://github.com/eclipse-zenoh/zenoh/pull/1844
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION f60bbaba51417256b267f59f909a48eb99f1833b
+  VCS_VERSION 6bea1f1ebc29412548f36af91cf2225c8bf476d4
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
@@ -48,7 +48,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 868fdad0e7418e8f8cb96e94c89a3aed05905e63
+  VCS_VERSION 7379592436398079934f4296d2fa90217f8eddf9
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -17,23 +17,18 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # when expanded.
 set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memory zenoh/transport_compression zenoh/transport_tcp zenoh/transport_udp zenoh/transport_tls")
 
-# Set VCS_VERSION to include latest changes from zenoh/zenoh-c/zenoh-cpp to benefit from:
-# - Fix a bug leading to invalid inapropriate "Unable to push non droppable network message" log and transport closure:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1855
-# - Fix crash with highly chunked keys:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1826
-# - Resolve issue with closing the Session in atexit:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1632
-# - Change `Session::close()` implementation so it can be safely waited and awaited in `atexit``
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1632
-# - Add QoS overwrite interceptor allowing for instance a Router to be configured to change QoS on the fly
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1825
-# - Add link protocols as subject to interceptors (access_control, downsampling or qos overwrite):
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1850
-# - Add new non periodic last sample miss detection mechanism for Advanced Publisher:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1861
-# - Improve tracing for better analysis on the system like rmw_zenoh
-#    - https://github.com/eclipse-zenoh/zenoh/pull/1844
+# Set VCS_VERSION to 1.4.0 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+# - Add a "bind" config option for endpoints:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/1892
+# - Add a "low_pass_filter" config:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/1868
+#    - https://github.com/eclipse-zenoh/zenoh/pull/1895
+# - Add "zids" config parameter to "qos_overwrite":
+#    - https://github.com/eclipse-zenoh/zenoh/pull/1908
+# - Add support for link weights:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/1914
+# - Add support for DiffServ's DSCP config for endpoints:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/1937
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 6bea1f1ebc29412548f36af91cf2225c8bf476d4


### PR DESCRIPTION
## Description

This PR updates Zenoh to v1.4.0, making the following changes of commit ids:

- zenoh-cpp: [868fdad](https://github.com/eclipse-zenoh/zenoh-cpp/commit/868fdad0e7418e8f8cb96e94c89a3aed05905e63) -> [7379592](https://github.com/eclipse-zenoh/zenoh-cpp/commit/7379592436398079934f4296d2fa90217f8eddf9) -  [diff](https://github.com/eclipse-zenoh/zenoh-cpp/compare/868fdad0e7418e8f8cb96e94c89a3aed05905e63...7379592436398079934f4296d2fa90217f8eddf9)
- zenoh-c: [f60bbab](https://github.com/eclipse-zenoh/zenoh-c/commit/ffa4bddc947f7ed6c0e3b4546205dd1b73e7df81) -> [6bea1f1](https://github.com/eclipse-zenoh/zenoh-c/commit/f60bbaba51417256b267f59f909a48eb99f1833b) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/f60bbaba51417256b267f59f909a48eb99f1833b...6bea1f1ebc29412548f36af91cf2225c8bf476d4)
- zenoh: [3f62ebc](https://github.com/eclipse-zenoh/zenoh/commit/3f62ebcdcf67e9ea941fec777f577b4376bf5bcb) -> [c051173](https://github.com/eclipse-zenoh/zenoh/commit/c051173b8d39659d633286a498ca171435ed28b4) - [diff](https://github.com/eclipse-zenoh/zenoh/compare/3f62ebcdcf67e9ea941fec777f577b4376bf5bcb...c051173b8d39659d633286a498ca171435ed28b4)

It includes those notable changes:

- Add a "bind" config option for endpoints:
   - https://github.com/eclipse-zenoh/zenoh/pull/1892
- Add a "low_pass_filter" config:
   - https://github.com/eclipse-zenoh/zenoh/pull/1868
   - https://github.com/eclipse-zenoh/zenoh/pull/1895
- Add "zids" config parameter to "qos_overwrite":
   - https://github.com/eclipse-zenoh/zenoh/pull/1908
- Add support for link weights:
   - https://github.com/eclipse-zenoh/zenoh/pull/1914
- Add support for DiffServ's DSCP config for endpoints:
   - https://github.com/eclipse-zenoh/zenoh/pull/1937


### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

