### PR TITLE
fix(liveliness): escape '/' in backend names embedded in key expressions

### DIFF
--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -114,6 +114,9 @@ std::string escape_backend_field(const std::string & input)
       case ':':
         out += "%3A";
         break;
+      case '/':
+        out += "%2F";
+        break;
       default:
         out += c;
         break;


### PR DESCRIPTION
## Summary

Escape `/` in `escape_backend_field()` so backend names or metadata containing a forward slash do not corrupt the liveliness key expression in #930.

## Key Changes

- `rmw_zenoh_cpp/src/detail/liveliness_utils.cpp` — add `case '/': out += "%2F"; break;` to `escape_backend_field()`.

## Rationale

The design note for the optional `<backends>` keyexpr component lists `:`, `;`, and `/` as the reserved separators that backend fields must not contain verbatim. `unescape_backend_field()` already handles `%2F` correctly via its generic `%XX` decoder, so the encode/decode pair becomes symmetric with this change.

Without this escape, a backend plugin whose `get_backend_type()` returns e.g. `"cuda/v2"` or `"vendor/gpu"` would embed a literal `/` in the liveliness token, which the keyexpr parser treats as a field separator — silently corrupting the `<backends>` component for every peer.

## Breaking Changes

None. `/` is not currently produced by any known backend, so this only closes a latent correctness hole. Existing tokens without `/` in backend fields are byte-identical before and after this change.

## Did you use Generative AI?

Yes. Claude (claude-sonnet-4-6) via Claude Code was used to assist with creating an initial prototype version of the changes contained in this PR.
