### PR TITLE
Restore ZENOH_CONFIG_OVERRIDE after isolation is finished

### DIFF
--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>

--- a/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
+++ b/rmw_zenoh_cpp/src/rmw_test_fixture.cpp
@@ -30,6 +30,8 @@
 
 static std::unique_ptr<zenoh::Session> g_session = nullptr;
 
+static std::optional<std::string> g_restore_config = {};
+
 static
 std::optional<std::string>
 get_endpoints(zenoh::Session & session)
@@ -128,6 +130,8 @@ rmw_test_isolation_start()
     return RMW_RET_ERROR;
   }
 
+  g_restore_config = rcpputils::get_env_var("ZENOH_CONFIG_OVERRIDE");
+
   std::string config_override = "connect/endpoints=" + endpoints.value();
   if (!rcpputils::set_env_var(
       "ZENOH_CONFIG_OVERRIDE",
@@ -145,7 +149,9 @@ rmw_test_isolation_start()
 rmw_ret_t
 rmw_test_isolation_stop()
 {
-  rcpputils::set_env_var("ZENOH_CONFIG_OVERRIDE", nullptr);
+  if(g_restore_config) {
+    rcpputils::set_env_var("ZENOH_CONFIG_OVERRIDE", g_restore_config->c_str());
+  }
 
   if(g_session) {
     g_session->close();


### PR DESCRIPTION
## Description

Rather than clearing the ZENOH_CONFIG_OVERRIDE environment variable after we stop RMW communication isolation, set it back to whatever it was before isolation was started.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=25633)](http://ci.ros2.org/job/ci_linux/25633/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=19669)](http://ci.ros2.org/job/ci_linux-aarch64/19669/)
* Linux-rhel [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-rhel&build=5192)](http://ci.ros2.org/job/ci_linux-rhel/5192/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=25862)](http://ci.ros2.org/job/ci_windows/25862/)