### PR TITLE
fix(graph_cache): release graph_mutex_ before invoking discovery callbacks

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -91,16 +91,18 @@ std::shared_ptr<GraphNode> GraphCache::make_graph_node(const Entity & entity) co
 }
 
 ///=============================================================================
-void GraphCache::update_topic_maps_for_put(
+std::vector<GraphCache::EntityDiscoveryCallback>
+GraphCache::update_topic_maps_for_put(
   GraphNodePtr graph_node,
   liveliness::ConstEntityPtr entity)
 {
   if (entity->type() == EntityType::Node) {
     // Nothing to update for a node entity.
-    return;
+    return {};
   }
 
   // First update the topic map within the node.
+  // These calls never fire discovery callbacks (report_events = false).
   if (entity->type() == EntityType::Publisher) {
     update_topic_map_for_put(graph_node->pubs_, entity);
   } else if (entity->type() == EntityType::Subscription) {
@@ -112,19 +114,20 @@ void GraphCache::update_topic_maps_for_put(
   }
 
   // Then update the variables tracking topics across the graph.
-  // We invoke update_topic_map_for_put() with report_events set to true for
-  // pub/sub.
+  // Only pub/sub calls collect discovery callbacks (report_events = true);
+  // return them to the caller for invocation outside graph_mutex_.
   if (entity->type() == EntityType::Publisher ||
     entity->type() == EntityType::Subscription)
   {
-    update_topic_map_for_put(this->graph_topics_, entity, true);
-  } else {
-    update_topic_map_for_put(this->graph_services_, entity);
+    return update_topic_map_for_put(this->graph_topics_, entity, true);
   }
+  update_topic_map_for_put(this->graph_services_, entity);
+  return {};
 }
 
 ///=============================================================================
-void GraphCache::update_topic_map_for_put(
+std::vector<GraphCache::EntityDiscoveryCallback>
+GraphCache::update_topic_map_for_put(
   GraphNode::TopicMap & topic_map,
   liveliness::ConstEntityPtr entity,
   bool report_events)
@@ -136,7 +139,7 @@ void GraphCache::update_topic_map_for_put(
       "rmw_zenoh_cpp",
       "update_topic_map_for_put() called for non-node entity without valid TopicInfo. "
       "Report this.");
-    return;
+    return {};
   }
 
   // For the sake of reusing data structures and lookup functions, we treat publishers and
@@ -155,7 +158,7 @@ void GraphCache::update_topic_map_for_put(
     topic_map.insert(std::make_pair(graph_topic_data->info_.name_, std::move(topic_data_map)));
     // We do not need to check for events since this is the first time and entiry for this topic
     // was added to the topic map.
-    return;
+    return {};
   }
   // The topic exists in the topic_map so we check if the type also exists.
   GraphNode::TopicTypeMap::iterator topic_type_map_it = topic_map_it->second.find(
@@ -167,7 +170,7 @@ void GraphCache::update_topic_map_for_put(
         graph_topic_data->info_.type_,
         std::move(topic_qos_map)));
     // TODO(Yadunund) Check for and report an *_INCOMPATIBLE_TYPE events.
-    return;
+    return {};
   }
   // The topic type already exists.
   if (report_events) {
@@ -196,10 +199,18 @@ void GraphCache::update_topic_map_for_put(
     }
   }
 
-  // Collect discovery callbacks under discovery_mutex_, then invoke them
-  // after releasing the lock to avoid ABBA deadlock with graph_mutex_.
-  // (graph_mutex_ is already held by parse_put; register_*_discovery_callback
-  // acquires graph_mutex_ → discovery_mutex_ in that order.)
+  // Collect discovery callbacks under discovery_mutex_ and return them to the
+  // caller for invocation *outside* graph_mutex_.
+  //
+  // Lock ordering invariant: graph_mutex_ → discovery_mutex_.
+  // parse_put holds graph_mutex_ for its entire body; register_*_callback
+  // also acquires graph_mutex_ before discovery_mutex_, so the order is
+  // consistent and ABBA-free.
+  //
+  // Callbacks must NOT be invoked while graph_mutex_ is held: any callback
+  // that re-enters a GraphCache method would deadlock (std::mutex is
+  // non-recursive).  Callers are responsible for invoking the returned
+  // callbacks only after releasing graph_mutex_.
   std::vector<EntityDiscoveryCallback> callbacks_to_invoke;
   {
     std::lock_guard<std::mutex> disc_lock(discovery_mutex_);
@@ -218,10 +229,7 @@ void GraphCache::update_topic_map_for_put(
       }
     }
   }
