### PR TITLE
rmw_zenoh_cpp: Include algorithm for std::find_if

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <algorithm>
 #include <array>
 #include <functional>
 #include <limits>


### PR DESCRIPTION
## Description

Fixing a compilation issue with Yocto at Master (GCC 15.1)

```
src/detail/graph_cache.cpp:355:36: error: 'find_if' is not a member of 'std'; did you mean 'find'?
```


Fixes # (issue)

### Is this user-facing behavior change?

no


### Did you use Generative AI?



### Additional Information


