### PR TITLE
Fix issue following bump to Zenoh 1.8.0

### DIFF
--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -312,12 +312,11 @@
   //       /// Optional list of link protocols. Transports with at least one of these links will have their qos overwritten.
   //       /// If absent, the overwrite will be applied to all transports. An empty list is invalid.
   //       link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
-  //       /// List of message types to apply to.
+  //       /// List of message types to apply to (replies qos cannot be overwritten).
   //       messages: [
   //         "put", // put publications
   //         "delete", // delete publications
   //         "query", // get queries
-  //         "reply", // replies to queries
   //       ],
   //       /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //       /// If absent, the rules will be applied to both flows.

--- a/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
+++ b/rmw_zenoh_cpp/config/DEFAULT_RMW_ZENOH_SESSION_CONFIG.json5
@@ -320,12 +320,11 @@
   //       /// Optional list of link protocols. Transports with at least one of these links will have their qos overwritten.
   //       /// If absent, the overwrite will be applied to all transports. An empty list is invalid.
   //       link_protocols: [ "tcp", "udp", "tls", "quic", "ws", "serial", "unixsock-stream", "unixpipe", "vsock"],
-  //       /// List of message types to apply to.
+  //       /// List of message types to apply to (replies qos cannot be overwritten).
   //       messages: [
   //         "put", // put publications
   //         "delete", // delete publications
   //         "query", // get queries
-  //         "reply", // replies to queries
   //       ],
   //       /// Optional list of data flows messages will be processed on ("egress" and/or "ingress").
   //       /// If absent, the rules will be applied to both flows.

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -25,7 +25,9 @@ else()
   # latter is a list separater in cmake and hence the string will be split into two when expanded.
   set(ZENOHC_CARGO_FLAGS "--features=shared-memory zenoh/transport_serial")
 
-  # Set VCS_VERSION to 1.8.0 commits of zenoh/zenoh-c/zenoh-cpp to benefit from:
+  # Set VCS_VERSION branch branch ROS/rust-1.75 of zenoh-c,
+  # on commit corresponding to Zenoh 1.8.0.
+  # Main changes wrt. previous version:
   # * Query cancellation
   #   - https://github.com/eclipse-zenoh/zenoh/pull/2223
   #   - https://github.com/eclipse-zenoh/zenoh-c/pull/1134
@@ -49,12 +51,11 @@ else()
   #   - https://github.com/eclipse-zenoh/zenoh/pull/2432
   ament_vendor(zenoh_c_vendor
     VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-    VCS_VERSION c1a477d3f5efc3abc0f0cf95e0773225d00dea3b
+    VCS_VERSION 0e3ec084142382096d09f7fc2ad59385998b92e6
     CMAKE_ARGS
       "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
       "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
       "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
-      "-DZENOHC_MSRV_1_75=TRUE"
   )
 
   ament_vendor(zenoh_cpp_vendor


### PR DESCRIPTION
## Description

The bump to Zenoh 1.8.0 made in https://github.com/ros2/rmw_zenoh/pull/935 brings an issue related to a change in zenoh-c. When building with zenoh-c with `ZENOHC_MSRV_1_75` flag, its `Cargo.lock` is ignored, leading to several build issues:
- the latest Rust dependencies are used and some are not supporting Rust 1.75
- the dependency to zenoh is using it's `main` branch instead of a commit for 1.8.0
 
We discussed within Zenoh team today, and our conclusion is that until ROS for Ubuntu can get rid of Rust 1.75, we need to maintain distinct `Cargo.lock` in zenoh-c, for Rust 1.75 and Rust 1.88+ which is our current MSRV without pinning crates.
Rather than tinkering the build to swap the `Cargo.lock` depending on Rust version, we prefer to maintain 2 branches for the short term - i.e. until a solution is found to allow the bump of Rust version in Ubuntu:
- [main](https://github.com/eclipse-zenoh/zenoh-c/tree/main) for projects using recent Rust
- [ROS/rust-1.75](https://github.com/eclipse-zenoh/zenoh-c/tree/ROS/rust-1.75) for ROS humble, jazzy and kilted

This PR make `rmw_zenoh` to use commit https://github.com/eclipse-zenoh/zenoh-c/commit/0e3ec084142382096d09f7fc2ad59385998b92e6 from branch [ROS/rust-1.75](https://github.com/eclipse-zenoh/zenoh-c/tree/ROS/rust-1.75).
It depends on https://github.com/eclipse-zenoh/zenoh/commit/f27282e78c6e42e04249349049fa68cfbc941369

This PR must be merged to humble, jazzy and kilted branches.

When the rolling branch will be switched to use Ubuntu resolute and for the incoming lyrical branch, `zenoh_cpp_vendor/CMakeLists.txt` shall be changed to use https://github.com/eclipse-zenoh/zenoh-c/commit/c1a477d3f5efc3abc0f0cf95e0773225d00dea3b (still without the `ZENOHC_MSRV_1_75`)