-
-  for (const auto & cb : callbacks_to_invoke) {
-    cb(*entity);
-  }
+  return callbacks_to_invoke;
 }
 
 ///=============================================================================
@@ -354,8 +362,11 @@ void GraphCache::parse_put(
     return;
   }
 
-  // Lock the graph mutex before accessing the graph.
-  std::lock_guard<std::mutex> lock(graph_mutex_);
+  // Use unique_lock so we can release graph_mutex_ before invoking discovery
+  // callbacks; callbacks must not run under graph_mutex_ (non-recursive mutex).
+  std::unique_lock<std::mutex> lock(graph_mutex_);
+
+  std::vector<EntityDiscoveryCallback> pending_callbacks;
 
   // If the namespace did not exist, create it and add the node to the graph and return.
   NamespaceMap::iterator ns_it = graph_.find(entity->node_namespace());
@@ -368,50 +379,58 @@ void GraphCache::parse_put(
     NodeMap node_map = {
       {entity->node_name(), node}};
     graph_.emplace(std::make_pair(entity->node_namespace(), std::move(node_map)));
-    update_topic_maps_for_put(node, entity);
+    pending_callbacks = update_topic_maps_for_put(node, entity);
     total_nodes_in_graph_ += 1;
-    return;
+  } else {
+    // Add the node to the namespace if it did not exist and return.
+    // Case 1: First time a node with this name is added to the namespace.
+    // Case 2: There are one or more nodes with the same name but the entity could
+    // represent a node with the same name but a unique id which would make it a
+    // new addition to the graph.
+    std::pair<NodeMap::iterator, NodeMap::iterator> range = ns_it->second.equal_range(
+      entity->node_name());
+    NodeMap::iterator node_it = std::find_if(
+      range.first, range.second,
+      [entity](const std::pair<std::string, GraphNodePtr> & node_it)
+      {
+        // Match nodes if their zenoh session and node ids match.
+        return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
+      });
+    if (node_it == range.second) {
+      // Either the first time a node with this name is added or with an existing
+      // name but unique id.
+      GraphNodePtr node = make_graph_node(*entity);
+      if (node == nullptr) {
+        // Error handled.
+        return;
+      }
+      NodeMap::iterator insertion_it =
+        ns_it->second.insert(std::make_pair(entity->node_name(), node));
+      pending_callbacks = update_topic_maps_for_put(node, entity);
+      total_nodes_in_graph_ += 1;
+      if (insertion_it == ns_it->second.end()) {
+        RMW_ZENOH_LOG_ERROR_NAMED(
+          "rmw_zenoh_cpp",
+          "Unable to add a new node /%s to an "
+          "existing namespace %s in the graph. Report this bug.",
+          entity->node_name().c_str(),
+          entity->node_namespace().c_str());
+      }
+    } else {
+      // Otherwise, the entity represents a node that already exists in the graph.
+      // Update topic info if required below.
+      pending_callbacks = update_topic_maps_for_put(node_it->second, entity);
+    }
   }
 
-  // Add the node to the namespace if it did not exist and return.
-  // Case 1: First time a node with this name is added to the namespace.
-  // Case 2: There are one or more nodes with the same name but the entity could
-  // represent a node with the same name but a unique id which would make it a
-  // new addition to the graph.
-  std::pair<NodeMap::iterator, NodeMap::iterator> range = ns_it->second.equal_range(
-    entity->node_name());
-  NodeMap::iterator node_it = std::find_if(
-    range.first, range.second,
-    [entity](const std::pair<std::string, GraphNodePtr> & node_it)
-    {
-      // Match nodes if their zenoh session and node ids match.
-      return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
-    });
-  if (node_it == range.second) {
-    // Either the first time a node with this name is added or with an existing
-    // name but unique id.
-    GraphNodePtr node = make_graph_node(*entity);
-    if (node == nullptr) {
-      // Error handled.
-      return;
-    }
-    NodeMap::iterator insertion_it =
-      ns_it->second.insert(std::make_pair(entity->node_name(), node));
-    update_topic_maps_for_put(node, entity);
-    total_nodes_in_graph_ += 1;
-    if (insertion_it == ns_it->second.end()) {
-      RMW_ZENOH_LOG_ERROR_NAMED(
-        "rmw_zenoh_cpp",
-        "Unable to add a new node /%s to an "
-        "existing namespace %s in the graph. Report this bug.",
-        entity->node_name().c_str(),
-        entity->node_namespace().c_str());
-    }
-    return;
+  // Release graph_mutex_ before invoking discovery callbacks.
+  // Callbacks may create per-endpoint Zenoh publishers/subscribers; they must
+  // not hold graph_mutex_ to avoid potential re-entrant deadlock.
+  lock.unlock();
+
+  for (const auto & cb : pending_callbacks) {
+    cb(*entity);
   }
-  // Otherwise, the entity represents a node that already exists in the graph.
-  // Update topic info if required below.
-  update_topic_maps_for_put(node_it->second, entity);
 }
 
 ///=============================================================================

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -228,11 +228,16 @@ private:
   std::shared_ptr<GraphNode> make_graph_node(const liveliness::Entity & entity) const;
 
   // Helper function to update TopicMap within the node the cache for the entire graph.
