### PR TITLE
Change zenoh-c features to use its default + shared-memory + transport_serial

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -10,12 +10,12 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-# Disable default features and enable only the most useful ones. This reduces build time and footprint.
+# Add a set of usefull features that are not enabled by default in zenoh-c.
 # For a complete list of features see: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
-# Note: We separate the two args needed for cargo with "$<SEMICOLON>" and not ";" as the
-# latter is a list separater in cmake and hence the string will be split into two
-# when expanded.
-set(ZENOHC_CARGO_FLAGS "--no-default-features$<SEMICOLON>--features=shared-memory zenoh/transport_compression zenoh/transport_tcp zenoh/transport_udp zenoh/transport_tls")
+# Note: the list of features are separated with whitespaces.
+# However, if you want to add other cargo build flags, is "$<SEMICOLON>" as separator and not ";" as the
+# latter is a list separater in cmake and hence the string will be split into two when expanded.
+set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 
 # Set VCS_VERSION to 1.4.0 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
 # - Add a "bind" config option for endpoints:

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -13,7 +13,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # Add a set of usefull features that are not enabled by default in zenoh-c.
 # For a complete list of features see: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
 # Note: the list of features are separated with whitespaces.
-# However, if you want to add other cargo build flags, is "$<SEMICOLON>" as separator and not ";" as the
+# However, if you want to add other cargo build flags, use "$<SEMICOLON>" as separator and not ";" as the
 # latter is a list separater in cmake and hence the string will be split into two when expanded.
 set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 


### PR DESCRIPTION
## Description

`rmw_zenoh` is currently building `zenoh-c` and `zenoh` with a limited subset of features:
- `shared-memory`
- `zenoh/transport_compression` 
- `zenoh/transport_tcp` 
- `zenoh/transport_udp` 
- `zenoh/transport_tls`

This PR changes the set of features to include:
- `zenoh-c` [default features](https://github.com/eclipse-zenoh/zenoh-c/blob/1.4.0/Cargo.toml#L49C1-L60C2) currently including:
  - `auth_pubkey`
  - `auth_usrpwd`
  - `transport_multilink`
  - `transport_compression`
  - `transport_quic`
  - `transport_tcp`
  - `transport_tls`
  - `transport_udp`
  - `transport_unixsock-stream`
  - `transport_ws`
- `shared-memory`
- `transport_serial`

Supersedes and closes #660 (as `transport_multilink` is included in default features).
Fixes #689

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information

This PR follows the discussion in #660, where I posted a [benchmark](https://github.com/ros2/rmw_zenoh/pull/660#issuecomment-3019856030) I made wrt. build time and disk usage with various features.

Adding more features to `zenoh-c` doesn't significantly increase the build time, and increases the disk space from 4.8GB to 5.1GB when adding multilink, serial and quic.