### PR TITLE
Fix commands in zenoh_security_tools README

### DIFF
--- a/zenoh_security_tools/README.md
+++ b/zenoh_security_tools/README.md
@@ -114,7 +114,7 @@ You can validate access control by remapping the `/chatter` topic which should r
 
 ```bash
 export ZENOH_SESSION_CONFIG_URI=zenohd.json5
-ros2 rmw_zenoh_cpp rmw_zenohd
+ros2 run rmw_zenoh_cpp rmw_zenohd
 ```
 
 ```bash
@@ -138,7 +138,7 @@ ros2 run zenoh_security_tools generate_configs \
   --policy policy_listener_talker.xml \
   --router-config <path to default router config>/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5 \
   --session-config <path to default session config>/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5 \
-  --ros-domain-id 0
+  --ros-domain-id 0 \
   --enclaves ~/sros2_demo/demo_keystore/enclaves/talker_listener
 ```
 
@@ -148,14 +148,14 @@ The executable assumes that the `~/sros2_demo/demo_keystore/enclaves/talker_list
 Start the zenoh router with the `zenohd.json` config file.
 ```bash
 export ZENOH_ROUTER_CONFIG_URI=zenohd.json5
-ros2 rmw_zenoh_cpp rmw_zenohd
+ros2 run rmw_zenoh_cpp rmw_zenohd
 ```
 
 Start the talker
 
 ```bash
 export ZENOH_SESSION_CONFIG_URI=talker.json5
-ros2 rmw_zenoh_cpp rmw_zenohd
+ros2 run demo_nodes_cpp talker
 ```
 
 Start the listener without setting the session config.


### PR DESCRIPTION
## Description

1. Add missing `run` after `ros2`
2. Add missing trailing `\` for multiline command
3. Fix command for `talker` node

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
