### PR TITLE
fix: update wrong hash for zenoh-c 1.8.0

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -49,7 +49,7 @@ else()
   #   - https://github.com/eclipse-zenoh/zenoh/pull/2432
   ament_vendor(zenoh_c_vendor
     VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-    VCS_VERSION c42f86e1f3e5af7b05ceb1227ff0f92fb9a1c4c0
+    VCS_VERSION 7b8478618861972b9f0115da75e694c9f0a2af5a
     CMAKE_ARGS
       "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
       "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -49,7 +49,7 @@ else()
   #   - https://github.com/eclipse-zenoh/zenoh/pull/2432
   ament_vendor(zenoh_c_vendor
     VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
-    VCS_VERSION c1a477d3f5efc3abc0f0cf95e0773225d00dea3b
+    VCS_VERSION c42f86e1f3e5af7b05ceb1227ff0f92fb9a1c4c0
     CMAKE_ARGS
       "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
       "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -59,7 +59,7 @@ else()
 
   ament_vendor(zenoh_cpp_vendor
     VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-    VCS_VERSION 776c59651a61dc53689dd68beace147e67a83a27
+    VCS_VERSION c3f98b7fad41bd91b7eb845d7853faadaf2249a5
     CMAKE_ARGS
       -DZENOHCXX_ZENOHC=OFF
   )


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

zenoh-c/cpp hash is not correct with release/1.8.0.
https://github.com/eclipse-zenoh/zenoh-c/tree/release/1.8.0

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
