### PR TITLE
refactor: avoid redundant key expression creation when replying

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -128,25 +128,27 @@ std::shared_ptr<ServiceData> ServiceData::make(
     return nullptr;
   }
 
+  zenoh::ZResult result;
+  std::string keyexpr_string = entity->topic_info()->topic_keyexpr_;
+  auto keyexpr = zenoh::KeyExpr(std::move(keyexpr_string), true, &result);
+  if (result != Z_OK) {
+    RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
+    return nullptr;
+  }
+
   auto service_data = std::shared_ptr<ServiceData>(
     new ServiceData{
       node,
       rmw_service,
       std::move(entity),
       session,
+      std::move(keyexpr),
       request_members,
       response_members,
       std::move(request_type_support),
       std::move(response_type_support)
     });
 
-  zenoh::ZResult result;
-  std::string keyexpr_string = service_data->entity_->topic_info()->topic_keyexpr_;
-  service_data->keyexpr_ = zenoh::KeyExpr(std::move(keyexpr_string), true, &result);
-  if (result != Z_OK) {
-    RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
-    return nullptr;
-  }
 
   zenoh::Session::QueryableOptions qable_options =
     zenoh::Session::QueryableOptions::create_default();
@@ -154,7 +156,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
 
   std::weak_ptr<rmw_zenoh_cpp::ServiceData> data_wp = service_data;
   service_data->qable_ = session->declare_queryable(
-    service_data->keyexpr_.value(),
+    service_data->keyexpr_,
     [data_wp](const zenoh::Query & query) {
       auto sub_data = data_wp.lock();
       if (sub_data == nullptr) {
@@ -196,6 +198,7 @@ ServiceData::ServiceData(
   const rmw_service_t * rmw_service,
   std::shared_ptr<liveliness::Entity> entity,
   std::shared_ptr<zenoh::Session> session,
+  zenoh::KeyExpr keyexpr,
   const void * request_type_support_impl,
   const void * response_type_support_impl,
   std::unique_ptr<RequestTypeSupport> request_type_support,
@@ -204,6 +207,7 @@ ServiceData::ServiceData(
   rmw_service_(rmw_service),
   entity_(std::move(entity)),
   sess_(std::move(session)),
+  keyexpr_(std::move(keyexpr)),
   request_type_support_impl_(request_type_support_impl),
   response_type_support_impl_(response_type_support_impl),
   request_type_support_(std::move(request_type_support)),
@@ -254,7 +258,7 @@ void ServiceData::add_new_query(std::unique_ptr<ZenohQuery> query)
       "Query queue depth of %ld reached, discarding oldest Query "
       "for service for %s",
       adapted_qos_profile.depth,
-      std::string(keyexpr_.value().as_string_view()).c_str());
+      std::string(keyexpr_.as_string_view()).c_str());
     query_queue_.pop_front();
   }
   query_queue_.emplace_back(std::move(query));
@@ -458,7 +462,7 @@ rmw_ret_t ServiceData::send_response(
     request_id->sequence_number,
     source_timestamp);
   zenoh::ZResult result;
-  loaned_query.reply(keyexpr_.value(), std::move(payload), std::move(options), &result);
+  loaned_query.reply(keyexpr_, std::move(payload), std::move(options), &result);
   if (result != Z_OK) {
     RMW_SET_ERROR_MSG("unable to reply");
     return RMW_RET_ERROR;

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
 
   zenoh::ZResult result;
   std::string keyexpr_string = service_data->entity_->topic_info()->topic_keyexpr_;
-  service_data->keyexpr_ = zenoh::KeyExpr(keyexpr_string, true, &result);
+  service_data->keyexpr_ = zenoh::KeyExpr(std::move(keyexpr_string), true, &result);
   if (result != Z_OK) {
     RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
     return nullptr;

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -141,8 +141,8 @@ std::shared_ptr<ServiceData> ServiceData::make(
     });
 
   zenoh::ZResult result;
-  service_data->keyexpr_ = service_data->entity_->topic_info()->topic_keyexpr_;
-  zenoh::KeyExpr service_ke(service_data->keyexpr_, true, &result);
+  std::string keyexpr_string = service_data->entity_->topic_info()->topic_keyexpr_;
+  service_data->keyexpr_ = zenoh::KeyExpr(keyexpr_string, true, &result);
   if (result != Z_OK) {
     RMW_SET_ERROR_MSG("unable to create zenoh keyexpr.");
     return nullptr;
@@ -154,7 +154,7 @@ std::shared_ptr<ServiceData> ServiceData::make(
 
   std::weak_ptr<rmw_zenoh_cpp::ServiceData> data_wp = service_data;
   service_data->qable_ = session->declare_queryable(
-    service_ke,
+    service_data->keyexpr_.value(),
     [data_wp](const zenoh::Query & query) {
       auto sub_data = data_wp.lock();
       if (sub_data == nullptr) {
@@ -254,7 +254,7 @@ void ServiceData::add_new_query(std::unique_ptr<ZenohQuery> query)
       "Query queue depth of %ld reached, discarding oldest Query "
       "for service for %s",
       adapted_qos_profile.depth,
-      keyexpr_.c_str());
+      std::string(keyexpr_.value().as_string_view()).c_str());
     query_queue_.pop_front();
   }
   query_queue_.emplace_back(std::move(query));
@@ -450,13 +450,6 @@ rmw_ret_t ServiceData::send_response(
     reinterpret_cast<const uint8_t *>(response_bytes) + data_length);
   zenoh::Bytes payload(std::move(raw_bytes));
 
-  zenoh::ZResult result;
-  zenoh::KeyExpr service_ke(keyexpr_.c_str(), true, &result);
-  if (result != Z_OK) {
-    RMW_SET_ERROR_MSG("unable to create KeyExpr");
-    return RMW_RET_ERROR;
-  }
-
   TRACETOOLS_TRACEPOINT(
     rmw_send_response,
     static_cast<const void *>(rmw_service_),
@@ -464,7 +457,8 @@ rmw_ret_t ServiceData::send_response(
     request_id->writer_guid,
     request_id->sequence_number,
     source_timestamp);
-  loaned_query.reply(service_ke, std::move(payload), std::move(options), &result);
+  zenoh::ZResult result;
+  loaned_query.reply(keyexpr_.value(), std::move(payload), std::move(options), &result);
   if (result != Z_OK) {
     RMW_SET_ERROR_MSG("unable to reply");
     return RMW_RET_ERROR;

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
@@ -102,6 +102,7 @@ private:
     const rmw_service_t * rmw_service,
     std::shared_ptr<liveliness::Entity> entity,
     std::shared_ptr<zenoh::Session> session,
+    zenoh::KeyExpr keyexpr,
     const void * request_type_support_impl,
     const void * response_type_support_impl,
     std::unique_ptr<RequestTypeSupport> request_type_support,
@@ -119,15 +120,7 @@ private:
   // A shared session
   std::shared_ptr<zenoh::Session> sess_;
   // An owned keyexpr.
-  // The KeyExpr *must* exist in order for anything in this ServiceData class,
-  // and hence rmw_zenoh_cpp, to work.
-  // However, zenoh::KeyExpr does not have an empty constructor,
-  // so just declaring this as a zenoh::KeyExpr fails to compile.
-  // We work around that by wrapping it in a std::optional, so the std::optional
-  // gets constructed at ServiceData constructor time,
-  // and then we initialize keyexpr_ later. Note that the zenoh-cpp API KeyExpr() throws an
-  // exception if it fails, so this should all be safe to do.
-  std::optional<zenoh::KeyExpr> keyexpr_;
+  zenoh::KeyExpr keyexpr_;
   // An owned queryable.
   // The Queryable *must* exist in order for anything in this ServiceData class,
   // and hence rmw_zenoh_cpp, to work.

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
@@ -118,7 +118,15 @@ private:
 
   // A shared session
   std::shared_ptr<zenoh::Session> sess_;
-  // The keyexpr.
+  // An owned keyexpr.
+  // The KeyExpr *must* exist in order for anything in this ServiceData class,
+  // and hence rmw_zenoh_cpp, to work.
+  // However, zenoh::KeyExpr does not have an empty constructor,
+  // so just declaring this as a zenoh::KeyExpr fails to compile.
+  // We work around that by wrapping it in a std::optional, so the std::optional
+  // gets constructed at ServiceData constructor time,
+  // and then we initialize keyexpr_ later. Note that the zenoh-cpp API KeyExpr() throws an
+  // exception if it fails, so this should all be safe to do.
   std::optional<zenoh::KeyExpr> keyexpr_;
   // An owned queryable.
   // The Queryable *must* exist in order for anything in this ServiceData class,

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.hpp
@@ -118,8 +118,8 @@ private:
 
   // A shared session
   std::shared_ptr<zenoh::Session> sess_;
-  // The keyexpr string.
-  std::string keyexpr_;
+  // The keyexpr.
+  std::optional<zenoh::KeyExpr> keyexpr_;
   // An owned queryable.
   // The Queryable *must* exist in order for anything in this ServiceData class,
   // and hence rmw_zenoh_cpp, to work.


### PR DESCRIPTION
## Description

The creation of the key expression while replying is duplicated and costly. This PR addresses this issue.