-  void update_topic_maps_for_put(
+  // Returns any discovery callbacks that should be invoked by the caller
+  // *outside* graph_mutex_ to prevent re-entrant deadlock.
+  std::vector<EntityDiscoveryCallback> update_topic_maps_for_put(
     GraphNodePtr graph_node,
     liveliness::ConstEntityPtr entity);
 
-  void update_topic_map_for_put(
+  // Returns discovery callbacks to invoke; never invokes them directly.
+  // Callers must hold graph_mutex_ when calling, and must invoke the returned
+  // callbacks *after* releasing graph_mutex_.
+  std::vector<EntityDiscoveryCallback> update_topic_map_for_put(
     GraphNode::TopicMap & topic_map,
     liveliness::ConstEntityPtr entity,
     bool report_events = false);

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -74,7 +74,9 @@ std::string gid_array_to_hex(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> & g
   return out.str();
 }
 
-bool is_cpu_only_backend_metadata(const std::unordered_map<std::string, std::string> & backend_metadata)
+bool is_cpu_only_backend_metadata(
+  const std::unordered_map<std::string,
+  std::string> & backend_metadata)
 {
   return backend_metadata.size() == 1 && backend_metadata.count("cpu") == 1;
 }


### PR DESCRIPTION
## Summary

`update_topic_map_for_put()` collected discovery callbacks under `discovery_mutex_` (correct)
but then invoked them while `graph_mutex_` was still held via the `lock_guard` in `parse_put()`.
Any callback that re-enters `GraphCache` — for example, creating a per-endpoint subscription
which calls `register_publisher_discovery_callback()` — would attempt to re-acquire
`graph_mutex_` on the same thread and deadlock immediately.

A ROS 2 stress test (6 × pub + 6 × sub, rapid create/destroy) with buffer-aware subscriptions
froze completely within ~40 s: the heartbeat thread stopped, and every thread blocked on
`futex_do_wait` in `/proc/PID/task/*/wchan`. The ABBA lock-order inversion between
`graph_mutex_` and `discovery_mutex_` (originally introduced before `e91c15a`) caused the
initial hang; the remaining hazard addressed here is the callback invocation under
`graph_mutex_`.

## Key Changes

- `update_topic_map_for_put()` returns `std::vector<EntityDiscoveryCallback>` instead of
  invoking callbacks internally; the same change propagates to `update_topic_maps_for_put()`
- `parse_put()` switches from `std::lock_guard` to `std::unique_lock` on `graph_mutex_`,
  calls `lock.unlock()` after all graph mutations are done, then iterates over the returned
  callbacks without holding any lock
- Header declarations updated to match new return types, with doc comments explaining the
  required call sequence

## Breaking Changes

None — the changed functions are `private` members of `GraphCache`.

## Relation to e91c15a

`e91c15a` fixed the ABBA by standardising lock order in `register_*_discovery_callback()`
to `graph_mutex_` → `discovery_mutex_`.  This PR is a complementary defensive measure:
even with consistent lock ordering, invoking external callbacks under an internal mutex
is an API contract violation that creates fragility when callbacks evolve.

---

## Did you use Generative AI?

Yes. Claude (claude-sonnet-4-6) via Claude Code was used to assist with creating an initial prototype version of the changes contained in this PR.