### PR TITLE
Fix handling of enclave path in zenoh_security_tools

### DIFF
--- a/zenoh_security_tools/src/config_generator.cpp
+++ b/zenoh_security_tools/src/config_generator.cpp
@@ -65,11 +65,11 @@ namespace zenoh_security_tools
 //==============================================================================
 ConfigGenerator::ConfigGenerator(
   const std::string & policy_filepath,
-  const std::string & enclaves_dir,
+  std::optional<std::string> enclaves_dir,
   const std::string & zenoh_router_config_filepath,
   const std::string & zenoh_session_config_filepath,
   uint8_t domain_id)
-: enclaves_dir_(std::nullopt),
+: enclaves_dir_(std::move(enclaves_dir)),
   zenoh_router_config_filepath_(std::move(zenoh_router_config_filepath)),
   zenoh_session_config_filepath_(std::move(zenoh_session_config_filepath)),
   domain_id_(std::move(domain_id))
@@ -77,13 +77,6 @@ ConfigGenerator::ConfigGenerator(
   const tinyxml2::XMLError error = doc_.LoadFile(policy_filepath.c_str());
   if (error != tinyxml2::XML_SUCCESS) {
     throw std::runtime_error("Invalid argument: wrong policy file.");
-  }
-
-  if (!enclaves_dir.empty()) {
-    std::filesystem::path maybe_dir{enclaves_dir};
-    if (std::filesystem::is_directory(enclaves_dir)) {
-      enclaves_dir_ = std::move(maybe_dir);
-    }
   }
 }
 
@@ -343,7 +336,16 @@ void ConfigGenerator::fill_certificates(
   if (!enclaves_dir_.has_value()) {
     return;
   }
-  auto enclaves_dir = enclaves_dir_.value();
+
+  std::filesystem::path enclaves_dir{enclaves_dir_.value()};
+  if (!std::filesystem::is_directory(enclaves_dir)) {
+    std::cout << "No directory for enclaves with name "
+              << enclaves_dir.string()
+              << ". Skipping authentication..."
+              << std::endl;
+    return;
+  }
+
   auto enclave_dir = enclaves_dir / node_name;
   if (!std::filesystem::is_directory(enclaves_dir)) {
     std::cout << "No directory with name "

--- a/zenoh_security_tools/src/config_generator.hpp
+++ b/zenoh_security_tools/src/config_generator.hpp
@@ -56,7 +56,7 @@ public:
    */
   ConfigGenerator(
     const std::string & policy_filepath,
-    const std::string & enclaves_dir,
+    std::optional<std::string> enclaves_dir,
     const std::string & zenoh_router_config_filepath,
     const std::string & zenoh_session_config_filepath,
     uint8_t domain_id);
@@ -79,7 +79,7 @@ private:
     const std::string & node_name);
 
   tinyxml2::XMLDocument doc_;
-  std::optional<std::filesystem::path> enclaves_dir_;
+  std::optional<std::string> enclaves_dir_;
   std::string zenoh_router_config_filepath_;
   std::string zenoh_session_config_filepath_;
 

--- a/zenoh_security_tools/src/main.cpp
+++ b/zenoh_security_tools/src/main.cpp
@@ -129,6 +129,10 @@ int main(int argc, char *argv[])
     return 1;
   }
 
+  if (!args.enclaves_dir) {
+    std::cerr << "Warning: --enclaves not provided." << std::endl;
+  }
+
   if (!args.ros_domain_id) {
     std::cerr << "Error: --ros-domain-id is required." << std::endl;
     print_help();
@@ -149,7 +153,7 @@ int main(int argc, char *argv[])
 
   auto config_generator = zenoh_security_tools::ConfigGenerator(
     args.policy_filepath.value(),
-    args.enclaves_dir.value(),
+    args.enclaves_dir,
     args.zenoh_router_config_filepath.value(),
     args.zenoh_session_config_filepath.value(),
     args.ros_domain_id.value());


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

This PR fixes https://github.com/ros2/rmw_zenoh/issues/752. 
The main issue was the `ConfigGenerator` treated the path to the enclaves directory as optional and would not fill in certificates information in the Zenoh configs if not provided. However, `main.cpp` did not treat this parameter as optional.


<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

https://github.com/ros2/rmw_zenoh/issues/752

### Is this user-facing behavior change?

Yes

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Executable no longer crashes when `--enclaves` is not provided.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
