### PR TITLE
Allow use of non-vendored Zenoh if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ sudo apt update && sudo apt install ros-<DISTRO>-rmw-zenoh-cpp # replace <DISTRO
 > [!NOTE]
 > By default, we vendor and compile `zenoh-cpp` with a subset of `zenoh` features.
 The `ZENOHC_CARGO_FLAGS` CMake argument may be overwritten with other features included if required.
+The `USE_SYSTEM_ZENOH` CMake argument can be used to use non-vendored system libraries instead.
+The user must ensure that the non-vendored libraries are found by CMake and provide the necessary features (e.g., shared-memory support).
 See [zenoh_cpp_vendor/CMakeLists.txt](./zenoh_cpp_vendor/CMakeLists.txt) for more details.
 
 ```bash

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -10,6 +10,9 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
+find_package(zenohc QUIET)
+find_package(zenohcxx QUIET)
+
 # Add a set of usefull features that are not enabled by default in zenoh-c.
 # For a complete list of features see: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
 # Note: the list of features are separated with whitespaces.
@@ -29,6 +32,7 @@ set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 # * Metrics per key (requires to add "zenoh/stats" feature to ZENOHC_CARGO_FLAGS for build)
 #   - https://github.com/eclipse-zenoh/zenoh/pull/2284
 ament_vendor(zenoh_c_vendor
+  SATISFIED ${zenohc_FOUND}
   VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
   VCS_VERSION 73e7a0bdcf78b8263a02b7aee453ee6de8187589
   CMAKE_ARGS
@@ -41,13 +45,16 @@ ament_vendor(zenoh_c_vendor
 ament_export_dependencies(zenohc)
 
 ament_vendor(zenoh_cpp_vendor
+  SATISFIED ${zenohcxx_FOUND}
   VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
   VCS_VERSION 47a80d345d74ebef16f3783423bf3bbd89cd6c30
   CMAKE_ARGS
     -DZENOHCXX_ZENOHC=OFF
 )
 
-externalproject_add_stepdependencies(zenoh_cpp_vendor configure zenoh_c_vendor)
+if(NOT zenohcxx_FOUND)
+  externalproject_add_stepdependencies(zenoh_cpp_vendor configure zenoh_c_vendor)
+endif()
 
 ament_export_dependencies(zenohcxx)
 

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -10,52 +10,53 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(ament_cmake_vendor_package REQUIRED)
 
-find_package(zenohc QUIET)
-find_package(zenohcxx QUIET)
+option(USE_SYSTEM_ZENOH "Use non-vendored zenoh from the system" OFF)
 
-# Add a set of usefull features that are not enabled by default in zenoh-c.
-# For a complete list of features see: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
-# Note: the list of features are separated with whitespaces.
-# However, if you want to add other cargo build flags, use "$<SEMICOLON>" as separator and not ";" as the
-# latter is a list separater in cmake and hence the string will be split into two when expanded.
-set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
+if(USE_SYSTEM_ZENOH)
+  find_package(zenohc REQUIRED)
+  find_package(zenohcxx REQUIRED)
+  message(STATUS "Using system zenohc version: ${zenohc_VERSION}")
+  message(STATUS "Using system zenohcxx version: ${zenohcxx_VERSION}")
+else()
+  # Add a set of usefull features that are not enabled by default in zenoh-c.
+  # For a complete list of features see: https://github.com/eclipse-zenoh/zenoh/blob/main/zenoh/Cargo.toml
+  # Note: the list of features are separated with whitespaces.
+  # However, if you want to add other cargo build flags, use "$<SEMICOLON>" as separator and not ";" as the
+  # latter is a list separater in cmake and hence the string will be split into two when expanded.
+  set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 
-# Set VCS_VERSION to 1.7.1 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
-# * Query cancellation
-#   - https://github.com/eclipse-zenoh/zenoh/pull/2223
-#   - https://github.com/eclipse-zenoh/zenoh-c/pull/1134
-#   - https://github.com/eclipse-zenoh/zenoh-cpp/pull/663
-# * Access to transport optimization SHM provider
-#   - https://github.com/eclipse-zenoh/zenoh/pull/2221
-#   - https://github.com/eclipse-zenoh/zenoh-c/pull/1132
-#   - https://github.com/eclipse-zenoh/zenoh-cpp/pull/654
-# * Metrics per key (requires to add "zenoh/stats" feature to ZENOHC_CARGO_FLAGS for build)
-#   - https://github.com/eclipse-zenoh/zenoh/pull/2284
-ament_vendor(zenoh_c_vendor
-  SATISFIED ${zenohc_FOUND}
-  VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-  VCS_VERSION 73e7a0bdcf78b8263a02b7aee453ee6de8187589
-  CMAKE_ARGS
-    "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
-    "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
-    "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
-  PATCHES ${CMAKE_CURRENT_SOURCE_DIR}/pin-rust-1.75.0.patch
-)
+  # Set VCS_VERSION to 1.7.1 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+  # * Query cancellation
+  #   - https://github.com/eclipse-zenoh/zenoh/pull/2223
+  #   - https://github.com/eclipse-zenoh/zenoh-c/pull/1134
+  #   - https://github.com/eclipse-zenoh/zenoh-cpp/pull/663
+  # * Access to transport optimization SHM provider
+  #   - https://github.com/eclipse-zenoh/zenoh/pull/2221
+  #   - https://github.com/eclipse-zenoh/zenoh-c/pull/1132
+  #   - https://github.com/eclipse-zenoh/zenoh-cpp/pull/654
+  # * Metrics per key (requires to add "zenoh/stats" feature to ZENOHC_CARGO_FLAGS for build)
+  #   - https://github.com/eclipse-zenoh/zenoh/pull/2284
+  ament_vendor(zenoh_c_vendor
+    VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
+    VCS_VERSION 73e7a0bdcf78b8263a02b7aee453ee6de8187589
+    CMAKE_ARGS
+      "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
+      "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
+      "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
+    PATCHES ${CMAKE_CURRENT_SOURCE_DIR}/pin-rust-1.75.0.patch
+  )
 
-ament_export_dependencies(zenohc)
+  ament_vendor(zenoh_cpp_vendor
+    VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
+    VCS_VERSION 47a80d345d74ebef16f3783423bf3bbd89cd6c30
+    CMAKE_ARGS
+      -DZENOHCXX_ZENOHC=OFF
+  )
 
-ament_vendor(zenoh_cpp_vendor
-  SATISFIED ${zenohcxx_FOUND}
-  VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-  VCS_VERSION 47a80d345d74ebef16f3783423bf3bbd89cd6c30
-  CMAKE_ARGS
-    -DZENOHCXX_ZENOHC=OFF
-)
-
-if(NOT zenohcxx_FOUND)
   externalproject_add_stepdependencies(zenoh_cpp_vendor configure zenoh_c_vendor)
 endif()
 
+ament_export_dependencies(zenohc)
 ament_export_dependencies(zenohcxx)
 
 ament_package()


### PR DESCRIPTION
## Description

Uses zenoh-c and zenoh-cpp if found by cmake. It's easier to handle distributing and patching of Zenoh on non-standard platforms if the rust build can be handled externally.

### Is this user-facing behavior change?

Should not affect any users, unless they are building from source and have installed the libraries to the cmake search path.

### Did you use Generative AI?

No

### Additional Information
There's also https://github.com/ros2/rmw_zenoh/pull/695 but it seems to have stalled. Would appreciate if this could be considered in the meantime.