### PR TITLE
Use Zenoh Querier to replace Session.get

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -131,12 +131,27 @@ std::shared_ptr<ClientData> ClientData::make(
     return nullptr;
   }
 
+  zenoh::KeyExpr querier_ke(entity->topic_info()->topic_keyexpr_);
+  auto options = zenoh::Session::QuerierOptions::create_default();
+  options.target = Z_QUERY_TARGET_ALL_COMPLETE;
+  // The default timeout for a z_get query is 10 seconds and if a response is not received within
+  // this window, the queryable will return an invalid reply. However, it is common for actions,
+  // which are implemented using services, to take an extended duration to complete. Hence, we set
+  // the timeout_ms to the largest supported value to account for most realistic scenarios.
+  options.timeout_ms = std::numeric_limits<uint64_t>::max();
+  // Latest consolidation guarantees unicity of replies for the same key expression,
+  // which optimizes bandwidth. The default is "None", which imples replies may come in any order
+  // and any number.
+  options.consolidation = zenoh::ConsolidationMode::Z_CONSOLIDATION_MODE_NONE;
+  auto querier = session->declare_querier(querier_ke, std::move(options));
+
   std::shared_ptr<ClientData> client_data = std::shared_ptr<ClientData>(
     new ClientData{
       node,
       client,
       entity,
       session,
+      std::move(querier),
       request_members,
       response_members,
       request_type_support,
@@ -152,6 +167,7 @@ ClientData::ClientData(
   const rmw_client_t * rmw_client,
   std::shared_ptr<liveliness::Entity> entity,
   std::shared_ptr<zenoh::Session> sess,
+  zenoh::Querier querier_,
   const void * request_type_support_impl,
   const void * response_type_support_impl,
   std::shared_ptr<RequestTypeSupport> request_type_support,
@@ -160,6 +176,7 @@ ClientData::ClientData(
   rmw_client_(rmw_client),
   entity_(std::move(entity)),
   sess_(std::move(sess)),
+  querier_(std::move(querier_)),
   request_type_support_impl_(request_type_support_impl),
   response_type_support_impl_(response_type_support_impl),
   request_type_support_(request_type_support),
@@ -169,8 +186,6 @@ ClientData::ClientData(
   is_shutdown_(false),
   initialized_(false)
 {
-  std::string topic_keyexpr = this->entity_->topic_info().value().topic_keyexpr_;
-  keyexpr_ = zenoh::KeyExpr(topic_keyexpr);
   std::string liveliness_keyexpr = this->entity_->liveliness_keyexpr();
   zenoh::ZResult result;
   this->token_ = sess_->liveliness_declare_token(
@@ -225,7 +240,7 @@ void ClientData::add_new_reply(std::unique_ptr<ZenohReply> reply)
       "Query queue depth of %ld reached, discarding oldest Query "
       "for client for %s",
       adapted_qos_profile.depth,
-      std::string(keyexpr_.value().as_string_view()).c_str());
+      this->entity_->topic_info().value().topic_keyexpr_);
     reply_queue_.pop_front();
   }
   reply_queue_.emplace_back(std::move(reply));
@@ -371,20 +386,10 @@ rmw_ret_t ClientData::send_request(
     *sequence_id);
 
   // Send request
-  zenoh::Session::GetOptions opts = zenoh::Session::GetOptions::create_default();
+  auto opts = zenoh::Querier::GetOptions::create_default();
   int64_t source_timestamp = rmw_zenoh_cpp::get_system_time_in_ns();
   opts.attachment = rmw_zenoh_cpp::AttachmentData(
     *sequence_id, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
-  opts.target = Z_QUERY_TARGET_ALL_COMPLETE;
-  // The default timeout for a z_get query is 10 seconds and if a response is not received within
-  // this window, the queryable will return an invalid reply. However, it is common for actions,
-  // which are implemented using services, to take an extended duration to complete. Hence, we set
-  // the timeout_ms to the largest supported value to account for most realistic scenarios.
-  opts.timeout_ms = std::numeric_limits<uint64_t>::max();
-  // Latest consolidation guarantees unicity of replies for the same key expression,
-  // which optimizes bandwidth. The default is "None", which imples replies may come in any order
-  // and any number.
-  opts.consolidation = zenoh::ConsolidationMode::Z_CONSOLIDATION_MODE_NONE;
 
   std::vector<uint8_t> raw_bytes(
     reinterpret_cast<const uint8_t *>(request_bytes),
@@ -397,8 +402,7 @@ rmw_ret_t ClientData::send_request(
   // We explicitly release the mutex here to avoid an ABBA deadlock as
   // documented in https://github.com/ros2/rmw_zenoh/issues/484.
   lock.unlock();
-  context_impl->session()->get(
-    keyexpr_.value(),
+  querier_.get(
     parameters,
     [client_data](const zenoh::Reply & reply) {
       if (!reply.is_ok()) {
@@ -501,6 +505,14 @@ rmw_ret_t ClientData::shutdown()
         "Unable to undeclare liveliness token");
       return RMW_RET_ERROR;
     }
+  }
+  zenoh::ZResult result;
+  std::move(querier_).undeclare(&result);
+  if (result != Z_OK) {
+    RMW_ZENOH_LOG_ERROR_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to undeclare querier");
+    return RMW_RET_ERROR;
   }
 
   sess_.reset();

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -240,7 +240,7 @@ void ClientData::add_new_reply(std::unique_ptr<ZenohReply> reply)
       "Query queue depth of %ld reached, discarding oldest Query "
       "for client for %s",
       adapted_qos_profile.depth,
-      this->entity_->topic_info().value().topic_keyexpr_);
+      this->entity_->topic_info().value().topic_keyexpr_.c_str());
     reply_queue_.pop_front();
   }
   reply_queue_.emplace_back(std::move(reply));
@@ -502,7 +502,7 @@ rmw_ret_t ClientData::shutdown()
     if (result != Z_OK) {
       RMW_ZENOH_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
-        "Unable to undeclare liveliness token");
+        "Unable to undeclare the liveliness token");
       return RMW_RET_ERROR;
     }
   }
@@ -511,7 +511,7 @@ rmw_ret_t ClientData::shutdown()
   if (result != Z_OK) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to undeclare querier");
+      "Unable to undeclare the querier");
     return RMW_RET_ERROR;
   }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.hpp
