### PR TITLE
 fixing typo flow to flows in config files

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -372,7 +372,7 @@
   //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the rules will be applied to both flows.
-  //      flow: ["ingress", "egress"],
+  //      flows: ["ingress", "egress"],
   //      /// List of message type on which downsampling will be applied. Must not be empty.
   //      messages: [
   //        /// Publication (Put and Delete)
@@ -510,7 +510,7 @@
   //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the filter will be applied to both flows.
-  //      flow: ["ingress", "egress"],
+  //      flows: ["ingress", "egress"],
   //      /// List of message type on which the filter will be applied. Must not be empty.
   //      messages: [
   //        "put",

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -380,7 +380,7 @@
   //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the rules will be applied to both flows.
-  //      flow: ["ingress", "egress"],
+  //      flows: ["ingress", "egress"],
   //      /// List of message type on which downsampling will be applied. Must not be empty.
   //      messages: [
   //        /// Publication (Put and Delete)
@@ -518,7 +518,7 @@
   //      link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
   //      /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //      /// If absent, the filter will be applied to both flows.
-  //      flow: ["ingress", "egress"],
+  //      flows: ["ingress", "egress"],
   //      /// List of message type on which the filter will be applied. Must not be empty.
   //      messages: [
   //        "put",


### PR DESCRIPTION
## Description

Fix typo in example configs. Use "flows" instead of "flow" in low_pass_filter and downsampling in ``DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5`` and ``DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5``

Fixes #738