### PR TITLE
fix: add dependence version of zenoh-cpp-vendor

### DIFF
--- a/rmw_zenoh_cpp/package.xml
+++ b/rmw_zenoh_cpp/package.xml
@@ -15,8 +15,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>nlohmann-json-dev</build_depend>
-  <build_depend>zenoh_cpp_vendor</build_depend>
-  <build_export_depend>zenoh_cpp_vendor</build_export_depend>
+  <build_depend version_gte="0.10.2">zenoh_cpp_vendor</build_depend>
+  <build_export_depend version_gte="0.10.2">zenoh_cpp_vendor</build_export_depend>
 
   <depend>ament_index_cpp</depend>
   <depend>fastcdr</depend>

--- a/zenoh_security_tools/package.xml
+++ b/zenoh_security_tools/package.xml
@@ -15,7 +15,7 @@
   <depend>rmw</depend>
   <depend>rmw_security_common</depend>
   <depend>tinyxml2</depend>
-  <depend>zenoh_cpp_vendor</depend>
+  <depend version_gte="0.10.2">zenoh_cpp_vendor</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
## Description

This PR establishes the version relationships among dependencies in the rmw_zenoh project. It uses the same technique as https://github.com/ros/urdfdom/blob/c506ba077f8e9da57906fe3c92bcdc4f21d8fed4/package.xml#L30. 


## Issue

The package rmw-zenoh-cpp doesn't depend on zenoh-cpp-vendor, a user may encounter an incompatibility between them after updating rmw-zenoh-cpp.

```bash
apt-get update && apt-get install -y ros-kilted-rmw-zenoh-cpp
```

```bash
root@1f3da3dc761a:/# apt show *zenoh*
Package: ros-kilted-rmw-zenoh-cpp
Version: 0.6.6-1noble.20251204.032218
Status: install ok installed
Priority: optional
Section: misc
Maintainer: Yadunund <yadunund@openrobotics.org>
Installed-Size: 795 kB
Depends: libc6 (>= 2.38), libgcc-s1 (>= 3.3.1), libstdc++6 (>= 13.1), ros-kilted-fastcdr, ros-kilted-ament-index-cpp, ros-kilted-rcpputils, ros-kilted-rcutils, ros-kilted-rmw, ros-kilted-rmw-test-fixture, ros-kilted-rosidl-typesupport-fastrtps-c, ros-kilted-rosidl-typesupport-fastrtps-cpp, ros-kilted-tracetools, ros-kilted-zenoh-cpp-vendor, ros-kilted-ros-workspace
Download-Size: unknown
APT-Manual-Installed: no
APT-Sources: /var/lib/dpkg/status
Description: A ROS 2 middleware implementation using zenoh-cpp

Package: ros-kilted-zenoh-cpp-vendor
Version: 0.6.2-1noble.20250622.134527
Status: install ok installed
Priority: optional
Section: misc
Maintainer: Yadunund <yadunund@openrobotics.org>
Installed-Size: 39.0 MB
Depends: libc6 (>= 2.34), libgcc-s1 (>= 4.2), ros-kilted-ros-workspace
Download-Size: unknown
APT-Manual-Installed: no
APT-Sources: /var/lib/dpkg/status
Description: Vendor pkg to install zenoh-cpp
```

This already causes an issue with the kilted Docker recently.

```bash
2025-12-18T15:56:20.597455Z ERROR ThreadId(01) zenohc::config: Failed to read config from /opt/ros/kilted/share/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5: JSON error: Message { msg: "unknown field `transport_optimization`, expected `enabled` or `mode`", location: Some(Location { line: 761, column: 7 }) } at /home/buildfarm/.cargo/git/checkouts/zenoh-cc237f2570fab813/c051173/commons/zenoh-config/src/lib.rs:1010.
```

