### PR TITLE
Patch Cargo.lock with newer Zenoh commit

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -32,12 +32,14 @@ else()
   # See https://github.com/eclipse-zenoh/zenoh-c/blob/c1a477d3f5efc3abc0f0cf95e0773225d00dea3b/Cargo.lock#L4229
   # pointing to zenoh https://github.com/eclipse-zenoh/zenoh/commit/69b410e705e94531902a41a51b74d0c7b098264c
   set(zenoh_c_commit c1a477d3f5efc3abc0f0cf95e0773225d00dea3b)
+  set(zenoh_c_patches patches-c1a477d3)
 
   # If Rust version below Zenoh MSRV (currently 1.88), use equivalent commit from branch ROS/rust-1.75
   # See https://github.com/eclipse-zenoh/zenoh-c/blob/0e3ec084142382096d09f7fc2ad59385998b92e6/Cargo.lock#L4237
   # pointing to zenoh https://github.com/eclipse-zenoh/zenoh/commit/f27282e78c6e42e04249349049fa68cfbc941369
   if(CARGO_VERSION VERSION_GREATER_EQUAL "1.75" AND CARGO_VERSION VERSION_LESS "1.88")
     set(zenoh_c_commit 0e3ec084142382096d09f7fc2ad59385998b92e6)
+    set(zenoh_c_patches patches-0e3ec084)
   endif()
 
   ament_vendor(zenoh_c_vendor
@@ -47,6 +49,7 @@ else()
       "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
       "-DZENOHC_BUILD_WITH_UNSTABLE_API=TRUE"
       "-DZENOHC_CUSTOM_TARGET=${ZENOHC_CUSTOM_TARGET}"
+    PATCHES "${zenoh_c_patches}"
   )
 
   ament_vendor(zenoh_cpp_vendor

--- a/zenoh_cpp_vendor/patches-0e3ec084/0001-zenoh-e5db0ce-from-0e3ec084.patch
+++ b/zenoh_cpp_vendor/patches-0e3ec084/0001-zenoh-e5db0ce-from-0e3ec084.patch
@@ -1,0 +1,292 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index dbec438e..d834231b 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -4234,7 +4234,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "ahash",
+  "arc-swap",
+@@ -4286,7 +4286,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-buffers"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "zenoh-collections",
+ ]
+@@ -4325,7 +4325,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-codec"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "tracing",
+  "uhlc",
+@@ -4337,7 +4337,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-collections"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "ahash",
+ ]
+@@ -4345,7 +4345,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-config"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "json5",
+  "nonempty-collections",
+@@ -4370,7 +4370,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-core"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "lazy_static",
+  "tokio",
+@@ -4381,7 +4381,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-crypto"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "aes",
+  "hmac",
+@@ -4394,7 +4394,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-ext"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "bincode",
+@@ -4413,7 +4413,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-keyexpr"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "getrandom 0.2.17",
+  "hashbrown 0.16.1",
+@@ -4428,7 +4428,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "zenoh-config",
+  "zenoh-link-commons",
+@@ -4448,7 +4448,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-commons"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "base64",
+@@ -4481,7 +4481,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-quic"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "base64",
+@@ -4506,7 +4506,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-serial"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "tokio",
+@@ -4524,7 +4524,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-tcp"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "socket2 0.5.10",
+@@ -4541,7 +4541,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-tls"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "base64",
+@@ -4570,7 +4570,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-udp"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "libc",
+@@ -4591,7 +4591,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-unixpipe"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "advisory-lock",
+  "async-trait",
+@@ -4613,7 +4613,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-unixsock_stream"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "nix 0.29.0",
+@@ -4631,7 +4631,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-vsock"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "libc",
+@@ -4649,7 +4649,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-ws"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "futures-util",
+@@ -4669,7 +4669,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-macros"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4680,7 +4680,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-pinned-deps-1-75"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-lock",
+  "base64ct",
+@@ -4725,7 +4725,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-plugin-trait"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "git-version",
+  "libloading",
+@@ -4742,7 +4742,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-protocol"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "const_format",
+  "rand 0.8.5",
+@@ -4757,7 +4757,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-result"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "anyhow",
+ ]
+@@ -4765,7 +4765,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-runtime"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "lazy_static",
+  "ron",
+@@ -4779,7 +4779,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-shm"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "advisory-lock",
+  "async-trait",
+@@ -4808,7 +4808,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-stats"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "ahash",
+  "prometheus-client",
+@@ -4821,7 +4821,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-sync"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "arc-swap",
+  "event-listener",
+@@ -4835,7 +4835,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-task"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "futures",
+  "tokio",
+@@ -4848,7 +4848,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-transport"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "crossbeam-utils",
+@@ -4883,7 +4883,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-util"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=f27282e78c6e42e04249349049fa68cfbc941369#f27282e78c6e42e04249349049fa68cfbc941369"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?rev=e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "const_format",

