### PR TITLE
Fix compile with clang-19

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -115,6 +115,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
   }
 
   using AdvancedPublisherOptions = zenoh::ext::SessionExt::AdvancedPublisherOptions;
+  using SampleMissDetectionOptions = AdvancedPublisherOptions::SampleMissDetectionOptions;
   auto adv_pub_opts = AdvancedPublisherOptions::create_default();
 
   if (adapted_qos_profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
@@ -126,8 +127,9 @@ std::shared_ptr<PublisherData> PublisherData::make(
       // If RELIABLE + TRANSIENT_LOCAL activate sample miss detection for subscriber
       // to detect missed samples and retrieve those from the Publisher cache.
       // HeartbeatSporadic is used to prevent excessive background traffic
-      adv_pub_opts.sample_miss_detection.emplace().heartbeat =
-        AdvancedPublisherOptions::SampleMissDetectionOptions::HeartbeatSporadic{
+      adv_pub_opts.sample_miss_detection = SampleMissDetectionOptions{};
+      adv_pub_opts.sample_miss_detection->heartbeat =
+        SampleMissDetectionOptions::HeartbeatSporadic{
         SAMPLE_MISS_DETECTION_HEARTBEAT_PERIOD};
     }
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -175,6 +175,7 @@ bool SubscriptionData::init()
   sess_ = context_impl->session();
 
   using AdvancedSubscriberOptions = zenoh::ext::SessionExt::AdvancedSubscriberOptions;
+  using RecoveryOptions = AdvancedSubscriberOptions::RecoveryOptions;
   auto adv_sub_opts = AdvancedSubscriberOptions::create_default();
 
   // By default, this subscription will receive publications from publishers within and outside of
@@ -200,8 +201,8 @@ bool SubscriptionData::init()
       // Activate recovery of lost samples.
       // This requires the Publisher to have sample_miss_detection configured,
       // which is the case for a RELIABLE + TRANSIENT_LOCAL Publisher.
-      adv_sub_opts.recovery.emplace().last_sample_miss_detection =
-        AdvancedSubscriberOptions::RecoveryOptions::Heartbeat{};
+      adv_sub_opts.recovery = AdvancedSubscriberOptions::RecoveryOptions{};
+      adv_sub_opts.recovery->last_sample_miss_detection = RecoveryOptions::Heartbeat{};
     }
   }
 


### PR DESCRIPTION
Fix #818 

clang-19 seems to be stricter than gcc. It expects the optional fields to have values before dereferencing.