### PR TITLE
Don't hold both locks when processing event data

### DIFF
--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -249,7 +249,7 @@ void EventsManager::notify_event(rmw_zenoh_event_type_t event_id)
     return;
   }
 
-  // Make sure to not lock both event_mutex_ and event_condition_mutex_ at the same time to avoid deadlocks. We can
+  // Make sure to not lock both event_mutex_ and event_condition_mutex_ at the same time to avoid deadlocks
   rmw_wait_set_data_t* wait_set_data = nullptr;
   {
     std::lock_guard<std::mutex> lock(event_condition_mutex_);

--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -249,7 +249,8 @@ void EventsManager::notify_event(rmw_zenoh_event_type_t event_id)
     return;
   }
 
-  // Make sure to not lock both event_mutex_ and event_condition_mutex_ at the same time to avoid deadlocks
+  /* Make sure to not lock both event_mutex_ and event_condition_mutex_ at the same time to avoid
+   * deadlocks with rmw_wait */
   rmw_wait_set_data_t * wait_set_data = nullptr;
   {
     std::lock_guard<std::mutex> lock(event_condition_mutex_);

--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -249,11 +249,16 @@ void EventsManager::notify_event(rmw_zenoh_event_type_t event_id)
     return;
   }
 
-  std::lock_guard<std::mutex> lock(event_condition_mutex_);
-  if (wait_set_data_[event_id] != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_[event_id]->condition_mutex);
-    wait_set_data_[event_id]->triggered = true;
-    wait_set_data_[event_id]->condition_variable.notify_one();
+  // Make sure to not lock both event_mutex_ and event_condition_mutex_ at the same time to avoid deadlocks. We can
+  rmw_wait_set_data_t* wait_set_data = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(event_condition_mutex_);
+    wait_set_data = wait_set_data_[event_id];
+  }
+  if (wait_set_data != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(wait_set_data->condition_mutex);
+    wait_set_data->triggered = true;
+    wait_set_data->condition_variable.notify_one();
   }
 }
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -250,7 +250,7 @@ void EventsManager::notify_event(rmw_zenoh_event_type_t event_id)
   }
 
   // Make sure to not lock both event_mutex_ and event_condition_mutex_ at the same time to avoid deadlocks
-  rmw_wait_set_data_t* wait_set_data = nullptr;
+  rmw_wait_set_data_t * wait_set_data = nullptr;
   {
     std::lock_guard<std::mutex> lock(event_condition_mutex_);
     wait_set_data = wait_set_data_[event_id];


### PR DESCRIPTION
## Description

Fixes #921. A deadlock can happen due to two code paths acquiring both locks in opposite order. The simplest fix is to take the locks in sequence, but not at the same time.

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
Github Copilot GPT-4.1 was used for some completions.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

I am not sure that this the best way to address the issue, but I'm hoping to get the conversation started.