### PR TITLE
Use zenoh-cpp 481b71b fixing build with MSVC 2022 in C++20 mode

### DIFF
--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -52,7 +52,7 @@ else()
 
   ament_vendor(zenoh_cpp_vendor
     VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
-    VCS_VERSION af381b420cc8837ac7da42c9984594ef8f110e90
+    VCS_VERSION 481b71bf974f684ea75afb4243b0313646d545f9
     CMAKE_ARGS
       -DZENOHCXX_ZENOHC=OFF
   )


### PR DESCRIPTION
## Description

The upgrade to MSVC 19.44 (VS 2022 17.14, 14.44.35207) and the change of the minimum c++ version for all ROS packages to c++20 and C17 made `zenoh-cpp` build to fail when building `zenoh_cpp_vendor`.
It was fixed in `zenoh-cpp` by https://github.com/eclipse-zenoh/zenoh-cpp/pull/776 and https://github.com/eclipse-zenoh/zenoh-cpp/pull/778.

This PR bump the `zenoh-cpp` commit id to https://github.com/eclipse-zenoh/zenoh-cpp/commit/481b71bf974f684ea75afb4243b0313646d545f9 to include those 2 fixes.


### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
