### PR TITLE
Remove default from switch with enum, so that compiler warns.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/qos.cpp
+++ b/rmw_zenoh_cpp/src/detail/qos.cpp
@@ -100,7 +100,9 @@ rmw_ret_t QoS::best_available_qos(
     case RMW_QOS_POLICY_HISTORY_SYSTEM_DEFAULT:
     case RMW_QOS_POLICY_HISTORY_UNKNOWN:
       qos_profile->history = default_qos_.history;
-    default:
+      break;
+    case RMW_QOS_POLICY_HISTORY_KEEP_LAST:
+    case RMW_QOS_POLICY_HISTORY_KEEP_ALL:
       break;
   }
 
@@ -112,7 +114,10 @@ rmw_ret_t QoS::best_available_qos(
     case RMW_QOS_POLICY_RELIABILITY_SYSTEM_DEFAULT:
     case RMW_QOS_POLICY_RELIABILITY_UNKNOWN:
       qos_profile->reliability = default_qos_.reliability;
-    default:
+      break;
+    case RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT:
+    case RMW_QOS_POLICY_RELIABILITY_RELIABLE:
+    case RMW_QOS_POLICY_RELIABILITY_BEST_AVAILABLE:
       break;
   }
 
@@ -120,7 +125,10 @@ rmw_ret_t QoS::best_available_qos(
     case RMW_QOS_POLICY_DURABILITY_SYSTEM_DEFAULT:
     case RMW_QOS_POLICY_DURABILITY_UNKNOWN:
       qos_profile->durability = default_qos_.durability;
-    default:
+      break;
+    case RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL:
+    case RMW_QOS_POLICY_DURABILITY_VOLATILE:
+    case RMW_QOS_POLICY_DURABILITY_BEST_AVAILABLE:
       break;
   }
 
@@ -143,7 +151,10 @@ rmw_ret_t QoS::best_available_qos(
     case RMW_QOS_POLICY_LIVELINESS_SYSTEM_DEFAULT:
     case RMW_QOS_POLICY_LIVELINESS_UNKNOWN:
       qos_profile->liveliness = default_qos_.liveliness;
-    default:
+      break;
+    case RMW_QOS_POLICY_LIVELINESS_AUTOMATIC:
+    case RMW_QOS_POLICY_LIVELINESS_MANUAL_BY_TOPIC:
+    case RMW_QOS_POLICY_LIVELINESS_BEST_AVAILABLE:
       break;
   }
 

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -263,7 +263,7 @@ rmw_take_event(
         *taken = true;
         return RMW_RET_OK;
       }
-    default: {
+    case rmw_zenoh_cpp::ZENOH_EVENT_INVALID: {
         return RMW_RET_INVALID_ARGUMENT;
       }
   }

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -145,9 +145,8 @@ bool rmw_feature_supported(rmw_feature_t feature)
       return true;
     case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:
       return false;
-    default:
-      return false;
   }
+  return false;
 }
 
 //==============================================================================
@@ -2667,8 +2666,6 @@ rmw_set_log_severity(rmw_log_severity_t severity)
     case RMW_LOG_SEVERITY_FATAL:
       rmw_zenoh_cpp::Logger::get().set_log_level(RCUTILS_LOG_SEVERITY_FATAL);
       break;
-    default:
-      return RMW_RET_UNSUPPORTED;
   }
   return RMW_RET_OK;
 }


### PR DESCRIPTION
## Description

Depends on https://github.com/ros2/rmw/pull/414

Now the compiler will warn us if new enum values are added to it but aren't handled in this function.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

> [!NOTE]
> Since this is just a minor enhancement, no backports requested.
