### PR TITLE
Only configure the timeout of the action-related service `get_result` to maximum value.

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -215,8 +215,7 @@
 
   /// The default timeout to apply to queries in milliseconds.
   /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together.
-  ///              Note: the requests to services and actions are hard-coded with an infinite timeout. Hence, this setting
-  ///              only applies to the queries made by the Advanced Subscriber for TRANSIENT_LOCAL implementation.
+  ///              Note that only action-related service get_result is hard-coded with an infinite timeout.
   queries_default_timeout: 60000,
 
   /// The routing strategy to use and it's configuration.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -225,8 +225,7 @@
 
   /// The default timeout to apply to queries in milliseconds.
   /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together.
-  ///              Note: the requests to services and actions are hard-coded with an infinite timeout. Hence, this setting
-  ///              only applies to the queries made by the Advanced Subscriber for TRANSIENT_LOCAL implementation.
+  ///              Note that only action-related service get_result is hard-coded with an infinite timeout.
   queries_default_timeout: 60000,
 
   /// The routing strategy to use and it's configuration.

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -137,7 +137,7 @@ std::shared_ptr<ClientData> ClientData::make(
   // Among action-related services, only get_result usually requires a long response time.
   // In most scenarios, a shorter timeout is sufficient and helps prevent excessive waiting
   // in case a service reply is missed.
-  if (keyexpr_->intersects(zenoh::KeyExpr("**/_action/get_result/**"))) {
+  if (querier_ke.intersects(zenoh::KeyExpr("**/_action/get_result/**"))) {
     // The default timeout for a z_get query is 10 seconds and if a response is not received within
     // this window, the queryable will return an invalid reply. However, it is common for actions,
     // which are implemented using services, to take an extended duration to complete. Hence, we set

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -134,11 +134,16 @@ std::shared_ptr<ClientData> ClientData::make(
   zenoh::KeyExpr querier_ke(entity->topic_info()->topic_keyexpr_);
   auto options = zenoh::Session::QuerierOptions::create_default();
   options.target = Z_QUERY_TARGET_ALL_COMPLETE;
-  // The default timeout for a z_get query is 10 seconds and if a response is not received within
-  // this window, the queryable will return an invalid reply. However, it is common for actions,
-  // which are implemented using services, to take an extended duration to complete. Hence, we set
-  // the timeout_ms to the largest supported value to account for most realistic scenarios.
-  options.timeout_ms = std::numeric_limits<uint64_t>::max();
+  // Among action-related services, only get_result usually requires a long response time.
+  // In most scenarios, a shorter timeout is sufficient and helps prevent excessive waiting
+  // in case a service reply is missed.
+  if (keyexpr_->intersects(zenoh::KeyExpr("**/_action/get_result/**"))) {
+    // The default timeout for a z_get query is 10 seconds and if a response is not received within
+    // this window, the queryable will return an invalid reply. However, it is common for actions,
+    // which are implemented using services, to take an extended duration to complete. Hence, we set
+    // the timeout_ms to the largest supported value to account for most realistic scenarios.
+    options.timeout_ms = std::numeric_limits<uint64_t>::max();
+  }
   // Latest consolidation guarantees unicity of replies for the same key expression,
   // which optimizes bandwidth. The default is "None", which imples replies may come in any order
   // and any number.


### PR DESCRIPTION
## Description

Now in rmw_zenoh_cpp, the timeout for queries is configured to the maximum value.
This is because the service is also used in action, and the timeout of one of the services (get_result) can't be estimated.
https://design.ros2.org/articles/actions.html
However, this might introduce a memory-growing issue if users keep sending many queries, and some of them are missed.
Here is the result with the irobot benchmark tool:

![image](https://github.com/user-attachments/assets/cf6d5a87-90ce-431b-885d-f4bc68380eaa)

I think we can check if the keyexpr matches the `**/_action/get_result/**` to avoid configuring all other services to the maximum timeout, which is not reasonable.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

The default timeout is now inherited from the configuration `queries_default_timeout`, which is 60000 ms by default.
