### PR TITLE
fix: populate reception_sequence_number and advertise sequence number features

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -151,6 +151,7 @@ SubscriptionData::SubscriptionData(
   type_support_(std::move(type_support)),
   sub_options_(std::move(sub_options)),
   last_known_published_msg_({}),
+  reception_sn_(0),
   wait_set_data_(nullptr),
   is_shutdown_(false),
   initialized_(false)
@@ -422,8 +423,8 @@ rmw_ret_t SubscriptionData::take_one_message(
     message_info->source_timestamp = msg_data->attachment.source_timestamp();
     message_info->received_timestamp = msg_data->recv_timestamp;
     message_info->publication_sequence_number = msg_data->attachment.sequence_number();
-    // TODO(clalancette): fill in reception_sequence_number
-    message_info->reception_sequence_number = 0;
+    message_info->reception_sequence_number =
+      reception_sn_.fetch_add(1, std::memory_order_relaxed);
     message_info->publisher_gid.implementation_identifier = rmw_zenoh_cpp::rmw_zenoh_identifier;
     memcpy(
       message_info->publisher_gid.data,
@@ -479,8 +480,8 @@ rmw_ret_t SubscriptionData::take_serialized_message(
     message_info->source_timestamp = msg_data->attachment.source_timestamp();
     message_info->received_timestamp = msg_data->recv_timestamp;
     message_info->publication_sequence_number = msg_data->attachment.sequence_number();
-    // TODO(clalancette): fill in reception_sequence_number
-    message_info->reception_sequence_number = 0;
+    message_info->reception_sequence_number =
+      reception_sn_.fetch_add(1, std::memory_order_relaxed);
     message_info->publisher_gid.implementation_identifier = rmw_zenoh_cpp::rmw_zenoh_identifier;
     memcpy(
       message_info->publisher_gid.data,

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.hpp
@@ -15,6 +15,7 @@
 #ifndef DETAIL__RMW_SUBSCRIPTION_DATA_HPP_
 #define DETAIL__RMW_SUBSCRIPTION_DATA_HPP_
 
+#include <atomic>
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
@@ -152,6 +153,8 @@ private:
   std::deque<std::unique_ptr<Message>> message_queue_;
   // Map GID of a subscription to the sequence number of the message it published.
   std::unordered_map<size_t, int64_t> last_known_published_msg_;
+  // Per-subscriber reception sequence number counter, incremented on every take.
+  std::atomic<uint64_t> reception_sn_;
   // Wait set data.
   rmw_wait_set_data_t * wait_set_data_;
   // Callback managers.

--- a/rmw_zenoh_cpp/src/rmw_zenoh.cpp
+++ b/rmw_zenoh_cpp/src/rmw_zenoh.cpp
@@ -140,9 +140,9 @@ bool rmw_feature_supported(rmw_feature_t feature)
 {
   switch (feature) {
     case RMW_FEATURE_MESSAGE_INFO_PUBLICATION_SEQUENCE_NUMBER:
-      return false;
+      return true;
     case RMW_FEATURE_MESSAGE_INFO_RECEPTION_SEQUENCE_NUMBER:
-      return false;
+      return true;
     case RMW_MIDDLEWARE_SUPPORTS_TYPE_DISCOVERY:
       return true;
     case RMW_MIDDLEWARE_CAN_TAKE_DYNAMIC_MESSAGE:


### PR DESCRIPTION
## Description

`rmw_feature_supported` currently returns `false` for both `RMW_FEATURE_MESSAGE_INFO_PUBLICATION_SEQUENCE_NUMBER` and `RMW_FEATURE_MESSAGE_INFO_RECEPTION_SEQUENCE_NUMBER`, causing rclcpp to skip populating these fields in `rclcpp::MessageInfo` entirely. Additionally, `reception_sequence_number` is always set to 0 with a `TODO` comment at both take sites.

The fix:

- Flips `rmw_feature_supported` to return `true` for both sequence number features.
- Adds a `std::atomic<uint64_t> reception_sn_` counter to `SubscriptionData`, initialized to 0. Each call to `take_one_message` or `take_serialized_message` increments it with `fetch_add(1, std::memory_order_relaxed)` and assigns the pre-increment value to `message_info->reception_sequence_number`.
- `publication_sequence_number` was already populated from the attachment; no change needed there.

The attachment wire format (`sequence_number | source_timestamp | source_gid`) is unchanged — this fix is purely in the subscriber-side bookkeeping.

Closes #907
Closes #906
