### PR TITLE
Bump zenoh to 1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ The following additional configuration options available as environment variable
 - `ZENOH_SHM_ALLOC_SIZE`: size (in bytes) of memory to allocate as shared memory arena. Must be a multiple of 4. The default value is 48 MiB.
 - `ZENOH_SHM_MESSAGE_SIZE_THRESHOLD`: threshold (in bytes) for ROS message wire size to be sent as SHM buffer. Must be a multiple of 4. The default value is 512. Note that depending on your hardware caracteristics (CPU, memory) it could be counter-productive for the latency of small messages to lower this threashold.
 
+> [!IMPORTANT]
+> Make sure that the host's shared memory space (`/dev/shm` on Linux) is large enough for all the processes you run to allocate the `ZENOH_SHM_ALLOC_SIZE` amount of memory. As `rmw_zenoh` is pre-commiting the memory on startup, a process will fail if the shared memory is not available.
+> The default value of 48 MiB has been chosen to support out-of-the-box very large payloads such as a 4K video image (~24 MiB per image, 2 images in-flight). If you want to reduce the global amount of shared memory used by your ROS 2 system, you can tune the `ZENOH_SHM_ALLOC_SIZE` value according to each node requirements.
+
 ### Interoperability
 
 - SHM-enabled nodes are fully interoperable with remote (non-localhost) nodes and localhost non-SHM-enabled nodes on transparent basis.

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -56,7 +56,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 65689877cb7dd877fca953eaf26366ebdbfe592b
+  VCS_VERSION 0cd54f291039a65b96921a5951a66aeef088e67c
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # latter is a list separater in cmake and hence the string will be split into two when expanded.
 set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 
-# Set VCS_VERSION to 1.6.1 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+# Set VCS_VERSION to 1.6.2 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
 #  * Various performance improvements:
 #    - https://github.com/eclipse-zenoh/zenoh/pull/2109
 #    - https://github.com/eclipse-zenoh/zenoh/pull/2127
@@ -38,9 +38,13 @@ set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 #    - https://github.com/eclipse-zenoh/zenoh/pull/2173
 #  * Fix Access Control subject matching
 #    - https://github.com/eclipse-zenoh/zenoh/pull/2141
+# * Fix 1.6.1 warnings: "Request to update QueryableInfo for inexistent face id"
+#   - https://github.com/eclipse-zenoh/zenoh/pull/2205
+# * Precommit SHM pages, avoiding overcommit and possible crash if SHM exhausts
+#   - https://github.com/eclipse-zenoh/zenoh/pull/2175
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION c12a77393fd8e1fc8b1e23a4aff8d8df9b4725f8
+  VCS_VERSION f376456ccf75ed837a21a186bdf5191cba50eb3b
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"


### PR DESCRIPTION
## Description

Bump Zenoh to [1.6.2](https://github.com/eclipse-zenoh/zenoh/releases/tag/1.6.2), making the following changes of commit ids:

- zenoh-cpp: [6568987](https://github.com/eclipse-zenoh/zenoh-c/commit/65689877cb7dd877fca953eaf26366ebdbfe592b) -> [0cd54f2](https://github.com/eclipse-zenoh/zenoh-c/commit/0cd54f291039a65b96921a5951a66aeef088e67c) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/65689877cb7dd877fca953eaf26366ebdbfe592b...0cd54f291039a65b96921a5951a66aeef088e67c)
- zenoh-c: [c12a773](https://github.com/eclipse-zenoh/zenoh-c/commit/c12a77393fd8e1fc8b1e23a4aff8d8df9b4725f8) -> [f376456](https://github.com/eclipse-zenoh/zenoh-c/commit/f376456ccf75ed837a21a186bdf5191cba50eb3b) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/c12a77393fd8e1fc8b1e23a4aff8d8df9b4725f8...f376456ccf75ed837a21a186bdf5191cba50eb3b)
- zenoh: [7ded85e](https://github.com/eclipse-zenoh/zenoh/commit/7ded85ec3feeb784b5ad0a44c1e9378ae0e54014) -> [b81e253](https://github.com/eclipse-zenoh/zenoh/commit/b81e253b32f98fa35bae34e44e647630f50f0321) - [diff](https://github.com/eclipse-zenoh/zenoh/compare/7ded85ec3feeb784b5ad0a44c1e9378ae0e54014...b81e253b32f98fa35bae34e44e647630f50f0321)

It includes those notable changes:

### zenoh

* Fix 1.6.1 warnings: "Request to update QueryableInfo for inexistent face id"
  - https://github.com/eclipse-zenoh/zenoh/pull/2205
* Precommit SHM pages, avoiding overcommit and possible crash if SHM exhausts  
  - https://github.com/eclipse-zenoh/zenoh/pull/2175
