### PR TITLE
Bump zenoh to 1.6.1

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -41,7 +41,7 @@ set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 #     - https://github.com/eclipse-zenoh/zenoh/pull/2116
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 8f9ce70e4c4b55d150632730fd4c48abffbde765
+  VCS_VERSION fff54bb201e2798487e43304ec0e51e19eea4806
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
@@ -53,7 +53,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 05533d20db70ffc1d53a0e07f39caa999e82febd
+  VCS_VERSION d66769f69d074ed51be13833f8e36749bfdee077
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -17,31 +17,30 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # latter is a list separater in cmake and hence the string will be split into two when expanded.
 set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 
-# Set VCS_VERSION to 1.5.1 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
-#   - Add CongestionControl::BlockFirst QoS
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2014
-#   - Add more options for messages selection to 'qos/network' config:
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2030
-#   - Add ZID subject property to access_control config:
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2015
-#   - Fix access control over UDP listen endpoints
-#      - https://github.com/eclipse-zenoh/zenoh/pull/1980
-#      - Performance improvements:
-#      - https://github.com/eclipse-zenoh/zenoh/pull/1988
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2025
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2035
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2046
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2047
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2053
-#      - https://github.com/eclipse-zenoh/zenoh/pull/2062
-#  - Fix build failure on Windows:
-#     - https://github.com/eclipse-zenoh/zenoh-c/pull/1079
-#  - Shared Memory performances improvements (throughput and latency)
-#     - https://github.com/eclipse-zenoh/zenoh/pull/2113
-#     - https://github.com/eclipse-zenoh/zenoh/pull/2116
+# Set VCS_VERSION to 1.6.1 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+#  * Various performance improvements:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2109
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2127
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2174
+#  * Shared Memory improvements:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2117
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2136
+#    - https://github.com/eclipse-zenoh/zenoh-c/pull/1105
+#    - https://github.com/eclipse-zenoh/zenoh-c/pull/1106
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2193
+#  * Fix IPv6 address parsing for TLS and QUIC locators:
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2138
+#  * Fix a bug leading to 100% CPU usage in certain circumstances :
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2140
+#  * Fix zenoh/stats feature support
+#    - https://github.com/eclipse-zenoh/zenoh-c/pull/1110
+#  * Fix partial reconnection in case of multilink configuration
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2173
+#  * Fix Access Control subject matching
+#    - https://github.com/eclipse-zenoh/zenoh/pull/2141
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION fff54bb201e2798487e43304ec0e51e19eea4806
+  VCS_VERSION c12a77393fd8e1fc8b1e23a4aff8d8df9b4725f8
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
@@ -53,7 +52,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION d66769f69d074ed51be13833f8e36749bfdee077
+  VCS_VERSION 029b00f131a089ee15e61ba42806ef8f3951f4e6
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -52,7 +52,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 029b00f131a089ee15e61ba42806ef8f3951f4e6
+  VCS_VERSION 65689877cb7dd877fca953eaf26366ebdbfe592b
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )


### PR DESCRIPTION
## Description

Bump Zenoh to 1.6.1, making the following changes of commit ids:

- zenoh-cpp: [05533d2](https://github.com/eclipse-zenoh/zenoh-cpp/commit/05533d20db70ffc1d53a0e07f39caa999e82febd) -> [6568987](https://github.com/eclipse-zenoh/zenoh-cpp/commit/65689877cb7dd877fca953eaf26366ebdbfe592b) -  [diff](https://github.com/eclipse-zenoh/zenoh-cpp/compare/05533d20db70ffc1d53a0e07f39caa999e82febd...65689877cb7dd877fca953eaf26366ebdbfe592b)
- zenoh-c: [8f9ce70](https://github.com/eclipse-zenoh/zenoh-c/commit/8f9ce70e4c4b55d150632730fd4c48abffbde765) -> [c12a773](https://github.com/eclipse-zenoh/zenoh-c/commit/c12a77393fd8e1fc8b1e23a4aff8d8df9b4725f8) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/8f9ce70e4c4b55d150632730fd4c48abffbde765...c12a77393fd8e1fc8b1e23a4aff8d8df9b4725f8)
- zenoh: [78dea46](https://github.com/eclipse-zenoh/zenoh/commit/78dea468af1ba81f969ab85a26d19f87fde088f7) -> [7ded85e](https://github.com/eclipse-zenoh/zenoh/commit/7ded85ec3feeb784b5ad0a44c1e9378ae0e54014) - [diff](https://github.com/eclipse-zenoh/zenoh/compare/78dea468af1ba81f969ab85a26d19f87fde088f7...7ded85ec3feeb784b5ad0a44c1e9378ae0e54014)

It includes those notable changes:

* Various performance improvements:
  - https://github.com/eclipse-zenoh/zenoh/pull/2109
  - https://github.com/eclipse-zenoh/zenoh/pull/2127
  - https://github.com/eclipse-zenoh/zenoh/pull/2174
* Shared Memory improvements:
  - https://github.com/eclipse-zenoh/zenoh/pull/2117
  - https://github.com/eclipse-zenoh/zenoh/pull/2136
  - https://github.com/eclipse-zenoh/zenoh-c/pull/1105
  - https://github.com/eclipse-zenoh/zenoh-c/pull/1106
  - https://github.com/eclipse-zenoh/zenoh/pull/2193
* Fix IPv6 address parsing for TLS and QUIC locators:
  - https://github.com/eclipse-zenoh/zenoh/pull/2138
* Fix a bug leading to 100% CPU usage in certain circumstances :
  - https://github.com/eclipse-zenoh/zenoh/pull/2140
* Fix zenoh/stats feature support 
  - https://github.com/eclipse-zenoh/zenoh-c/pull/1110
* Fix partial reconnection in case of multilink configuration
  - https://github.com/eclipse-zenoh/zenoh/pull/2173
* Fix Access Control subject matching
  - https://github.com/eclipse-zenoh/zenoh/pull/2141
