### PR TITLE
Use data() to avoid potentially dereferencing an empty vector (fixes #666)

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1141,7 +1141,7 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
   }
 
   memcpy(
-    endpoints_info->info_array, &endpoints[0],
+    endpoints_info->info_array, endpoints.data(),
     sizeof(rmw_topic_endpoint_info_t) * endpoints.size());
 
   return RMW_RET_OK;


### PR DESCRIPTION
## Description
Fixes #666

Very minor change, but fixes this failure when vector assertions are enabled and the endpoint vector is empty.

### Is this user-facing behavior change?
No.

### Did you use Generative AI?
No.

### Additional Information
