### PR TITLE
Remove the extra copy on the publisher side

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -265,10 +265,10 @@ rmw_ret_t PublisherData::publish(
 
   // TODO(ahcorde): shmbuf
   auto deleter = [msg_bytes, allocator](uint8_t *) {
-    if (msg_bytes) {
-      allocator->deallocate(msg_bytes, allocator->state);
-    }
-  };
+      if (msg_bytes) {
+        allocator->deallocate(msg_bytes, allocator->state);
+      }
+    };
   zenoh::Bytes payload(msg_bytes, data_length, deleter);
   // The delete responsibility has been handed over to zenoh::Bytes now
   always_free_msg_bytes.cancel();

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -222,7 +222,7 @@ rmw_ret_t PublisherData::publish(
     type_support_impl_);
 
   // To store serialized message byte array.
-  char * msg_bytes = nullptr;
+  uint8_t * msg_bytes = nullptr;
 
   rcutils_allocator_t * allocator = &rmw_node_->context->options.allocator;
 
@@ -234,12 +234,12 @@ rmw_ret_t PublisherData::publish(
     });
 
   // Get memory from the allocator.
-  msg_bytes = static_cast<char *>(allocator->allocate(max_data_length, allocator->state));
+  msg_bytes = static_cast<uint8_t *>(allocator->allocate(max_data_length, allocator->state));
   RMW_CHECK_FOR_NULL_WITH_MSG(
     msg_bytes, "bytes for message is null", return RMW_RET_BAD_ALLOC);
 
   // Object that manages the raw buffer
-  eprosima::fastcdr::FastBuffer fastbuffer(msg_bytes, max_data_length);
+  eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char *>(msg_bytes), max_data_length);
 
   // Object that serializes the data
   rmw_zenoh_cpp::Cdr ser(fastbuffer);
@@ -264,10 +264,14 @@ rmw_ret_t PublisherData::publish(
     sequence_number_++, source_timestamp, entity_->copy_gid()).serialize_to_zbytes();
 
   // TODO(ahcorde): shmbuf
-  std::vector<uint8_t> raw_data(
-    reinterpret_cast<const uint8_t *>(msg_bytes),
-    reinterpret_cast<const uint8_t *>(msg_bytes) + data_length);
-  zenoh::Bytes payload(std::move(raw_data));
+  auto deleter = [msg_bytes, allocator](uint8_t *) {
+    if (msg_bytes) {
+      allocator->deallocate(msg_bytes, allocator->state);
+    }
+  };
+  zenoh::Bytes payload(msg_bytes, data_length, deleter);
+  // The delete responsibility has been handed over to zenoh::Bytes now
+  always_free_msg_bytes.cancel();
 
   TRACETOOLS_TRACEPOINT(
     rmw_publish, static_cast<const void *>(rmw_publisher_), ros_message, source_timestamp);


### PR DESCRIPTION
## Description

In the current implementation, when we publish data, we copy the serialized data to a new vector and then send it out. It will increase the latency and CPU utilization
We can use another constructor in ZBytes to release the resource with a deleter, which will improve the performance.

* Before

<img width="1839" height="451" alt="image" src="https://github.com/user-attachments/assets/e49ed628-8f9e-44f3-b803-ca99d4e4f90b" />

* After

<img width="1839" height="451" alt="image" src="https://github.com/user-attachments/assets/61760023-ce60-411a-ae87-c5d7340c0c69" />

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

No
