### PR TITLE
Catch `PackageNotFoundError` during default config uri loading to prevent crash

### DIFF
--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -120,7 +120,7 @@ std::optional<zenoh::Config> get_z_config(const ConfigurableEntity & entity)
       "rmw_zenoh_cpp", "get_z_config called with invalid ConfigurableEntity.");
     return std::nullopt;
   }
-  
+
   std::filesystem::path default_config_path;
 
   try {
@@ -129,9 +129,9 @@ std::optional<zenoh::Config> get_z_config(const ConfigurableEntity & entity)
       ament_index_cpp::get_package_share_path("rmw_zenoh_cpp") / "config";
 
     default_config_path = path_to_config_folder / envar_map_it->second.second;
-  } catch (const ament_index_cpp::PackageNotFoundError& e) {
+  } catch (const ament_index_cpp::PackageNotFoundError & e) {
     RMW_ZENOH_LOG_WARN_NAMED(
-      "rmw_zenoh_cpp", 
+      "rmw_zenoh_cpp",
       "Failed to find rmw_zenoh_cpp package in ament_index (%s). "
       "Relying on 'ZENOH_*_CONFIG_URI' ENV vars.", e.what());
   }

--- a/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
+++ b/rmw_zenoh_cpp/src/detail/zenoh_config.cpp
@@ -26,6 +26,7 @@
 #include "logging_macros.hpp"
 
 #include <ament_index_cpp/get_package_share_path.hpp>
+#include <ament_index_cpp/get_package_prefix.hpp> /* for PackageNotFoundError */
 #include <rmw/impl/cpp/macros.hpp>
 
 ///=============================================================================
@@ -119,12 +120,21 @@ std::optional<zenoh::Config> get_z_config(const ConfigurableEntity & entity)
       "rmw_zenoh_cpp", "get_z_config called with invalid ConfigurableEntity.");
     return std::nullopt;
   }
-  // Get the absolute path to the default configuration file.
-  std::filesystem::path path_to_config_folder =
-    ament_index_cpp::get_package_share_path("rmw_zenoh_cpp") / "config";
+  
+  std::filesystem::path default_config_path;
 
-  const std::filesystem::path default_config_path =
-    path_to_config_folder / envar_map_it->second.second;
+  try {
+    // Get the absolute path to the default configuration file.
+    std::filesystem::path path_to_config_folder =
+      ament_index_cpp::get_package_share_path("rmw_zenoh_cpp") / "config";
+
+    default_config_path = path_to_config_folder / envar_map_it->second.second;
+  } catch (const ament_index_cpp::PackageNotFoundError& e) {
+    RMW_ZENOH_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp", 
+      "Failed to find rmw_zenoh_cpp package in ament_index (%s). "
+      "Relying on 'ZENOH_*_CONFIG_URI' ENV vars.", e.what());
+  }
 
   return _get_z_config(envar_map_it->second.first, default_config_path);
 }


### PR DESCRIPTION
## Description

I was using `rmw_zenoh_cpp`, and I noticed my nodes kept crashing during `rclcpp::init()`. 
I was using just `librmw_zenoh_cpp.so` and `libzenohc.so` (some bare-bones ros2 jazzy build), not the full ament workspace.

Debugging the process, it was because it couldn't locate its default config files (which are in `<ament-pkg-dir>/config/`).
Then `ament_index_cpp::get_package_share_directory()` would throw `PackageNotFoundError` which was not caught. 

This propagates through up to `std::bad_alloc` for some reason, but that is not important now

<details>
<summary><b>GDB Backtrace</b></summary>

```
Thread 43 "CelixEvent" hit Breakpoint 1, 0x00007ffff7cf2490 in __cxa_throw () from /lib/x86_64-linux-gnu/libstdc++.so.6
#0 0x00007ffff7cf2490 in __cxa_throw ()
#1 0x00007ffff4365a40 in ament_index_cpp::get_package_prefix(...)
#2 0x00007ffff43674fd in ament_index_cpp::get_package_share_directory(...)
#3 0x00007fffef408b72 in rmw_zenoh_cpp::get_z_config(...)
#4 0x00007fffef3ef08a in rmw_context_impl_s::Data::Data(...)
#5 0x00007fffef3eba57 in rmw_context_impl_s::rmw_context_impl_s(...)
#6 0x00007fffef40dd1f in rmw_init ()
#7 0x00007fffeed0e004 in rcl_init ()
```

</details>

## Solution

I solved the problem by catching the error so the initialization can proceed and safely fall back to environment variables (ZENOH_SESSION_CONFIG_URI, ZENOH_ROUTER_CONFIG_URI)

### Is this user-facing

I'd say it is, as it requires the user to know to set env var if using only libraries from `rmw_zenoh_cpp` package, but it is a pretty rare occurence that someone will use it in such a way.

## Discussion

This is a "fix" that works, but it relies on me setting the correct ENV variable. If I don't I'm not sure what owuld happen or how would zenoh sessions be configured.

The order of what happens now is:
1. if we have a custom config URI via env var, we load from there
2. if we dont, we load from default URI
3. if we have neither... what? Crash with a descriptive error to set the ENV var?

For a fully-fledged solution, It might be good to hardcode a default `zenoh::Config` in `zenoh_config.hpp` with these ros specific configs.

Then the order of happenings would be:
1. if we have a custom config URI via env var, we load from there
2. if we dont, we load from default URI
3. if we don't have anything there, we just leave the basic config we hardcoded

Then we'd be golden in all cases.

I can do that, but I want to confirm first if that would be an acceptable direction. In any case, if this is a rare problem, we can just try-catch the ament package call, throw a warning and call it a day.

Cheers,
Nikola