### PR TITLE
Log warnings in send_response when query data is missing

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -252,11 +252,14 @@ void ServiceData::add_new_query(std::unique_ptr<ZenohQuery> query)
   if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
     query_queue_.size() >= adapted_qos_profile.depth)
   {
-    // Log warning if message is discarded due to hitting the queue depth
+    // Log warning if message is discarded due to hitting the queue depth.
+    // When a query is discarded here, its corresponding client will never receive a response
+    // because the query is dropped before being stored in sequence_to_query_map_. This causes
+    // the client to wait until the query times out.
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Query queue depth of %ld reached, discarding oldest Query "
-      "for service '%s'",
+      "for service '%s'. The client for the discarded query will not receive a response.",
       adapted_qos_profile.depth,
       entity_->topic_info().value().name_.c_str());
     query_queue_.pop_front();
@@ -391,14 +394,22 @@ rmw_ret_t ServiceData::send_response(
   const size_t hash = hash_gid(writer_guid);
   std::unordered_map<size_t, SequenceToQuery>::iterator it = sequence_to_query_map_.find(hash);
   if (it == sequence_to_query_map_.end()) {
-    // If there is no data associated with this request, the higher layers of
-    // ROS 2 seem to expect that we just silently return with no work.
+    RMW_ZENOH_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to send response for service '%s': no query data found for client GID hash %zu. "
+      "This may indicate that the query was discarded due to the query queue being full.",
+      entity_->topic_info().value().name_.c_str(),
+      hash);
     return RMW_RET_OK;
   }
   SequenceToQuery::iterator query_it = it->second.find(request_id->sequence_number);
   if (query_it == it->second.end()) {
-    // If there is no data associated with this request, the higher layers of
-    // ROS 2 seem to expect that we just silently return with no work.
+    RMW_ZENOH_LOG_WARN_NAMED(
+      "rmw_zenoh_cpp",
+      "Unable to send response for service '%s': no query data found for sequence number %ld. "
+      "This may indicate that the query was discarded due to the query queue being full.",
+      entity_->topic_info().value().name_.c_str(),
+      request_id->sequence_number);
     return RMW_RET_OK;
   }
   std::unique_ptr<ZenohQuery> query = std::move(query_it->second);


### PR DESCRIPTION
## Summary

When a service query is discarded due to query queue overflow in `add_new_query()`, the discarded query's entry is never stored in `sequence_to_query_map_`. When `send_response()` later tries to look up the query to send a reply, it finds nothing and previously returned `RMW_RET_OK` silently with no indication of the problem.

This silent failure makes debugging very difficult because:
- The service server shows no errors
- The client hangs waiting for a response until query timeout (default: 10 minutes)
- There is no log message connecting the queue overflow to the missing response

### Changes

- Add `WARN`-level log messages in `send_response()` when query data is not found, noting the likely cause (query queue overflow)
- Improve the existing `ERROR` log in `add_new_query()` to explicitly state that the discarded query's client will not receive a response
- Add code comments documenting the relationship between query discard and response failure

### Design decisions

The return value in `send_response()` remains `RMW_RET_OK` because returning `RMW_RET_ERROR` would cause `rclcpp::Service::send_response()` to throw an exception that propagates unhandled through the executor's spin loop (`take_and_do_error_handling` only catches exceptions from `take_action`, not `handle_action`), which would crash the entire component container and take down all loaded nodes.

### Background

This issue was discovered while debugging ComposableNode loading failures on resource-constrained ARM devices. When multiple `LoadComposableNodes` launch actions fire concurrently, they issue parallel `load_node` service calls. On slow CPUs, these queries arrive faster than the server can process them, causing `query_queue_` to overflow. The discarded queries result in silent response failures, causing clients to hang indefinitely with no error output. See the [detailed root cause analysis](https://github.com/pf-robotics/sr01/issues/3424) (private link) for reproduction steps and experimental verification.

## Test plan

- [ ] Build and run existing rmw_zenoh tests
- [ ] Verify WARN messages appear in logs when query queue overflow causes response failures
- [ ] Verify no behavioral change for normal service call flows (queries not discarded)