### PR TITLE
Config: increase queries_default_timeout to 10min

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -216,9 +216,14 @@
   },
 
   /// The default timeout to apply to queries in milliseconds.
-  /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together.
-  ///              Note that only action-related service get_result is hard-coded with an infinite timeout.
-  queries_default_timeout: 60000,
+  /// ROS setting: The default value of 600000 ms (10 minutes) is already quite high, but it can be increased if needed.
+  ///              For instance to avoid timeout with Service Server that that is unresponsive or lagging,
+  ///              which could occur at launch time with a large number of Nodes starting all together.
+  ///              It’s recommended to configure a value that exceeds the longest timeout specified in any
+  ///              `spin_until_complete(service_call_future_result, timeout)` call.
+  ///              Note that the action-related service "get_result" is hard-coded with an infinite timeout,
+  ///              as in some use case an action could spend several hours (e.g. mission plans).
+  queries_default_timeout: 600000,
 
   /// The routing strategy to use and it's configuration.
   routing: {

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -226,9 +226,14 @@
   },
 
   /// The default timeout to apply to queries in milliseconds.
-  /// ROS setting: increase the value to avoid timeout at launch time with a large number of Nodes starting all together.
-  ///              Note that only action-related service get_result is hard-coded with an infinite timeout.
-  queries_default_timeout: 60000,
+  /// ROS setting: The default value of 600000 ms (10 minutes) is already quite high, but it can be increased if needed.
+  ///              For instance to avoid timeout with Service Server that that is unresponsive or lagging,
+  ///              which could occur at launch time with a large number of Nodes starting all together.
+  ///              It’s recommended to configure a value that exceeds the longest timeout specified in any
+  ///              `spin_until_complete(service_call_future_result, timeout)` call.
+  ///              Note that the action-related service "get_result" is hard-coded with an infinite timeout,
+  ///              as in some use case an action could spend several hours (e.g. mission plans).
+  queries_default_timeout: 600000,
 
   /// The routing strategy to use and it's configuration.
   routing: {


### PR DESCRIPTION
As reported in #783, the current 60 seconds default timeout for queries is too short in some use cases and lead to unexpected and false timeouts when the user calls `spin_until_future_complete(future, timeout)` with `timeout > std::chrono::seconds(60)` or lead to deadlock with `timeout = std::chrono::milliseconds(-1)`.

Increasing the `queries_default_timeout` to 600 seconds (10min) will such unexpected timeout with Service Server that that is unresponsive or lagging, which could occur in a slow CI or at launch time with a large number of Nodes starting all together.

While the core of the issue is addressed in https://github.com/ros2/rmw/issues/404, this PR will help users waiting for a more definitive solution.

