### PR TITLE
Fix line ending in session open error message

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,8 @@ On any system without IPv6 support (either because it has been disabled or becau
 ```
 WARN ThreadId(03) zenoh::net::runtime::orchestrator: Unable to open listener tcp/[::]:7447: Can not create a new TCP listener bound to tcp/[::]:7447: [Os { code: 97, kind: Uncategorized, message: "Address family not supported by protocol" }] at /home/buildfarm/.cargo/git/checkouts/zenoh-cc237f2570fab813/9640d22/io/zenoh-links/zenoh-link-tcp/src/unicast.rs:326.
 ERROR ThreadId(03) zenohc::session: Error opening session: Can not create a new TCP listener bound to tcp/[::]:7447: [Os { code: 97, kind: Uncategorized, message: "Address family not supported by protocol" }] at /home/buildfarm/.cargo/git/checkouts/zenoh-cc237f2570fab813/9640d22/io/zenoh-links/zenoh-link-tcp/src/unicast.rs:326.
-Error opening Session!\n[ros2run]: Process exited with failure 1
+Error opening Session!
+[ros2run]: Process exited with failure 1
 ```
 
 </details>

--- a/rmw_zenoh_cpp/src/zenohd/main.cpp
+++ b/rmw_zenoh_cpp/src/zenohd/main.cpp
@@ -79,7 +79,7 @@ int main(int argc, char ** argv)
     zenoh::Session::SessionOptions::create_default(),
     &result);
   if (result != Z_OK) {
-    std::cout << "Error opening Session!" << "\\n";
+    std::cout << "Error opening Session!" << std::endl;
     return 1;
   }
 


### PR DESCRIPTION
## Description
Fixes the line ending in the error message when a Session cannot be opened. Prints the following:  
```
2026-01-08T12:45:33.836959Z ERROR ThreadId(01) zenohc::session: Error opening session: Can not create a new TCP listener bound to tcp/[::]:7447: [[::]:7447: Address already in use (os error 98) at ...                                                                      
Error opening Session!
user@hostname:~$
```

Instead of:  
```
2026-01-08T12:45:33.836959Z ERROR ThreadId(01) zenohc::session: Error opening session: Can not create a new TCP listener bound to tcp/[::]:7447: [[::]:7447: Address already in use (os error 98) at ...                                                                        
Error opening Session!\nuser@hostname:~$
```

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

### Additional Information
None