### PR TITLE
SROS: add ACL rules for TRANSIENT_LOCAL pub/sub (fix #753)

### DIFF
--- a/zenoh_security_tools/src/config_generator.cpp
+++ b/zenoh_security_tools/src/config_generator.cpp
@@ -97,7 +97,7 @@ bool replace(
 }
 
 //==============================================================================
-// Convert topic/service names to allowed key expression for 
+// Convert topic/service names to allowed key expression for
 // Zenoh publications, subscriptions, queryables and queries
 json to_key_exprs(
   const std::set<std::string> & key_exprs,

--- a/zenoh_security_tools/src/config_generator.cpp
+++ b/zenoh_security_tools/src/config_generator.cpp
@@ -113,7 +113,8 @@ json to_key_exprs(
 }
 
 //==============================================================================
-// Convert topic names to allowed key expression for Zenoh AdvancedPublisher's queryable and liveliness token
+// Convert topic names to allowed key expression for
+// Zenoh AdvancedPublisher's queryable and liveliness token
 json to_adv_pub_queryable_key_exprs(
   const std::set<std::string> & key_exprs,
   uint8_t domain_id)
@@ -297,7 +298,8 @@ void ConfigGenerator::fill_access_control(
     rules.push_back(rule_allow_pub_in);
     policies_rules.push_back("incoming_subscriptions");
 
-    // For TRANSIENT_LOCAL publishers, allow outgoing AdvancedPublisher's Queryable and LivelinessToken declarations
+    // For TRANSIENT_LOCAL publishers, allow outgoing AdvancedPublisher's
+    // Queryable and LivelinessToken declarations
     json rule_allow_transient_local_queryable = json::object({
         {"id", "outgoing_publications_transient_local_queryable"},
         {"messages", json::array({"declare_queryable", "liveliness_token"})},
@@ -309,7 +311,8 @@ void ConfigGenerator::fill_access_control(
     policies_rules.push_back("outgoing_publications_transient_local_queryable");
 
     // For TRANSIENT_LOCAL publishers, allow incoming queries from AdvancedSubscriber.
-    // The replies have the same key expression than the publication (allowed by rule "outgoing_publications")
+    // The replies have the same key expression than the publication, and this is
+    // allowed by rule "outgoing_publications" above.
     json rule_allow_transient_local_query = json::object({
         {"id", "incoming_subscriptions_transient_local_query"},
         {"messages", json::array({"query"})},
@@ -343,7 +346,8 @@ void ConfigGenerator::fill_access_control(
     policies_rules.push_back("incoming_publications");
 
     // For TRANSIENT_LOCAL subscriber, allow outgoing queries to the AdvancedPublishers
-    // The replies have the same key expression than the publication (allowed by rule "incoming_publications")
+    // The replies have the same key expression than the publication, and this is
+    // allowed by rule "incoming_publications" above.
     json rule_allow_transient_local_query = json::object({
         {"id", "outgoing_subscriptions_transient_local_query"},
         {"messages", json::array({"query", "declare_liveliness_subscriber"})},
@@ -354,7 +358,8 @@ void ConfigGenerator::fill_access_control(
     rules.push_back(rule_allow_transient_local_query);
     policies_rules.push_back("outgoing_subscriptions_transient_local_query");
 
-    // For TRANSIENT_LOCAL subscriber, allow incoming Queryable and LivelinessToken declarations from AdvancedPublisher.
+    // For TRANSIENT_LOCAL subscriber, allow incoming Queryable and
+    // LivelinessToken declarations from AdvancedPublisher.
     json rule_allow_transient_local_queryable = json::object({
         {"id", "incoming_subscriptions_transient_local_queryable"},
         {"messages", json::array({"declare_queryable", "liveliness_token"})},

--- a/zenoh_security_tools/src/config_generator.cpp
+++ b/zenoh_security_tools/src/config_generator.cpp
@@ -37,6 +37,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <set>
 
 #include <nlohmann/json.hpp>
 

--- a/zenoh_security_tools/src/config_generator.cpp
+++ b/zenoh_security_tools/src/config_generator.cpp
@@ -97,6 +97,8 @@ bool replace(
 }
 
 //==============================================================================
+// Convert topic/service names to allowed key expression for 
+// Zenoh publications, subscriptions, queryables and queries
 json to_key_exprs(
   const std::set<std::string> & key_exprs,
   uint8_t domain_id)
@@ -104,7 +106,37 @@ json to_key_exprs(
   json key_exprs_ret = json::array();
 
   for (const auto & name : key_exprs) {
-    key_exprs_ret.push_back(std::to_string(domain_id) + "/" + name + "/**");
+    key_exprs_ret.push_back(std::to_string(domain_id) + "/" + name + "/*/*");
+  }
+
+  return key_exprs_ret;
+}
+
+//==============================================================================
+// Convert topic names to allowed key expression for Zenoh AdvancedPublisher's queryable and liveliness token
+json to_adv_pub_queryable_key_exprs(
+  const std::set<std::string> & key_exprs,
+  uint8_t domain_id)
+{
+  json key_exprs_ret = json::array();
+
+  for (const auto & name : key_exprs) {
+    key_exprs_ret.push_back(std::to_string(domain_id) + "/" + name + "/*/*/@adv/pub/*/*/_");
+  }
+
+  return key_exprs_ret;
+}
+
+//==============================================================================
+// Convert topic names to allowed key expression for Zenoh AdvancedSubscriber's query
+json to_adv_sub_query_key_exprs(
+  const std::set<std::string> & key_exprs,
+  uint8_t domain_id)
+{
+  json key_exprs_ret = json::array();
+
+  for (const auto & name : key_exprs) {
+    key_exprs_ret.push_back(std::to_string(domain_id) + "/" + name + "/*/*/@adv/**");
   }
 
   return key_exprs_ret;
@@ -247,7 +279,7 @@ void ConfigGenerator::fill_access_control(
   if (!topics_pub_allow_.empty()) {
     json rule_allow_pub_out = json::object({
         {"id", "outgoing_publications"},
-        {"messages", json::array({"put"})},
+        {"messages", json::array({"put", "reply"})},
         {"flows", json::array({"egress"})},
         {"permission", "allow"},
         {"key_exprs", to_key_exprs(topics_pub_allow_, domain_id_)},
@@ -264,6 +296,29 @@ void ConfigGenerator::fill_access_control(
     });
     rules.push_back(rule_allow_pub_in);
     policies_rules.push_back("incoming_subscriptions");
+
+    // For TRANSIENT_LOCAL publishers, allow outgoing AdvancedPublisher's Queryable and LivelinessToken declarations
+    json rule_allow_transient_local_queryable = json::object({
+        {"id", "outgoing_publications_transient_local_queryable"},
+        {"messages", json::array({"declare_queryable", "liveliness_token"})},
+        {"flows", json::array({"egress"})},
+        {"permission", "allow"},
+        {"key_exprs", to_adv_pub_queryable_key_exprs(topics_pub_allow_, domain_id_)},
+    });
+    rules.push_back(rule_allow_transient_local_queryable);
+    policies_rules.push_back("outgoing_publications_transient_local_queryable");
+
+    // For TRANSIENT_LOCAL publishers, allow incoming queries from AdvancedSubscriber.
+    // The replies have the same key expression than the publication (allowed by rule "outgoing_publications")
+    json rule_allow_transient_local_query = json::object({
+        {"id", "incoming_subscriptions_transient_local_query"},
+        {"messages", json::array({"query"})},
+        {"flows", json::array({"ingress"})},
+        {"permission", "allow"},
+        {"key_exprs", to_adv_sub_query_key_exprs(topics_pub_allow_, domain_id_)},
+    });
+    rules.push_back(rule_allow_transient_local_query);
+    policies_rules.push_back("incoming_subscriptions_transient_local_query");
   }
 
   if (!topics_sub_allow_.empty()) {
@@ -279,13 +334,36 @@ void ConfigGenerator::fill_access_control(
 
     json rule_allow_sub_in = json::object({
         {"id", "incoming_publications"},
-        {"messages", json::array({"put"})},
+        {"messages", json::array({"put", "reply"})},
         {"flows", json::array({"ingress"})},
         {"permission", "allow"},
         {"key_exprs", to_key_exprs(topics_sub_allow_, domain_id_)},
     });
     rules.push_back(rule_allow_sub_in);
     policies_rules.push_back("incoming_publications");
+
+    // For TRANSIENT_LOCAL subscriber, allow outgoing queries to the AdvancedPublishers
+    // The replies have the same key expression than the publication (allowed by rule "incoming_publications")
+    json rule_allow_transient_local_query = json::object({
+        {"id", "outgoing_subscriptions_transient_local_query"},
+        {"messages", json::array({"query", "declare_liveliness_subscriber"})},
+        {"flows", json::array({"egress"})},
+        {"permission", "allow"},
+        {"key_exprs", to_adv_sub_query_key_exprs(topics_sub_allow_, domain_id_)},
+    });
+    rules.push_back(rule_allow_transient_local_query);
+    policies_rules.push_back("outgoing_subscriptions_transient_local_query");
+
+    // For TRANSIENT_LOCAL subscriber, allow incoming Queryable and LivelinessToken declarations from AdvancedPublisher.
+    json rule_allow_transient_local_queryable = json::object({
+        {"id", "incoming_subscriptions_transient_local_queryable"},
+        {"messages", json::array({"declare_queryable", "liveliness_token"})},
+        {"flows", json::array({"ingress"})},
+        {"permission", "allow"},
+        {"key_exprs", to_adv_pub_queryable_key_exprs(topics_sub_allow_, domain_id_)},
+    });
+    rules.push_back(rule_allow_transient_local_queryable);
+    policies_rules.push_back("incoming_subscriptions_transient_local_queryable");
   }
 
   json liveliness_messages = json::array({


### PR DESCRIPTION
## Description

In zenoh_security_tools `config_generator`: add missing access control rules for TRANSIENT_LOCAL Publishers and Subscribers:

* for a Publisher: 
  - in **egress**: `"put"` and `"reply"` on `"<domain_id>/<full_name>/*/*"` 
  - in **egress**: `"declare_queryable"` and `"liveliness_token"` on `"<domain_id>/<full_name>/*/*/@adv/pub/*/*/_"`
  - in **ingress**: `"query"` on `"<domain_id>/<full_name>/*/*/@adv/**"`
* for a Subscriber:
  - in **egress**: `"declare_subscriber"` on `"<domain_id>/<full_name>/*/*"`
  - in **egress**:  `"query"` and `"declare_liveliness_subscriber"` on `"<domain_id>/<full_name>/*/*/@adv/**"`
  - in **ingress**: `"put"` and `"reply"` on `"<domain_id>/<full_name>/*/*"`
  - in **ingress**: `"declare_queryable"` and `"liveliness_token"` on `"<domain_id>/<full_name>/*/*/@adv/pub/*/*/_"` 


Fixes #753

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.
