### PR TITLE
Build zenoh_security_tools on Github action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,5 +41,6 @@ jobs:
         package-name: |
           rmw_zenoh_cpp
           zenoh_cpp_vendor
+          zenoh_security_tools
         target-ros2-distro: ${{ matrix.ROS_DISTRO }}
         vcs-repo-file-url: ${{ matrix.BUILD_TYPE == 'source' && env.ROS2_REPOS_FILE_URL || '' }}


### PR DESCRIPTION
Build `zenoh_security_tools` on Github action