### PR TITLE
Fix config loading using the env variable instead of the URI

### DIFF
--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -64,7 +64,7 @@ std::optional<zenoh::Config> _get_z_config(
       "rmw_zenoh_cpp", "Envar %s cannot be read.", envar_name);
     return std::nullopt;
   }
-  std::filesystem::path envar_uri_p(envar_name);
+  std::filesystem::path envar_uri_p(envar_uri);
   // If the environment variable is set, try to read the configuration from the file,
   // if the environment variable is not set use internal configuration
   configured_uri = envar_uri[0] != '\0' ? envar_uri_p : default_uri;


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Apparently when the `ament_index_cpp` API was updated a few weeks ago in https://github.com/ros2/rmw_zenoh/pull/879, the ability to load custom configurations from environment variables got broken. Before this PR, specifying a custom `ZENOH_ROUTER_CONFIG_URI` will crash the zenoh router, even if the path it points to is valid. This is a simple change to fix the use of custom configs in rolling by using the actual `envar_uri` in `envar_uri_p` instead of `envar_name`. 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->
The user will now be able to properly use `ZENOH_ROUTER_CONFIG_URI` and `ZENOH_SESSION_CONFIG_URI` to configure zenoh in their applications.
### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
