### PR TITLE
Update documentation for Zenoh timestamping configuration

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -524,7 +524,8 @@ Here is an incomplete list of some of the settings and the values that they can 
 * `DEPTH` - The maximum number of samples to keep; this only comes into play when `KEEP_LAST` history is used.  If `DEPTH` is set to 0, `rmw_zenoh_cpp` will choose a depth of 42.
 * `DURABILITY`
     * `VOLATILE` - Samples will only be delivered to subscriptions that are active at the time of publishing. This is the `SYSTEM_DEFAULT` durability.
-    * `TRANSIENT_LOCAL` - "Late-joining" subscriptions will receive historical data, along with any new data.  In `rmw_zenoh_cpp`, this is implemented for publishers via the activation of a cache on the `AdvancedPublisher`. On the subscription side the `AdvancedSubscriber` is configured to query this cache to retrieve the historical data.
+    * `TRANSIENT_LOCAL` - "Late-joining" subscriptions will receive historical data, along with any new data.  In `rmw_zenoh_cpp`, this is implemented for publishers via the activation of a cache on the `AdvancedPublisher`. On the subscription side the `AdvancedSubscriber` is configured to query this cache to retrieve the historical data.  
+    **Note**: Zenoh timestamping has to be enabled by configuration in case of `TRANSIENT_LOCAL`+`BEST_EFFORT` publishers. This allows an `AdvancedSubscriber` to reorder historical data and live publications received at the same time, before delivery to the callback API. `TRANSIENT_LOCAL`+`RELIABLE` `AdvancedPublishers` are configured with `miss_sample_detection` which adds a sequence number to each publication for reordering and detection of missing samples.
 * `LIVELINESS`
     * `AUTOMATIC` - The "liveliness" of an entity of the system is managed by the RMW layer.  This is the only `LIVELINESS` that `rmw_zenoh_cpp` supports.
     * `MANUAL_BY_TOPIC` - Not supported. It is up to the application to periodically publish to a particular topic to assert liveliness.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -205,6 +205,9 @@
   timestamping: {
     /// Whether data messages should be timestamped if not already.
     /// Accepts a single boolean value or different values for router, peer and client.
+    ///
+    /// ROS setting: timestamping is required for TRANSIENT_LOCAL + BEST_EFFORT publishers.
+    ///              See rmw_zenoh_cpp/docs/design.md - "Quality of Service" chapter - for details.
     enabled: { router: true, peer: true, client: true },
     /// Whether data messages with timestamps in the future should be dropped or not.
     /// If set to false (default), messages with timestamps in the future are retimestamped.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -205,9 +205,6 @@
   timestamping: {
     /// Whether data messages should be timestamped if not already.
     /// Accepts a single boolean value or different values for router, peer and client.
-    ///
-    /// ROS setting: PublicationCache which is required for transient_local durability
-    ///              only works when time-stamping is enabled.
     enabled: { router: true, peer: true, client: true },
     /// Whether data messages with timestamps in the future should be dropped or not.
     /// If set to false (default), messages with timestamps in the future are retimestamped.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -215,6 +215,9 @@
   timestamping: {
     /// Whether data messages should be timestamped if not already.
     /// Accepts a single boolean value or different values for router, peer and client.
+    ///
+    /// ROS setting: timestamping is required for TRANSIENT_LOCAL + BEST_EFFORT publishers.
+    ///              See rmw_zenoh_cpp/docs/design.md - "Quality of Service" chapter - for details.
     enabled: { router: true, peer: true, client: true },
     /// Whether data messages with timestamps in the future should be dropped or not.
     /// If set to false (default), messages with timestamps in the future are retimestamped.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -215,9 +215,6 @@
   timestamping: {
     /// Whether data messages should be timestamped if not already.
     /// Accepts a single boolean value or different values for router, peer and client.
-    ///
-    /// ROS setting: PublicationCache which is required for transient_local durability
-    ///              only works when time-stamping is enabled.
     enabled: { router: true, peer: true, client: true },
     /// Whether data messages with timestamps in the future should be dropped or not.
     /// If set to false (default), messages with timestamps in the future are retimestamped.


### PR DESCRIPTION
## Description

Update documentation for Zenoh timstamping configurations for server and router configs. When testing locally with a simple "transient local" publisher and subscriber, the comment in the default configurations seems to be outdated. "transient local" topics were still working even when setting `timestamping: { enabled: false }` for both sending topics locally on the same machine and sending topics between two different machines over the network.

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No

### Additional Information