### PR TITLE
Revert "fix: handle missing enclaves_dir argument for zenoh_security_tools"

### DIFF
--- a/zenoh_security_tools/src/main.cpp
+++ b/zenoh_security_tools/src/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char *argv[])
 
   auto config_generator = zenoh_security_tools::ConfigGenerator(
     args.policy_filepath.value(),
-    args.enclaves_dir.has_value() ? args.enclaves_dir.value() : "",
+    args.enclaves_dir,
     args.zenoh_router_config_filepath.value(),
     args.zenoh_session_config_filepath.value(),
     args.ros_domain_id.value());


### PR DESCRIPTION
Reverts ros2/rmw_zenoh#788 for reasons described in https://github.com/ros2/rmw_zenoh/pull/788#issuecomment-3284226163