### PR TITLE
fix: handle missing enclaves_dir argument for zenoh_security_tools

### DIFF
--- a/zenoh_security_tools/src/main.cpp
+++ b/zenoh_security_tools/src/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 
   auto config_generator = zenoh_security_tools::ConfigGenerator(
     args.policy_filepath.value(),
-    args.enclaves_dir,
+    args.enclaves_dir.has_value() ? args.enclaves_dir.value() : "",
     args.zenoh_router_config_filepath.value(),
     args.zenoh_session_config_filepath.value(),
     args.ros_domain_id.value());


### PR DESCRIPTION
## Description

Fixes #787 

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No