--- a/zenoh_cpp_vendor/patches-c1a477d3/0001-zenoh-e5db0ce-from-c1a477d3.patch
+++ b/zenoh_cpp_vendor/patches-c1a477d3/0001-zenoh-e5db0ce-from-c1a477d3.patch
@@ -1,0 +1,283 @@
+diff --git a/Cargo.lock b/Cargo.lock
+index 45e757f9..e4c3042c 100644
+--- a/Cargo.lock
++++ b/Cargo.lock
+@@ -4226,7 +4226,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "ahash",
+  "arc-swap",
+@@ -4278,7 +4278,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-buffers"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "zenoh-collections",
+ ]
+@@ -4315,7 +4315,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-codec"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "tracing",
+  "uhlc",
+@@ -4327,7 +4327,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-collections"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "ahash",
+ ]
+@@ -4335,7 +4335,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-config"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "json5",
+  "nonempty-collections",
+@@ -4360,7 +4360,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-core"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "lazy_static",
+  "tokio",
+@@ -4371,7 +4371,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-crypto"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "aes",
+  "hmac",
+@@ -4384,7 +4384,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-ext"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "bincode",
+@@ -4403,7 +4403,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-keyexpr"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "getrandom 0.2.17",
+  "hashbrown 0.16.1",
+@@ -4418,7 +4418,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "zenoh-config",
+  "zenoh-link-commons",
+@@ -4438,7 +4438,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-commons"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "base64",
+@@ -4471,7 +4471,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-quic"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "base64",
+@@ -4496,7 +4496,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-serial"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "tokio",
+@@ -4514,7 +4514,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-tcp"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "socket2 0.5.10",
+@@ -4531,7 +4531,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-tls"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "base64",
+@@ -4560,7 +4560,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-udp"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "libc",
+@@ -4581,7 +4581,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-unixpipe"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "advisory-lock",
+  "async-trait",
+@@ -4603,7 +4603,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-unixsock_stream"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "nix 0.29.0",
+@@ -4621,7 +4621,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-vsock"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "libc",
+@@ -4639,7 +4639,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-link-ws"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "futures-util",
+@@ -4659,7 +4659,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-macros"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "proc-macro2",
+  "quote",
+@@ -4670,7 +4670,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-plugin-trait"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "git-version",
+  "libloading",
+@@ -4687,7 +4687,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-protocol"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "const_format",
+  "rand 0.8.5",
+@@ -4702,7 +4702,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-result"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "anyhow",
+ ]
+@@ -4710,7 +4710,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-runtime"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "lazy_static",
+  "ron",
+@@ -4724,7 +4724,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-shm"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "advisory-lock",
+  "async-trait",
+@@ -4753,7 +4753,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-stats"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "ahash",
+  "prometheus-client",
+@@ -4766,7 +4766,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-sync"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "arc-swap",
+  "event-listener",
+@@ -4780,7 +4780,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-task"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "futures",
+  "tokio",
+@@ -4793,7 +4793,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-transport"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "crossbeam-utils",
+@@ -4828,7 +4828,7 @@ dependencies = [
+ [[package]]
+ name = "zenoh-util"
+ version = "1.8.0"
+-source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#69b410e705e94531902a41a51b74d0c7b098264c"
++source = "git+https://github.com/eclipse-zenoh/zenoh.git?branch=main#e5db0ce8a52ddcd95c7449508434518db2f6fbec"
+ dependencies = [
+  "async-trait",
+  "const_format",


### PR DESCRIPTION
## Description

Trying patching Cargo.lock to use newer Zenoh version to get https://github.com/eclipse-zenoh/zenoh/pull/2528

Fixes #956

### Is this user-facing behavior change?

no

### Did you use Generative AI?

no

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