@@ -109,6 +109,7 @@ private:
     const rmw_client_t * client,
     std::shared_ptr<liveliness::Entity> entity,
     std::shared_ptr<zenoh::Session> sess,
+    zenoh::Querier querier_,
     const void * request_type_support_impl,
     const void * response_type_support_impl,
     std::shared_ptr<RequestTypeSupport> request_type_support,
@@ -124,8 +125,8 @@ private:
   std::shared_ptr<liveliness::Entity> entity_;
   // A shared session.
   std::shared_ptr<zenoh::Session> sess_;
-  // An owned keyexpression.
-  std::optional<zenoh::KeyExpr> keyexpr_;
+  // Zenoh querier
+  zenoh::Querier querier_;
   // Liveliness token for the service.
   std::optional<zenoh::LivelinessToken> token_;
   // Type support fields.

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -243,7 +243,7 @@ public:
       if (result != Z_OK) {
         RMW_ZENOH_LOG_ERROR_NAMED(
           "rmw_zenoh_cpp",
-          "Unable to undeclare liveliness token");
+          "Unable to undeclare the liveliness token");
         return RMW_RET_ERROR;
       }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_node_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_node_data.cpp
@@ -402,7 +402,7 @@ rmw_ret_t NodeData::shutdown()
   if (result != Z_OK) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to undeclare liveliness token");
+      "Unable to undeclare the liveliness token");
     return RMW_RET_ERROR;
   }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -396,14 +396,14 @@ rmw_ret_t PublisherData::shutdown()
   if (result != Z_OK) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to undeclare liveliness token");
+      "Unable to undeclare the liveliness token");
     return RMW_RET_ERROR;
   }
   std::move(pub_).undeclare(&result);
   if (result != Z_OK) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to undeclare publisher");
+      "Unable to undeclare the publisher");
     return RMW_RET_ERROR;
   }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -533,7 +533,7 @@ rmw_ret_t ServiceData::shutdown()
     if (result != Z_OK) {
       RMW_ZENOH_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
-        "Unable to undeclare liveliness token");
+        "Unable to undeclare the liveliness token");
       return RMW_RET_ERROR;
     }
 
@@ -541,7 +541,7 @@ rmw_ret_t ServiceData::shutdown()
     if (result != Z_OK) {
       RMW_ZENOH_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
-        "Unable to undeclare queryable");
+        "Unable to undeclare the queryable");
       return RMW_RET_ERROR;
     }
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -324,7 +324,7 @@ rmw_ret_t SubscriptionData::shutdown()
   if (result != Z_OK) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Unable to undeclare liveliness token");
+      "Unable to undeclare the liveliness token");
     return RMW_RET_ERROR;
   }
 
@@ -333,7 +333,7 @@ rmw_ret_t SubscriptionData::shutdown()
     if (result != Z_OK) {
       RMW_ZENOH_LOG_ERROR_NAMED(
         "rmw_zenoh_cpp",
-        "failed to undeclare sub.");
+        "Unable to undeclare the subscriber.");
       return RMW_RET_ERROR;
     }
   }


### PR DESCRIPTION
## Description

Zenoh supports Querier, which can avoid assigning key_expr and reperforming matching at every get.
This can also reduce the CPU usage in rmw_zenoh.

### Is this user-facing behavior change?

### Did you use Generative AI?

No

### Additional Information

N/A
