### PR TITLE
Avoid deadlocks when dispatching event callbacks

### DIFF
--- a/rmw_zenoh_cpp/src/detail/event.cpp
+++ b/rmw_zenoh_cpp/src/detail/event.cpp
@@ -68,19 +68,31 @@ rmw_zenoh_event_status_t::rmw_zenoh_event_status_t()
 void DataCallbackManager::set_callback(
   const void * user_data, rmw_event_callback_t callback)
 {
-  std::lock_guard<std::mutex> lock_mutex(event_mutex_);
+  rmw_event_callback_t pending_callback = nullptr;
+  const void * pending_user_data = nullptr;
+  size_t pending_unread_count = 0;
 
-  if (callback) {
-    // Push events arrived before setting the the executor callback.
-    if (unread_count_) {
-      callback(user_data, unread_count_);
-      unread_count_ = 0;
+  {
+    std::lock_guard<std::mutex> lock_mutex(event_mutex_);
+
+    if (callback) {
+      // Push events arrived before setting the the executor callback.
+      if (unread_count_) {
+        pending_callback = callback;
+        pending_user_data = user_data;
+        pending_unread_count = unread_count_;
+        unread_count_ = 0;
+      }
+      user_data_ = user_data;
+      callback_ = callback;
+    } else {
+      user_data_ = nullptr;
+      callback_ = nullptr;
     }
-    user_data_ = user_data;
-    callback_ = callback;
-  } else {
-    user_data_ = nullptr;
-    callback_ = nullptr;
+  }
+
+  if (pending_callback != nullptr) {
+    pending_callback(pending_user_data, pending_unread_count);
   }
 }
 
@@ -88,11 +100,21 @@ void DataCallbackManager::set_callback(
 void DataCallbackManager::trigger_callback()
 {
   // Trigger the user provided event callback if available.
-  std::lock_guard<std::mutex> lock_mutex(event_mutex_);
-  if (callback_ != nullptr) {
-    callback_(user_data_, 1);
-  } else {
-    ++unread_count_;
+  rmw_event_callback_t callback = nullptr;
+  const void * user_data = nullptr;
+
+  {
+    std::lock_guard<std::mutex> lock_mutex(event_mutex_);
+    if (callback_ != nullptr) {
+      callback = callback_;
+      user_data = user_data_;
+    } else {
+      ++unread_count_;
+    }
+  }
+
+  if (callback != nullptr) {
+    callback(user_data, 1);
   }
 }
 
@@ -110,16 +132,28 @@ void EventsManager::event_set_callback(
     return;
   }
 
-  std::lock_guard<std::mutex> lock(event_mutex_);
+  rmw_event_callback_t pending_callback = nullptr;
+  const void * pending_user_data = nullptr;
+  size_t pending_unread_count = 0;
 
-  // Set the user callback data
-  event_callback_[event_id] = callback;
-  event_data_[event_id] = user_data;
+  {
+    std::lock_guard<std::mutex> lock(event_mutex_);
 
-  if (callback && event_unread_count_[event_id]) {
-    // Push events happened before having assigned a callback
-    callback(user_data, event_unread_count_[event_id]);
-    event_unread_count_[event_id] = 0;
+    // Set the user callback data
+    event_callback_[event_id] = callback;
+    event_data_[event_id] = user_data;
+
+    if (callback && event_unread_count_[event_id]) {
+      // Push events happened before having assigned a callback
+      pending_callback = callback;
+      pending_user_data = user_data;
+      pending_unread_count = event_unread_count_[event_id];
+      event_unread_count_[event_id] = 0;
+    }
+  }
+
+  if (pending_callback != nullptr) {
+    pending_callback(pending_user_data, pending_unread_count);
   }
   return;
 }
@@ -135,12 +169,22 @@ void EventsManager::trigger_event_callback(rmw_zenoh_event_type_t event_id)
     return;
   }
 
-  std::lock_guard<std::mutex> lock(event_mutex_);
+  rmw_event_callback_t callback = nullptr;
+  const void * user_data = nullptr;
 
-  if (event_callback_[event_id] != nullptr) {
-    event_callback_[event_id](event_data_[event_id], 1);
-  } else {
-    ++event_unread_count_[event_id];
+  {
+    std::lock_guard<std::mutex> lock(event_mutex_);
+
+    if (event_callback_[event_id] != nullptr) {
+      callback = event_callback_[event_id];
+      user_data = event_data_[event_id];
+    } else {
+      ++event_unread_count_[event_id];
+    }
+  }
+
+  if (callback != nullptr) {
+    callback(user_data, 1);
   }
   return;
 }

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -91,7 +91,8 @@ std::shared_ptr<GraphNode> GraphCache::make_graph_node(const Entity & entity) co
 ///=============================================================================
 void GraphCache::update_topic_maps_for_put(
   GraphNodePtr graph_node,
-  liveliness::ConstEntityPtr entity)
+  liveliness::ConstEntityPtr entity,
+  PendingGraphEvents & pending_events)
 {
   if (entity->type() == EntityType::Node) {
     // Nothing to update for a node entity.
@@ -100,13 +101,13 @@ void GraphCache::update_topic_maps_for_put(
 
   // First update the topic map within the node.
   if (entity->type() == EntityType::Publisher) {
-    update_topic_map_for_put(graph_node->pubs_, entity);
+    update_topic_map_for_put(graph_node->pubs_, entity, pending_events);
   } else if (entity->type() == EntityType::Subscription) {
-    update_topic_map_for_put(graph_node->subs_, entity);
+    update_topic_map_for_put(graph_node->subs_, entity, pending_events);
   } else if (entity->type() == EntityType::Service) {
-    update_topic_map_for_put(graph_node->services_, entity);
+    update_topic_map_for_put(graph_node->services_, entity, pending_events);
   } else {
-    update_topic_map_for_put(graph_node->clients_, entity);
+    update_topic_map_for_put(graph_node->clients_, entity, pending_events);
   }
 
   // Then update the variables tracking topics across the graph.
@@ -115,9 +116,9 @@ void GraphCache::update_topic_maps_for_put(
   if (entity->type() == EntityType::Publisher ||
     entity->type() == EntityType::Subscription)
   {
-    update_topic_map_for_put(this->graph_topics_, entity, true);
+    update_topic_map_for_put(this->graph_topics_, entity, pending_events, true);
   } else {
-    update_topic_map_for_put(this->graph_services_, entity);
+    update_topic_map_for_put(this->graph_services_, entity, pending_events);
   }
 }
 
@@ -125,6 +126,7 @@ void GraphCache::update_topic_maps_for_put(
 void GraphCache::update_topic_map_for_put(
   GraphNode::TopicMap & topic_map,
   liveliness::ConstEntityPtr entity,
+  PendingGraphEvents & pending_events,
   bool report_events)
 {
   TopicDataPtr graph_topic_data = TopicData::make(entity);
@@ -174,7 +176,8 @@ void GraphCache::update_topic_map_for_put(
     // without having to check for any qos compatibilities.
     this->handle_matched_events_for_put(
       entity,
-      topic_type_map_it->second);
+      topic_type_map_it->second,
+      pending_events);
   }
   // We check if an entity with the exact same qos also exists.
   GraphNode::TopicQoSMap::iterator topic_qos_map_it =
@@ -198,7 +201,8 @@ void GraphCache::update_topic_map_for_put(
 ///=============================================================================
 void GraphCache::handle_matched_events_for_put(
   liveliness::ConstEntityPtr entity,
-  const GraphNode::TopicQoSMap & topic_qos_map)
+  const GraphNode::TopicQoSMap & topic_qos_map,
+  PendingGraphEvents & pending_events)
 {
   if (!entity->topic_info().has_value()) {
     return;
@@ -226,16 +230,21 @@ void GraphCache::handle_matched_events_for_put(
           sub_entity->topic_info().value().topic_keyexpr_)
         {
           if (is_entity_local(*sub_entity)) {
-            update_event_counters(sub_entity, ZENOH_EVENT_SUBSCRIPTION_MATCHED, 1);
+            queue_event_counter_update(
+              sub_entity,
+              ZENOH_EVENT_SUBSCRIPTION_MATCHED,
+              1,
+              pending_events);
           }
         }
       }
       // Update event counters for the new entity.
       if (is_entity_local(*entity) && match_count_for_entity > 0) {
-        update_event_counters(
+        queue_event_counter_update(
           entity,
           ZENOH_EVENT_PUBLICATION_MATCHED,
-          match_count_for_entity);
+          match_count_for_entity,
+          pending_events);
       }
     } else {
       // Entity is a sub.
@@ -255,16 +264,21 @@ void GraphCache::handle_matched_events_for_put(
           pub_entity->topic_info().value().topic_keyexpr_)
         {
           if (is_entity_local(*pub_entity)) {
-            update_event_counters(pub_entity, ZENOH_EVENT_PUBLICATION_MATCHED, 1);
+            queue_event_counter_update(
+              pub_entity,
+              ZENOH_EVENT_PUBLICATION_MATCHED,
+              1,
+              pending_events);
           }
         }
       }
       // Update event counters for the new entity.
       if (is_entity_local(*entity) && match_count_for_entity > 0) {
-        update_event_counters(
+        queue_event_counter_update(
           entity,
           ZENOH_EVENT_SUBSCRIPTION_MATCHED,
-          match_count_for_entity);
+          match_count_for_entity,
+          pending_events);
       }
     }
   }
@@ -273,7 +287,8 @@ void GraphCache::handle_matched_events_for_put(
 ///=============================================================================
 void GraphCache::handle_matched_events_for_del(
   liveliness::ConstEntityPtr entity,
-  const GraphNode::TopicQoSMap & topic_qos_map)
+  const GraphNode::TopicQoSMap & topic_qos_map,
+  PendingGraphEvents & pending_events)
 {
   // We do not have to report any events for the entity removed event
   // as it is already destructed. So we only check for matched entities
@@ -287,10 +302,11 @@ void GraphCache::handle_matched_events_for_del(
     for (const auto & [_, topic_data_ptr] : topic_qos_map) {
       for (liveliness::ConstEntityPtr sub_entity : topic_data_ptr->subs_) {
         if (is_entity_local(*sub_entity)) {
-          update_event_counters(
+          queue_event_counter_update(
             sub_entity,
             ZENOH_EVENT_SUBSCRIPTION_MATCHED,
-            static_cast<int32_t>(-1));
+            static_cast<int32_t>(-1),
+            pending_events);
         }
       }
     }
@@ -299,10 +315,11 @@ void GraphCache::handle_matched_events_for_del(
     for (const auto & [_, topic_data_ptr] : topic_qos_map) {
       for (liveliness::ConstEntityPtr pub_entity : topic_data_ptr->pubs_) {
         if (is_entity_local(*pub_entity)) {
-          update_event_counters(
+          queue_event_counter_update(
             pub_entity,
             ZENOH_EVENT_PUBLICATION_MATCHED,
-            static_cast<int32_t>(-1));
+            static_cast<int32_t>(-1),
+            pending_events);
         }
       }
     }
@@ -326,70 +343,80 @@ void GraphCache::parse_put(
     return;
   }
 
-  // Lock the graph mutex before accessing the graph.
-  std::lock_guard<std::mutex> lock(graph_mutex_);
+  PendingGraphEvents pending_events;
+  auto update_graph = [&]() {
+      // Lock the graph mutex before accessing the graph.
+      std::lock_guard<std::mutex> lock(graph_mutex_);
+      auto enqueue_events = rcpputils::make_scope_exit(
+        [this, &pending_events]() {
+          enqueue_pending_events(std::move(pending_events));
+        });
 
-  // If the namespace did not exist, create it and add the node to the graph and return.
-  NamespaceMap::iterator ns_it = graph_.find(entity->node_namespace());
-  if (ns_it == graph_.end()) {
-    GraphNodePtr node = make_graph_node(*entity);
-    if (node == nullptr) {
-      // Error handled.
-      return;
-    }
-    NodeMap node_map = {
-      {entity->node_name(), node}};
-    graph_.emplace(std::make_pair(entity->node_namespace(), std::move(node_map)));
-    update_topic_maps_for_put(node, entity);
-    total_nodes_in_graph_ += 1;
-    return;
-  }
+      // If the namespace did not exist, create it and add the node to the graph and return.
+      NamespaceMap::iterator ns_it = graph_.find(entity->node_namespace());
+      if (ns_it == graph_.end()) {
+        GraphNodePtr node = make_graph_node(*entity);
+        if (node == nullptr) {
+          // Error handled.
+          return;
+        }
+        NodeMap node_map = {
+          {entity->node_name(), node}};
+        graph_.emplace(std::make_pair(entity->node_namespace(), std::move(node_map)));
+        update_topic_maps_for_put(node, entity, pending_events);
+        total_nodes_in_graph_ += 1;
+        return;
+      }
 
-  // Add the node to the namespace if it did not exist and return.
-  // Case 1: First time a node with this name is added to the namespace.
-  // Case 2: There are one or more nodes with the same name but the entity could
-  // represent a node with the same name but a unique id which would make it a
-  // new addition to the graph.
-  std::pair<NodeMap::iterator, NodeMap::iterator> range = ns_it->second.equal_range(
-    entity->node_name());
-  NodeMap::iterator node_it = std::find_if(
-    range.first, range.second,
-    [entity](const std::pair<std::string, GraphNodePtr> & node_it)
-    {
-      // Match nodes if their zenoh session and node ids match.
-      return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
-    });
-  if (node_it == range.second) {
-    // Either the first time a node with this name is added or with an existing
-    // name but unique id.
-    GraphNodePtr node = make_graph_node(*entity);
-    if (node == nullptr) {
-      // Error handled.
-      return;
-    }
-    NodeMap::iterator insertion_it =
-      ns_it->second.insert(std::make_pair(entity->node_name(), node));
-    update_topic_maps_for_put(node, entity);
-    total_nodes_in_graph_ += 1;
-    if (insertion_it == ns_it->second.end()) {
-      RMW_ZENOH_LOG_ERROR_NAMED(
-        "rmw_zenoh_cpp",
-        "Unable to add a new node /%s to an "
-        "existing namespace %s in the graph. Report this bug.",
-        entity->node_name().c_str(),
-        entity->node_namespace().c_str());
-    }
-    return;
-  }
-  // Otherwise, the entity represents a node that already exists in the graph.
-  // Update topic info if required below.
-  update_topic_maps_for_put(node_it->second, entity);
+      // Add the node to the namespace if it did not exist and return.
+      // Case 1: First time a node with this name is added to the namespace.
+      // Case 2: There are one or more nodes with the same name but the entity could
+      // represent a node with the same name but a unique id which would make it a
+      // new addition to the graph.
+      std::pair<NodeMap::iterator, NodeMap::iterator> range = ns_it->second.equal_range(
+        entity->node_name());
+      NodeMap::iterator node_it = std::find_if(
+        range.first, range.second,
+        [entity](const std::pair<std::string, GraphNodePtr> & node_it)
+        {
+          // Match nodes if their zenoh session and node ids match.
+          return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
+        });
+      if (node_it == range.second) {
+        // Either the first time a node with this name is added or with an existing
+        // name but unique id.
+        GraphNodePtr node = make_graph_node(*entity);
+        if (node == nullptr) {
+          // Error handled.
+          return;
+        }
+        NodeMap::iterator insertion_it =
+          ns_it->second.insert(std::make_pair(entity->node_name(), node));
+        update_topic_maps_for_put(node, entity, pending_events);
+        total_nodes_in_graph_ += 1;
+        if (insertion_it == ns_it->second.end()) {
+          RMW_ZENOH_LOG_ERROR_NAMED(
+            "rmw_zenoh_cpp",
+            "Unable to add a new node /%s to an "
+            "existing namespace %s in the graph. Report this bug.",
+            entity->node_name().c_str(),
+            entity->node_namespace().c_str());
+        }
+        return;
+      }
+      // Otherwise, the entity represents a node that already exists in the graph.
+      // Update topic info if required below.
+      update_topic_maps_for_put(node_it->second, entity, pending_events);
+    };
+  update_graph();
+  drain_pending_events();
 }
 
 ///=============================================================================
 void GraphCache::update_topic_maps_for_del(
   GraphNodePtr graph_node,
-  liveliness::ConstEntityPtr entity)
+  liveliness::ConstEntityPtr entity,
+  PendingGraphEvents & pending_events)
 {
   if (entity->type() == EntityType::Node) {
     // Nothing to update for a node entity->
@@ -397,22 +424,22 @@ void GraphCache::update_topic_maps_for_del(
   }
   // First update the topic map within the node.
   if (entity->type() == EntityType::Publisher) {
-    update_topic_map_for_del(graph_node->pubs_, entity);
+    update_topic_map_for_del(graph_node->pubs_, entity, pending_events);
   } else if (entity->type() == EntityType::Subscription) {
-    update_topic_map_for_del(graph_node->subs_, entity);
+    update_topic_map_for_del(graph_node->subs_, entity, pending_events);
   } else if (entity->type() == EntityType::Service) {
-    update_topic_map_for_del(graph_node->services_, entity);
+    update_topic_map_for_del(graph_node->services_, entity, pending_events);
   } else {
-    update_topic_map_for_del(graph_node->clients_, entity);
+    update_topic_map_for_del(graph_node->clients_, entity, pending_events);
   }
 
   // Then update the variables tracking topics across the graph.
   if (entity->type() == EntityType::Publisher ||
     entity->type() == EntityType::Subscription)
   {
-    update_topic_map_for_del(this->graph_topics_, entity, true);
+    update_topic_map_for_del(this->graph_topics_, entity, pending_events, true);
   } else {
-    update_topic_map_for_del(this->graph_services_, entity);
+    update_topic_map_for_del(this->graph_services_, entity, pending_events);
   }
 }
 
@@ -420,6 +447,7 @@ void GraphCache::update_topic_maps_for_del(
 void GraphCache::update_topic_map_for_del(
   GraphNode::TopicMap & topic_map,
   liveliness::ConstEntityPtr entity,
+  PendingGraphEvents & pending_events,
   bool report_events)
 {
   if (!entity->topic_info().has_value()) {
@@ -486,7 +514,8 @@ void GraphCache::update_topic_map_for_del(
   if (report_events) {
     handle_matched_events_for_del(
       entity,
-      cache_topic_type_it->second);
+      cache_topic_type_it->second,
+      pending_events);
   }
   // If the type does not have any qos entries, erase it from the type map.
   if (cache_topic_type_it->second.empty()) {
@@ -501,7 +530,8 @@ void GraphCache::update_topic_map_for_del(
 ///=============================================================================
 void GraphCache::remove_topic_map_from_cache(
   const GraphNode::TopicMap & to_remove,
-  GraphNode::TopicMap & from_cache)
+  GraphNode::TopicMap & from_cache,
+  PendingGraphEvents & pending_events)
 {
   for (GraphNode::TopicMap::const_iterator topic_it = to_remove.begin();
     topic_it != to_remove.end(); ++topic_it)
@@ -520,12 +550,14 @@ void GraphCache::remove_topic_map_from_cache(
           update_topic_map_for_del(
             from_cache,
             entity,
+            pending_events,
             true);
         }
         for (const liveliness::ConstEntityPtr & entity : topic_qos_it->second->subs_) {
           update_topic_map_for_del(
             from_cache,
             entity,
+            pending_events,
             true);
         }
       }
@@ -549,69 +581,79 @@ void GraphCache::parse_del(
       "Ignoring parse_del for %s from the same session.\n", entity->liveliness_keyexpr().c_str());
     return;
   }
-  // Lock the graph mutex before accessing the graph.
-  std::lock_guard<std::mutex> lock(graph_mutex_);
 
-  // If namespace does not exist, ignore the request.
-  NamespaceMap::iterator ns_it = graph_.find(entity->node_namespace());
-  if (ns_it == graph_.end()) {
-    return;
-  }
+  PendingGraphEvents pending_events;
+  auto update_graph = [&]() {
+      // Lock the graph mutex before accessing the graph.
+      std::lock_guard<std::mutex> lock(graph_mutex_);
+      auto enqueue_events = rcpputils::make_scope_exit(
+        [this, &pending_events]() {
+          enqueue_pending_events(std::move(pending_events));
+        });
 
-  // If the node does not exist, ignore the request.
-  std::pair<NodeMap::iterator, NodeMap::iterator> range = ns_it->second.equal_range(
-    entity->node_name());
-  NodeMap::iterator node_it = std::find_if(
-    range.first, range.second,
-    [entity](const std::pair<std::string, GraphNodePtr> & node_it)
-    {
-      // Match nodes if their zenoh session and node ids match.
-      return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
-    });
-  if (node_it == range.second) {
-    // Node does not exist.
-    RMW_ZENOH_LOG_DEBUG_NAMED(
-      "rmw_zenoh_cpp",
-      "Received liveliness token to remove unknown node /%s from the graph. Ignoring...",
-      entity->node_name().c_str()
-    );
-    return;
-  }
+      // If namespace does not exist, ignore the request.
+      NamespaceMap::iterator ns_it = graph_.find(entity->node_namespace());
+      if (ns_it == graph_.end()) {
+        return;
+      }
 
-  if (entity->type() == EntityType::Node) {
-    // Node
-    // When destroying a node, Zenoh does not guarantee that liveliness tokens to remove pub/subs
-    // arrive before the one to remove the node from the graph despite un-registering those entities
-    // earlier. In such scenarios, if we find any pub/subs present in the node, we reduce their
-    // counts in graph_topics_.
-    const GraphNodePtr graph_node = node_it->second;
-    if (!graph_node->pubs_.empty() ||
-      !graph_node->subs_.empty() ||
-      !graph_node->clients_.empty() ||
-      !graph_node->services_.empty())
-    {
-      RMW_ZENOH_LOG_DEBUG_NAMED(
-        "rmw_zenoh_cpp",
-        "Received liveliness token to remove node /%s from the graph before all pub/subs/"
-        "clients/services for this node have been removed. Removing all entities first...",
-        entity->node_name().c_str()
-      );
-      // We update the tracking variables to reduce the count of entities present in this node.
-      remove_topic_map_from_cache(graph_node->pubs_, graph_topics_);
-      remove_topic_map_from_cache(graph_node->subs_, graph_topics_);
-      remove_topic_map_from_cache(graph_node->services_, graph_services_);
-      remove_topic_map_from_cache(graph_node->clients_, graph_services_);
-    }
-    ns_it->second.erase(node_it);
-    total_nodes_in_graph_ -= 1;
-    if (ns_it->second.size() == 0) {
-      graph_.erase(entity->node_namespace());
-    }
-    return;
-  }
+      // If the node does not exist, ignore the request.
+      std::pair<NodeMap::iterator, NodeMap::iterator> range = ns_it->second.equal_range(
+        entity->node_name());
+      NodeMap::iterator node_it = std::find_if(
+        range.first, range.second,
+        [entity](const std::pair<std::string, GraphNodePtr> & node_it)
+        {
+          // Match nodes if their zenoh session and node ids match.
+          return entity->zid() == node_it.second->zid_ && entity->nid() == node_it.second->nid_;
+        });
+      if (node_it == range.second) {
+        // Node does not exist.
+        RMW_ZENOH_LOG_DEBUG_NAMED(
+          "rmw_zenoh_cpp",
+          "Received liveliness token to remove unknown node /%s from the graph. Ignoring...",
+          entity->node_name().c_str()
+        );
+        return;
+      }
 
-  // Update the graph based on the entity->
-  update_topic_maps_for_del(node_it->second, entity);
+      if (entity->type() == EntityType::Node) {
+        // Node
+        // When destroying a node, Zenoh does not guarantee that liveliness tokens to remove pub/subs
+        // arrive before the one to remove the node from the graph despite un-registering those
+        // entities earlier. In such scenarios, if we find any pub/subs present in the node, we
+        // reduce their counts in graph_topics_.
+        const GraphNodePtr graph_node = node_it->second;
+        if (!graph_node->pubs_.empty() ||
+          !graph_node->subs_.empty() ||
+          !graph_node->clients_.empty() ||
+          !graph_node->services_.empty())
+        {
+          RMW_ZENOH_LOG_DEBUG_NAMED(
+            "rmw_zenoh_cpp",
+            "Received liveliness token to remove node /%s from the graph before all pub/subs/"
+            "clients/services for this node have been removed. Removing all entities first...",
+            entity->node_name().c_str()
+          );
+          // We update the tracking variables to reduce the count of entities present in this node.
+          remove_topic_map_from_cache(graph_node->pubs_, graph_topics_, pending_events);
+          remove_topic_map_from_cache(graph_node->subs_, graph_topics_, pending_events);
+          remove_topic_map_from_cache(graph_node->services_, graph_services_, pending_events);
+          remove_topic_map_from_cache(graph_node->clients_, graph_services_, pending_events);
+        }
+        ns_it->second.erase(node_it);
+        total_nodes_in_graph_ -= 1;
+        if (ns_it->second.size() == 0) {
+          graph_.erase(entity->node_namespace());
+        }
+        return;
+      }
+
+      // Update the graph based on the entity->
+      update_topic_maps_for_del(node_it->second, entity, pending_events);
+    };
+  update_graph();
+  drain_pending_events();
 }
 
 ///=============================================================================
@@ -1166,35 +1208,45 @@ void GraphCache::set_qos_event_callback(
   const rmw_zenoh_event_type_t & event_type,
   GraphCacheEventCallback callback)
 {
-  std::lock_guard<std::mutex> lock(events_mutex_);
+  GraphCacheEventCallback pending_callback;
+  int32_t pending_change = 0;
 
-  if (event_type > ZENOH_EVENT_ID_MAX) {
-    RMW_ZENOH_LOG_WARN_NAMED(
-      "rmw_zenoh_cpp",
-      "set_qos_event_callback() called for unsupported event. Report this.");
-    return;
-  }
+  {
+    std::lock_guard<std::mutex> lock(events_mutex_);
 
-  const GraphEventCallbackMap::iterator event_cb_it = event_callbacks_.find(entity_gid_hash);
-  if (event_cb_it == event_callbacks_.end()) {
-    // First time a callback is being set for this entity.
-    event_callbacks_[entity_gid_hash] = {std::make_pair(event_type, std::move(callback))};
-  } else {
-    event_cb_it->second[event_type] = std::move(callback);
-  }
+    if (event_type > ZENOH_EVENT_ID_MAX) {
+      RMW_ZENOH_LOG_WARN_NAMED(
+        "rmw_zenoh_cpp",
+        "set_qos_event_callback() called for unsupported event. Report this.");
+      return;
+    }
 
-  // Check if there are any event changes for this event type before the callback was registered.
-  auto unregistered_event_changes_it = unregistered_event_changes_.find(entity_gid_hash);
-  if (unregistered_event_changes_it != unregistered_event_changes_.end()) {
-    auto event_changes_it = unregistered_event_changes_it->second.find(event_type);
-    if (event_changes_it != unregistered_event_changes_it->second.end()) {
-      event_callbacks_[entity_gid_hash][event_type](event_changes_it->second);
-      // Update bookkeeping for unregistered_event_changes_.
-      unregistered_event_changes_it->second.erase(event_changes_it);
-      if (unregistered_event_changes_it->second.empty()) {
-        unregistered_event_changes_.erase(unregistered_event_changes_it);
+    const GraphEventCallbackMap::iterator event_cb_it = event_callbacks_.find(entity_gid_hash);
+    if (event_cb_it == event_callbacks_.end()) {
+      // First time a callback is being set for this entity.
+      event_callbacks_[entity_gid_hash] = {std::make_pair(event_type, std::move(callback))};
+    } else {
+      event_cb_it->second[event_type] = std::move(callback);
+    }
+
+    // Check if there are any event changes for this event type before the callback was registered.
+    auto unregistered_event_changes_it = unregistered_event_changes_.find(entity_gid_hash);
+    if (unregistered_event_changes_it != unregistered_event_changes_.end()) {
+      auto event_changes_it = unregistered_event_changes_it->second.find(event_type);
+      if (event_changes_it != unregistered_event_changes_it->second.end()) {
+        pending_callback = event_callbacks_[entity_gid_hash][event_type];
+        pending_change = event_changes_it->second;
+        // Update bookkeeping for unregistered_event_changes_.
+        unregistered_event_changes_it->second.erase(event_changes_it);
+        if (unregistered_event_changes_it->second.empty()) {
+          unregistered_event_changes_.erase(unregistered_event_changes_it);
+        }
       }
     }
+  }
+
+  if (pending_callback) {
+    pending_callback(pending_change);
   }
 }
 
@@ -1226,57 +1278,105 @@ bool GraphCache::is_entity_pub(const liveliness::Entity & entity)
 }
 
 ///=============================================================================
-void GraphCache::update_event_counters(
+void GraphCache::queue_event_counter_update(
   liveliness::ConstEntityPtr entity,
   const rmw_zenoh_event_type_t event_id,
-  int32_t change)
+  int32_t change,
+  PendingGraphEvents & pending_events)
 {
   if (event_id > ZENOH_EVENT_ID_MAX) {
     return;
   }
 
+  // Capture the callback under events_mutex_ so dispatch needs no lock.
+  // Lock ordering (graph_mutex_ -> events_mutex_) matches the original code.
   std::lock_guard<std::mutex> lock(events_mutex_);
 
-  // Lambda to add changes to unregistered_event_changes_ if a callback for the
-  // event_type is not yet registered.
-  auto update_unregistered_event_changes =
-    [&]()
-    {
-      auto unregistered_event_changes_it = unregistered_event_changes_.find(entity->gid_hash());
-      if (unregistered_event_changes_it == unregistered_event_changes_.end()) {
-        // First time this entity has changes for any events without a callback registered.
+  auto update_unregistered_event_changes = [&]() {
+      auto it = unregistered_event_changes_.find(entity->gid_hash());
+      if (it == unregistered_event_changes_.end()) {
         unregistered_event_changes_[entity->gid_hash()] = {std::make_pair(event_id, change)};
       } else {
-        auto event_changes_it = unregistered_event_changes_it->second.find(event_id);
-        if (event_changes_it == unregistered_event_changes_it->second.end()) {
-          // First time this entity has changes for this specific event_id.
-          unregistered_event_changes_it->second[event_id] = change;
+        auto event_it = it->second.find(event_id);
+        if (event_it == it->second.end()) {
+          it->second[event_id] = change;
         } else {
-          // There have been changes for this event_id in the past so we simply increment
-          // the changes.
-          unregistered_event_changes_it->second[event_id] += change;
+          event_it->second += change;
         }
       }
     };
 
-  // Trigger callback set for this entity for the event type.
   GraphEventCallbackMap::const_iterator event_callbacks_it =
     event_callbacks_.find(entity->gid_hash());
   if (event_callbacks_it != event_callbacks_.end()) {
     GraphEventCallbacks::const_iterator callback_it =
       event_callbacks_it->second.find(event_id);
     if (callback_it != event_callbacks_it->second.end()) {
-      // Trigger the registered callback.
-      callback_it->second(change);
+      pending_events.push_back({callback_it->second, change});
     } else {
-      // A callback for a different event_type has been registered for this entity.
-      // We add the change for the unregistered event_type to unregistered_event_changes_.
       update_unregistered_event_changes();
     }
   } else {
-    // No callbacks for any event type have been registered for this entity.
-    // We add the change for the unregistered event_type to unregistered_event_changes_.
     update_unregistered_event_changes();
+  }
+}
+
+///=============================================================================
+void GraphCache::enqueue_pending_events(PendingGraphEvents && pending_events)
+{
+  if (pending_events.empty()) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(dispatch_mutex_);
+  for (PendingGraphEvent & event : pending_events) {
+    dispatch_queue_.push_back(std::move(event));
+  }
+}
+
+///=============================================================================
+void GraphCache::drain_pending_events()
+{
+  {
+    std::lock_guard<std::mutex> lock(dispatch_mutex_);
+    if (dispatching_) {
+      return;
+    }
+    dispatching_ = true;
+  }
+
+  // Use scope_exit to guarantee dispatching_ is reset even if a callback throws.
+  auto reset_dispatching = rcpputils::make_scope_exit(
+    [this]() {
+      std::lock_guard<std::mutex> lock(dispatch_mutex_);
+      dispatching_ = false;
+    });
+
+  while (true) {
+    PendingGraphEvent event;
+    {
+      std::lock_guard<std::mutex> lock(dispatch_mutex_);
+      if (dispatch_queue_.empty()) {
+        return;
+      }
+      event = std::move(dispatch_queue_.front());
+      dispatch_queue_.pop_front();
+    }
+
+    if (event.callback) {
+      try {
+        event.callback(event.change);
+      } catch (const std::exception & e) {
+        RMW_ZENOH_LOG_ERROR_NAMED(
+          "rmw_zenoh_cpp",
+          "Graph event callback threw an exception: %s",
+          e.what());
+      } catch (...) {
+        RMW_ZENOH_LOG_ERROR_NAMED(
+          "rmw_zenoh_cpp",
+          "Graph event callback threw an unknown exception.");
+      }
+    }
   }
 }
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/graph_cache.hpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.hpp
@@ -16,6 +16,7 @@
 #define DETAIL__GRAPH_CACHE_HPP_
 
 #include <cstddef>
+#include <deque>
 #include <functional>
 #include <map>
 #include <memory>
@@ -187,6 +188,13 @@ public:
   static bool is_entity_pub(const liveliness::Entity & entity);
 
 private:
+  struct PendingGraphEvent
+  {
+    GraphCacheEventCallback callback;
+    int32_t change;
+  };
+  using PendingGraphEvents = std::vector<PendingGraphEvent>;
+
   // Helper function to convert an Entity into a GraphNode.
   // Note: this will update bookkeeping variables in GraphCache.
   std::shared_ptr<GraphNode> make_graph_node(const liveliness::Entity & entity) const;
@@ -194,41 +202,53 @@ private:
   // Helper function to update TopicMap within the node the cache for the entire graph.
   void update_topic_maps_for_put(
     GraphNodePtr graph_node,
-    liveliness::ConstEntityPtr entity);
+    liveliness::ConstEntityPtr entity,
+    PendingGraphEvents & pending_events);
 
   void update_topic_map_for_put(
     GraphNode::TopicMap & topic_map,
     liveliness::ConstEntityPtr entity,
+    PendingGraphEvents & pending_events,
     bool report_events = false);
 
   void update_topic_maps_for_del(
     GraphNodePtr graph_node,
-    liveliness::ConstEntityPtr entity);
+    liveliness::ConstEntityPtr entity,
+    PendingGraphEvents & pending_events);
 
   void update_topic_map_for_del(
     GraphNode::TopicMap & topic_map,
     liveliness::ConstEntityPtr entity,
+    PendingGraphEvents & pending_events,
     bool report_events = false);
 
   void remove_topic_map_from_cache(
     const GraphNode::TopicMap & to_remove,
-    GraphNode::TopicMap & from_cache);
+    GraphNode::TopicMap & from_cache,
+    PendingGraphEvents & pending_events);
 
   /// Returns true if the entity was created within the same context / zenoh session.
   bool is_entity_local(const liveliness::Entity & entity) const;
 
-  void update_event_counters(
+  void queue_event_counter_update(
     liveliness::ConstEntityPtr entity,
     const rmw_zenoh_event_type_t event_id,
-    int32_t change);
+    int32_t change,
+    PendingGraphEvents & pending_events);
+
+  void enqueue_pending_events(PendingGraphEvents && pending_events);
+
+  void drain_pending_events();
 
   void handle_matched_events_for_put(
     liveliness::ConstEntityPtr entity,
-    const GraphNode::TopicQoSMap & topic_qos_map);
+    const GraphNode::TopicQoSMap & topic_qos_map,
+    PendingGraphEvents & pending_events);
 
   void handle_matched_events_for_del(
     liveliness::ConstEntityPtr entity,
-    const GraphNode::TopicQoSMap & topic_qos_map);
+    const GraphNode::TopicQoSMap & topic_qos_map,
+    PendingGraphEvents & pending_events);
 
   std::string zid_str_;
   /*
@@ -283,6 +303,10 @@ private:
   std::unordered_map<std::size_t,
     std::unordered_map<rmw_zenoh_event_type_t, int32_t>> unregistered_event_changes_;
   std::mutex events_mutex_;
+
+  std::deque<PendingGraphEvent> dispatch_queue_;
+  bool dispatching_{false};
+  std::mutex dispatch_mutex_;
 
   // Mutex to lock before modifying the members above.
   mutable std::mutex graph_mutex_;

--- a/rmw_zenoh_cpp/src/detail/guard_condition.cpp
+++ b/rmw_zenoh_cpp/src/detail/guard_condition.cpp
@@ -30,17 +30,26 @@ GuardCondition::GuardCondition()
 ///=============================================================================
 void GuardCondition::trigger()
 {
-  std::lock_guard<std::mutex> lock(internal_mutex_);
+  // Hold internal_mutex_ only long enough to update has_triggered_ and snapshot
+  // wait_set_data_, then release it before taking the wait_set's condition_mutex.
+  // rmw_wait locks the wait_set's condition_mutex first and then calls
+  // check_and_attach_condition_if_not() which takes internal_mutex_; holding
+  // both at the same time here would create an ABBA deadlock.
+  rmw_wait_set_data_t * local_wait_set_data = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(internal_mutex_);
 
-  // the change to hasTriggered_ needs to be mutually exclusive with
-  // rmw_wait() which checks hasTriggered() and decides if wait() needs to
-  // be called
-  has_triggered_ = true;
+    // the change to hasTriggered_ needs to be mutually exclusive with
+    // rmw_wait() which checks hasTriggered() and decides if wait() needs to
+    // be called
+    has_triggered_ = true;
+    local_wait_set_data = wait_set_data_;
+  }
 
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+  if (local_wait_set_data != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(local_wait_set_data->condition_mutex);
+    local_wait_set_data->triggered = true;
+    local_wait_set_data->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -215,29 +215,37 @@ std::array<uint8_t, 16> ClientData::copy_gid() const
 ///=============================================================================
 void ClientData::add_new_reply(std::unique_ptr<ZenohReply> reply)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  const rmw_qos_profile_t adapted_qos_profile =
-    entity_->topic_info().value().qos_;
-  if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
-    reply_queue_.size() >= adapted_qos_profile.depth)
+  // See SubscriptionData::add_new_message for the deadlock rationale: never hold
+  // mutex_ while taking the wait_set's condition_mutex (rmw_wait locks them in the
+  // opposite order).
+  rmw_wait_set_data_t * local_wait_set_data = nullptr;
   {
-    // Log warning if message is discarded due to hitting the queue depth
-    RMW_ZENOH_LOG_ERROR_NAMED(
-      "rmw_zenoh_cpp",
-      "Query queue depth of %ld reached, discarding oldest Query "
-      "for client for %s",
-      adapted_qos_profile.depth,
-      this->entity_->topic_info().value().topic_keyexpr_.c_str());
-    reply_queue_.pop_front();
+    std::lock_guard<std::mutex> lock(mutex_);
+    const rmw_qos_profile_t adapted_qos_profile =
+      entity_->topic_info().value().qos_;
+    if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
+      reply_queue_.size() >= adapted_qos_profile.depth)
+    {
+      // Log warning if message is discarded due to hitting the queue depth
+      RMW_ZENOH_LOG_ERROR_NAMED(
+        "rmw_zenoh_cpp",
+        "Query queue depth of %ld reached, discarding oldest Query "
+        "for client for %s",
+        adapted_qos_profile.depth,
+        this->entity_->topic_info().value().topic_keyexpr_.c_str());
+      reply_queue_.pop_front();
+    }
+    reply_queue_.emplace_back(std::move(reply));
+
+    local_wait_set_data = wait_set_data_;
   }
-  reply_queue_.emplace_back(std::move(reply));
 
   // Since we added new data, trigger user callback and guard condition if they are available
   data_callback_mgr_.trigger_callback();
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+  if (local_wait_set_data != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(local_wait_set_data->condition_mutex);
+    local_wait_set_data->triggered = true;
+    local_wait_set_data->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -221,36 +221,44 @@ bool ServiceData::liveliness_is_valid() const
 ///=============================================================================
 void ServiceData::add_new_query(std::unique_ptr<ZenohQuery> query)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (is_shutdown_.load(std::memory_order_acquire)) {
-    RMW_ZENOH_LOG_DEBUG_NAMED(
-      "rmw_zenoh_cpp",
-      "Request from client will be ignored since the service is shutdown."
-    );
-    return;
-  }
-  const rmw_qos_profile_t adapted_qos_profile =
-    entity_->topic_info().value().qos_;
-  if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
-    query_queue_.size() >= adapted_qos_profile.depth)
+  // See SubscriptionData::add_new_message for the deadlock rationale: never hold
+  // mutex_ while taking the wait_set's condition_mutex (rmw_wait locks them in the
+  // opposite order).
+  rmw_wait_set_data_t * local_wait_set_data = nullptr;
   {
-    // Log warning if message is discarded due to hitting the queue depth
-    RMW_ZENOH_LOG_ERROR_NAMED(
-      "rmw_zenoh_cpp",
-      "Query queue depth of %ld reached, discarding oldest Query "
-      "for service '%s'",
-      adapted_qos_profile.depth,
-      entity_->topic_info().value().name_.c_str());
-    query_queue_.pop_front();
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (is_shutdown_.load(std::memory_order_acquire)) {
+      RMW_ZENOH_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "Request from client will be ignored since the service is shutdown."
+      );
+      return;
+    }
+    const rmw_qos_profile_t adapted_qos_profile =
+      entity_->topic_info().value().qos_;
+    if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
+      query_queue_.size() >= adapted_qos_profile.depth)
+    {
+      // Log warning if message is discarded due to hitting the queue depth
+      RMW_ZENOH_LOG_ERROR_NAMED(
+        "rmw_zenoh_cpp",
+        "Query queue depth of %ld reached, discarding oldest Query "
+        "for service '%s'",
+        adapted_qos_profile.depth,
+        entity_->topic_info().value().name_.c_str());
+      query_queue_.pop_front();
+    }
+    query_queue_.emplace_back(std::move(query));
+
+    local_wait_set_data = wait_set_data_;
   }
-  query_queue_.emplace_back(std::move(query));
 
   // Since we added new data, trigger user callback and guard condition if they are available
   data_callback_mgr_.trigger_callback();
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+  if (local_wait_set_data != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(local_wait_set_data->condition_mutex);
+    local_wait_set_data->triggered = true;
+    local_wait_set_data->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -475,61 +475,76 @@ rmw_ret_t SubscriptionData::take_serialized_message(
 void SubscriptionData::add_new_message(
   std::unique_ptr<SubscriptionData::Message> msg, const std::string & topic_name)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (is_shutdown_) {
-    return;
-  }
-  const rmw_qos_profile_t adapted_qos_profile = entity_->topic_info().value().qos_;
-  if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
-    message_queue_.size() >= adapted_qos_profile.depth)
+  // Update internal state (queue + last_known_published_msg_) while holding mutex_,
+  // but defer every "outbound" notification (events_mgr_, data_callback_mgr_, and the
+  // wait_set's condition_mutex) until after mutex_ is released. Holding mutex_ while
+  // taking wait_set_data_->condition_mutex causes an ABBA deadlock against rmw_wait,
+  // which acquires the wait_set's condition_mutex first and then calls
+  // queue_has_data_and_attach_condition_if_not(), which locks mutex_.
+  int32_t num_msg_lost = 0;
+  bool report_msg_lost = false;
+  rmw_wait_set_data_t * local_wait_set_data = nullptr;
   {
-    // Log warning if message is discarded due to hitting the queue depth
-    RMW_ZENOH_LOG_DEBUG_NAMED(
-      "rmw_zenoh_cpp",
-      "Message queue depth of %ld reached, discarding oldest message "
-      "for subscription for %s",
-      adapted_qos_profile.depth,
-      topic_name.c_str());
-
-    // If the adapted_qos_profile.depth is 0, the std::move command below will result
-    // in UB and the z_drop will segfault. We explicitly set the depth to a minimum of 1
-    // in rmw_create_subscription() but to be safe, we only attempt to discard from the
-    // queue if it is non-empty.
-    if (!message_queue_.empty()) {
-      std::unique_ptr<Message> old = std::move(message_queue_.front());
-      message_queue_.pop_front();
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (is_shutdown_) {
+      return;
     }
+    const rmw_qos_profile_t adapted_qos_profile = entity_->topic_info().value().qos_;
+    if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
+      message_queue_.size() >= adapted_qos_profile.depth)
+    {
+      // Log warning if message is discarded due to hitting the queue depth
+      RMW_ZENOH_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "Message queue depth of %ld reached, discarding oldest message "
+        "for subscription for %s",
+        adapted_qos_profile.depth,
+        topic_name.c_str());
+
+      // If the adapted_qos_profile.depth is 0, the std::move command below will result
+      // in UB and the z_drop will segfault. We explicitly set the depth to a minimum of 1
+      // in rmw_create_subscription() but to be safe, we only attempt to discard from the
+      // queue if it is non-empty.
+      if (!message_queue_.empty()) {
+        std::unique_ptr<Message> old = std::move(message_queue_.front());
+        message_queue_.pop_front();
+      }
+    }
+
+    // Check for messages lost if the new sequence number is not monotonically increasing.
+    const size_t gid_hash = hash_gid(msg->attachment.copy_gid());
+    auto last_known_pub_it = last_known_published_msg_.find(gid_hash);
+    if (last_known_pub_it != last_known_published_msg_.end()) {
+      const int64_t seq_increment = std::abs(
+        msg->attachment.sequence_number() -
+        last_known_pub_it->second);
+      if (seq_increment > 1) {
+        num_msg_lost =
+          static_cast<int32_t>(std::clamp(
+            seq_increment - 1,
+            static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
+            static_cast<int64_t>(std::numeric_limits<int32_t>::max())));
+        report_msg_lost = true;
+      }
+    }
+    // Always update the last known sequence number for the publisher.
+    last_known_published_msg_[gid_hash] = msg->attachment.sequence_number();
+
+    message_queue_.emplace_back(std::move(msg));
+
+    local_wait_set_data = wait_set_data_;
   }
 
-  // Check for messages lost if the new sequence number is not monotonically increasing.
-  const size_t gid_hash = hash_gid(msg->attachment.copy_gid());
-  auto last_known_pub_it = last_known_published_msg_.find(gid_hash);
-  if (last_known_pub_it != last_known_published_msg_.end()) {
-    const int64_t seq_increment = std::abs(
-      msg->attachment.sequence_number() -
-      last_known_pub_it->second);
-    if (seq_increment > 1) {
-      int32_t num_msg_lost =
-        static_cast<int32_t>(std::clamp(
-          seq_increment - 1,
-          static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
-          static_cast<int64_t>(std::numeric_limits<int32_t>::max())));
-      events_mgr_->update_event_status(
-        ZENOH_EVENT_MESSAGE_LOST,
-        std::move(num_msg_lost));
-    }
+  if (report_msg_lost) {
+    events_mgr_->update_event_status(ZENOH_EVENT_MESSAGE_LOST, num_msg_lost);
   }
-  // Always update the last known sequence number for the publisher.
-  last_known_published_msg_[gid_hash] = msg->attachment.sequence_number();
-
-  message_queue_.emplace_back(std::move(msg));
 
   // Since we added new data, trigger user callback and guard condition if they are available
   data_callback_mgr_.trigger_callback();
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+  if (local_wait_set_data != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(local_wait_set_data->condition_mutex);
+    local_wait_set_data->triggered = true;
+    local_wait_set_data->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/rmw_event.cpp
+++ b/rmw_zenoh_cpp/src/rmw_event.cpp
@@ -145,13 +145,14 @@ rmw_subscription_event_init(
     return RMW_RET_OK;
   }
 
-  // std::weak_ptr<rmw_zenoh_cpp::SubscriptionData> data_wp = sub_data;
+  std::weak_ptr<rmw_zenoh_cpp::SubscriptionData> data_wp = sub_data->shared_from_this();
   sub_data->graph_cache()->set_qos_event_callback(
     sub_data->gid_hash(),
     zenoh_event_type,
-    [sub_data,
+    [data_wp,
     zenoh_event_type](int32_t change)
     {
+      auto sub_data = data_wp.lock();
       if (sub_data == nullptr) {
         return;
       }

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -30,15 +30,15 @@ else()
 
   # Based on commit id from branch ROS/zenoh-2687c5135.
   # It corresponds to zenoh-c 1.8.0 plus few fixes, including removal of an error log at closure causing #951,
-  # with zenoh pinned to https://github.com/BOURBONCASK/zenoh/commit/7f47053f537bc358c2aed600484fe978956f14a1
+  # with zenoh pinned to https://github.com/BOURBONCASK/zenoh/commit/8db2f3b7660238c0c6b40634c2554961d40f294a
   # which is based on https://github.com/eclipse-zenoh/zenoh/commit/2687c51352121f006e3a603ce07925a8ad0b295c
-  # plus the declare-final deadlock fix.
-  set(zenoh_c_commit 814c924447f9f4df9656f08a127f3b86032482c0)
+  # plus routing-lock deadlock fixes.
+  set(zenoh_c_commit 0443dc095cce080e0dedd357335b40770b5fd301)
 
   # If Rust version below Zenoh MSRV (currently 1.88), use equivalent commit from branch
   # ROS/rust-1.75-zenoh-2687c5135 with the same zenoh deadlock fix pin.
   if(CARGO_VERSION VERSION_GREATER_EQUAL "1.75" AND CARGO_VERSION VERSION_LESS "1.88")
-    set(zenoh_c_commit 3e3bdfc0623cbf1e1186938faa0487f98391d328)
+    set(zenoh_c_commit c8cb1d7effbb12800dfb95dcceffcd17780e5de8)
   endif()
 
   ament_vendor(zenoh_c_vendor

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -28,21 +28,21 @@ else()
   include(get_cargo_version.cmake)
   get_cargo_version()
 
-  # By default, use commit id from branch ROS/zenoh-2687c5135.
-  # It corresponding to zenoh-c 1.8.0 plus few fixes, including removal of a error log at closure causing #951
-  # See https://github.com/eclipse-zenoh/zenoh-c/blob/05bd370343b5161ca9269649b9a914c9c2dc4170/Cargo.lock#L4207
-  # pointing to zenoh https://github.com/eclipse-zenoh/zenoh/commit/2687c51352121f006e3a603ce07925a8ad0b295c
-  set(zenoh_c_commit 05bd370343b5161ca9269649b9a914c9c2dc4170)
+  # Based on commit id from branch ROS/zenoh-2687c5135.
+  # It corresponds to zenoh-c 1.8.0 plus few fixes, including removal of an error log at closure causing #951,
+  # with zenoh pinned to https://github.com/BOURBONCASK/zenoh/commit/7f47053f537bc358c2aed600484fe978956f14a1
+  # which is based on https://github.com/eclipse-zenoh/zenoh/commit/2687c51352121f006e3a603ce07925a8ad0b295c
+  # plus the declare-final deadlock fix.
+  set(zenoh_c_commit 43752173957a56deb6dcf5e7d14642869ee3c191)
 
-  # If Rust version below Zenoh MSRV (currently 1.88), use equivalent commit from branch ROS/rust-1.75-zenoh-2687c5135
-  # See https://github.com/eclipse-zenoh/zenoh-c/blob/b31348fa7f94f44f1f7b049c111a710e970a2725/Cargo.lock#L4237
-  # pointing to zenoh https://github.com/eclipse-zenoh/zenoh/commit/2687c51352121f006e3a603ce07925a8ad0b295c
+  # If Rust version below Zenoh MSRV (currently 1.88), use equivalent commit from branch
+  # ROS/rust-1.75-zenoh-2687c5135 with the same zenoh deadlock fix pin.
   if(CARGO_VERSION VERSION_GREATER_EQUAL "1.75" AND CARGO_VERSION VERSION_LESS "1.88")
-    set(zenoh_c_commit b31348fa7f94f44f1f7b049c111a710e970a2725)
+    set(zenoh_c_commit 84a82f6dc8da81f866bdd2ae126e4d4ce120e117)
   endif()
 
   ament_vendor(zenoh_c_vendor
-    VCS_URL https://github.com/eclipse-zenoh/zenoh-c.git
+    VCS_URL https://github.com/BOURBONCASK/zenoh-c.git
     VCS_VERSION ${zenoh_c_commit}
     CMAKE_ARGS
       "-DZENOHC_CARGO_FLAGS=${ZENOHC_CARGO_FLAGS}"
@@ -51,7 +51,7 @@ else()
   )
 
   ament_vendor(zenoh_cpp_vendor
-    VCS_URL https://github.com/eclipse-zenoh/zenoh-cpp
+    VCS_URL https://github.com/BOURBONCASK/zenoh-cpp
     VCS_VERSION af381b420cc8837ac7da42c9984594ef8f110e90
     CMAKE_ARGS
       -DZENOHCXX_ZENOHC=OFF

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -30,15 +30,15 @@ else()
 
   # Based on commit id from branch ROS/zenoh-2687c5135.
   # It corresponds to zenoh-c 1.8.0 plus few fixes, including removal of an error log at closure causing #951,
-  # with zenoh pinned to https://github.com/BOURBONCASK/zenoh/commit/8db2f3b7660238c0c6b40634c2554961d40f294a
+  # with zenoh pinned to https://github.com/BOURBONCASK/zenoh/commit/7f47053f537bc358c2aed600484fe978956f14a1
   # which is based on https://github.com/eclipse-zenoh/zenoh/commit/2687c51352121f006e3a603ce07925a8ad0b295c
-  # plus routing-lock deadlock fixes.
-  set(zenoh_c_commit 0443dc095cce080e0dedd357335b40770b5fd301)
+  # plus the declare-final deadlock fix.
+  set(zenoh_c_commit 814c924447f9f4df9656f08a127f3b86032482c0)
 
   # If Rust version below Zenoh MSRV (currently 1.88), use equivalent commit from branch
   # ROS/rust-1.75-zenoh-2687c5135 with the same zenoh deadlock fix pin.
   if(CARGO_VERSION VERSION_GREATER_EQUAL "1.75" AND CARGO_VERSION VERSION_LESS "1.88")
-    set(zenoh_c_commit c8cb1d7effbb12800dfb95dcceffcd17780e5de8)
+    set(zenoh_c_commit 3e3bdfc0623cbf1e1186938faa0487f98391d328)
   endif()
 
   ament_vendor(zenoh_c_vendor

--- a/zenoh_cpp_vendor/CMakeLists.txt
+++ b/zenoh_cpp_vendor/CMakeLists.txt
@@ -33,12 +33,12 @@ else()
   # with zenoh pinned to https://github.com/BOURBONCASK/zenoh/commit/7f47053f537bc358c2aed600484fe978956f14a1
   # which is based on https://github.com/eclipse-zenoh/zenoh/commit/2687c51352121f006e3a603ce07925a8ad0b295c
   # plus the declare-final deadlock fix.
-  set(zenoh_c_commit 43752173957a56deb6dcf5e7d14642869ee3c191)
+  set(zenoh_c_commit 814c924447f9f4df9656f08a127f3b86032482c0)
 
   # If Rust version below Zenoh MSRV (currently 1.88), use equivalent commit from branch
   # ROS/rust-1.75-zenoh-2687c5135 with the same zenoh deadlock fix pin.
   if(CARGO_VERSION VERSION_GREATER_EQUAL "1.75" AND CARGO_VERSION VERSION_LESS "1.88")
-    set(zenoh_c_commit 84a82f6dc8da81f866bdd2ae126e4d4ce120e117)
+    set(zenoh_c_commit 3e3bdfc0623cbf1e1186938faa0487f98391d328)
   endif()
 
   ament_vendor(zenoh_c_vendor


### PR DESCRIPTION
## Description

Avoid deadlocks caused by invoking event callbacks while holding internal mutexes.

This change moves callback execution out of `event_mutex_`, `events_mutex_`, and
`graph_mutex_` critical sections. Graph event callbacks are collected while the
graph is updated, enqueued in graph mutation order, and dispatched after internal
locks are released.

Key changes:
- Copy event callbacks and user data under `event_mutex_`, then invoke them after
  releasing the lock.
- Collect graph event callbacks under the existing lock order, enqueue them in a
  FIFO dispatch queue while `graph_mutex_` is still held, and drain the queue
  after releasing internal locks.
- Prevent recursive dispatch with a `dispatching_` flag.
- Catch and log exceptions from queued graph callbacks so one failing callback
  does not leave dispatch stuck or block later events.
- Use weak subscription data captures for graph event callbacks.

This follows the same general direction as #937 and #955: avoid holding internal
locks while invoking callbacks that may re-enter `rmw_zenoh`.

Fixes # (issue)

### Is this user-facing behavior change?

This should not change normal user-facing behavior. It is intended to prevent
deadlocks/hangs when graph or event callbacks are triggered concurrently.

### Did you use Generative AI?

Yes. ChatGPT/Codex/Claude/Copilot was used to help analyze the lock-order issue and draft parts
of the implementation.

### Additional Information

Validation performed:
- `git diff --check`
- `ament_uncrustify rmw_zenoh_cpp/src/detail/event.cpp rmw_zenoh_cpp/src/detail/graph_cache.cpp rmw_zenoh_cpp/src/detail/graph_cache.hpp rmw_zenoh_cpp/src/rmw_event.cpp`

A full `colcon build` could not be completed locally because the environment is
missing `cargo`; the build stops in `zenoh_cpp_vendor` before compiling
`rmw_zenoh_cpp`.