### PR TITLE
Change default value of ZENOH_SHM_ALLOC_SIZE to 48 MiB

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,9 +259,9 @@ export ZENOH_CONFIG_OVERRIDE='transport/shared_memory/enabled=true'
 ```
 
 The following additional configuration options available as environment variables:
-- `ZENOH_SHM_ALLOC_SIZE`: size (in bytes) of memory to allocate as shared memory arena. Must be a multiple of 4. The default value is 16MB.
-- `ZENOH_SHM_MESSAGE_SIZE_THRESHOLD`: threshold (in bytes) for ROS message wire size to be sent as SHM buffer. Must be a multiple of 4. The default value is 512. Note that depending on your hardware caracteristics (CPU, memory) it could be counter-productive for the latency of small messages to lower this threashold.
 
+- `ZENOH_SHM_ALLOC_SIZE`: size (in bytes) of memory to allocate as shared memory arena. Must be a multiple of 4. The default value is 48 MiB.
+- `ZENOH_SHM_MESSAGE_SIZE_THRESHOLD`: threshold (in bytes) for ROS message wire size to be sent as SHM buffer. Must be a multiple of 4. The default value is 512. Note that depending on your hardware caracteristics (CPU, memory) it could be counter-productive for the latency of small messages to lower this threashold.
 
 ### Interoperability
 

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -45,7 +45,7 @@ static const std::unordered_map<ConfigurableEntity,
 
 static const char * router_check_attempts_envar = "ZENOH_ROUTER_CHECK_ATTEMPTS";
 static const char * zenoh_shm_alloc_size_envar = "ZENOH_SHM_ALLOC_SIZE";
-static const size_t zenoh_shm_alloc_size_default = 16 * 1024 * 1024;
+static const size_t zenoh_shm_alloc_size_default = 48 * 1024 * 1024;
 static const char * zenoh_shm_message_size_threshold_envar = "ZENOH_SHM_MESSAGE_SIZE_THRESHOLD";
 static const size_t zenoh_shm_message_size_threshold_default = 512;
 /// Allow users to override the configuration using key-value pairs.


### PR DESCRIPTION
## Description

As explained in #828: change the default value for `ZENOH_SHM_ALLOC_SIZE` from 16 MiB to 48 MiB.
In case of default configuration, this will prevent the biggest data (> 16 MiB) to fallback to TCP when SHM is enabled.

Resolves #828 

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.
