### PR TITLE
Bump zenoh to 1.7.1

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -536,6 +536,15 @@
   //   },
   // ],
 
+  /// Enable stats per key expression.
+  // stats: {
+  //   filters: [
+  //     {
+  //       key: "some/key/expression/**",
+  //     }
+  //   ],
+  // },
+
   /// Configure internal transport parameters
   transport: {
     unicast: {

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -544,6 +544,15 @@
   //   },
   // ],
 
+  /// Enable stats per key expression.
+  // stats: {
+  //   filters: [
+  //     {
+  //       key: "some/key/expression/**",
+  //     }
+  //   ],
+  // },
+
   /// Configure internal transport parameters
   transport: {
     unicast: {

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -17,34 +17,20 @@ find_package(ament_cmake_vendor_package REQUIRED)
 # latter is a list separater in cmake and hence the string will be split into two when expanded.
 set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 
-# Set VCS_VERSION to 1.6.2 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
-#  * Various performance improvements:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2109
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2127
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2174
-#  * Shared Memory improvements:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2117
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2136
-#    - https://github.com/eclipse-zenoh/zenoh-c/pull/1105
-#    - https://github.com/eclipse-zenoh/zenoh-c/pull/1106
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2193
-#  * Fix IPv6 address parsing for TLS and QUIC locators:
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2138
-#  * Fix a bug leading to 100% CPU usage in certain circumstances :
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2140
-#  * Fix zenoh/stats feature support
-#    - https://github.com/eclipse-zenoh/zenoh-c/pull/1110
-#  * Fix partial reconnection in case of multilink configuration
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2173
-#  * Fix Access Control subject matching
-#    - https://github.com/eclipse-zenoh/zenoh/pull/2141
-# * Fix 1.6.1 warnings: "Request to update QueryableInfo for inexistent face id"
-#   - https://github.com/eclipse-zenoh/zenoh/pull/2205
-# * Precommit SHM pages, avoiding overcommit and possible crash if SHM exhausts
-#   - https://github.com/eclipse-zenoh/zenoh/pull/2175
+# Set VCS_VERSION to 1.7.1 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+# * Query cancellation
+#   - https://github.com/eclipse-zenoh/zenoh/pull/2223
+#   - https://github.com/eclipse-zenoh/zenoh-c/pull/1134
+#   - https://github.com/eclipse-zenoh/zenoh-cpp/pull/663
+# * Access to transport optimization SHM provider
+#   - https://github.com/eclipse-zenoh/zenoh/pull/2221
+#   - https://github.com/eclipse-zenoh/zenoh-c/pull/1132
+#   - https://github.com/eclipse-zenoh/zenoh-cpp/pull/654
+# * Metrics per key (requires to add "zenoh/stats" feature to ZENOHC_CARGO_FLAGS for build)
+#   - https://github.com/eclipse-zenoh/zenoh/pull/2284
 ament_vendor(zenoh_c_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION f376456ccf75ed837a21a186bdf5191cba50eb3b
+  VCS_VERSION 73e7a0bdcf78b8263a02b7aee453ee6de8187589
   CMAKE_ARGS
     "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
     "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
@@ -56,7 +42,7 @@ ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 0cd54f291039a65b96921a5951a66aeef088e67c
+  VCS_VERSION 47a80d345d74ebef16f3783423bf3bbd89cd6c30
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )


### PR DESCRIPTION
## Description

Bump Zenoh to [1.7.1](https://github.com/eclipse-zenoh/zenoh/releases/tag/1.7.1), making the following changes of commit ids:

- zenoh-cpp: [0cd54f2](https://github.com/eclipse-zenoh/zenoh-cpp/commit/0cd54f291039a65b96921a5951a66aeef088e67c) -> [47a80d3](https://github.com/eclipse-zenoh/zenoh-cpp/commit/47a80d345d74ebef16f3783423bf3bbd89cd6c30) -  [diff](https://github.com/eclipse-zenoh/zenoh-cpp/compare/0cd54f291039a65b96921a5951a66aeef088e67c...47a80d345d74ebef16f3783423bf3bbd89cd6c30)
- zenoh-c: [f376456](https://github.com/eclipse-zenoh/zenoh-c/commit/f376456ccf75ed837a21a186bdf5191cba50eb3b) -> [73e7a0b](https://github.com/eclipse-zenoh/zenoh-c/commit/73e7a0bdcf78b8263a02b7aee453ee6de8187589) - [diff](https://github.com/eclipse-zenoh/zenoh-c/compare/f376456ccf75ed837a21a186bdf5191cba50eb3b...73e7a0bdcf78b8263a02b7aee453ee6de8187589)
- zenoh: [b81e253](https://github.com/eclipse-zenoh/zenoh/commit/b81e253b32f98fa35bae34e44e647630f50f0321) -> [66f9091](https://github.com/eclipse-zenoh/zenoh/commit/66f9091c5734367ae97b414984018ea231ebc20e) - [diff](https://github.com/eclipse-zenoh/zenoh/compare/b81e253b32f98fa35bae34e44e647630f50f0321...66f9091c5734367ae97b414984018ea231ebc20e)

It includes those notable changes:

### zenoh

* Add query cancellation
  - https://github.com/eclipse-zenoh/zenoh/pull/2223
* Reorganize lazy transport optimization SHM provider 
  - https://github.com/eclipse-zenoh/zenoh/pull/2221
* Metrics per key (requires to add "zenoh/stats" feature to ZENOHC_CARGO_FLAGS for build)
  - https://github.com/eclipse-zenoh/zenoh/pull/2284

### zenoh-c

* Add query cancellation tokens support 
  - https://github.com/eclipse-zenoh/zenoh-c/pull/1134
* Add API access to transport optimization SHM provider 
  - https://github.com/eclipse-zenoh/zenoh-c/pull/1132

### zenoh-cpp

* Add query cancellation tokens support 
  - https://github.com/eclipse-zenoh/zenoh-cpp/pull/663
* Add API to access transport optimization SHM provider 
  - https://github.com/eclipse-zenoh/zenoh-cpp/pull/654

