### PR TITLE
fix(ci): replace logging check with path-scoped diff scan

### DIFF
--- a/.github/workflows/check_logging.yaml
+++ b/.github/workflows/check_logging.yaml
@@ -1,13 +1,39 @@
-# Ensure that PR diff does not include RCUTILS_LOG_* macros as these induce deadlocks.
+# Ensure that a PR does not introduce rcutils logging macros, as these log over
+# /rosout and can deadlock rmw_zenoh under concurrent graph callbacks.
 # See https://github.com/ros2/rmw_zenoh/issues/182 for more details.
+#
+# Forbidden in added source lines:
+#   - the RCUTILS_LOG_<severity>[...] call macros (DEBUG/INFO/WARN/ERROR/FATAL),
+#   - the rcutils/logging_macros.h include, and
+#   - direct rcutils_log(...) calls.
+# Allowed: the RCUTILS_LOG_SEVERITY_* enum, which rmw_zenoh_cpp's own console-only
+# RMW_ZENOH_LOG_* wrappers are built on.
+#
+# The scan is restricted to C/C++ source files, so this workflow never inspects
+# its own definition and the forbidden patterns can live here without self-flagging.
 name: "Check logging macros"
 on: [pull_request]
 jobs:
   check_logging:
     runs-on: ubuntu-latest
     steps:
-    - name: Check logging macros
-      uses: JJ/github-pr-contains-action@releases/v14.1
+    - uses: actions/checkout@v4
       with:
-        github-token: ${{github.token}}
-        diffDoesNotContain: "RCUTILS_LOG_|rcutils/logging_macros.h"
+        fetch-depth: 0
+    - name: Check logging macros
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        added=$(git diff --unified=0 "$BASE_SHA" "$HEAD_SHA" -- \
+                  '*.c' '*.cpp' '*.cc' '*.h' '*.hpp' '*.hh' \
+                | grep -E '^\+' | grep -vE '^\+\+\+' || true)
+        hits=$(printf '%s\n' "$added" \
+                | grep -nE 'rcutils/logging_macros\.h|RCUTILS_LOG_(DEBUG|INFO|WARN|ERROR|FATAL)|[^A-Za-z_]rcutils_log[[:space:]]*\(' \
+                || true)
+        if [ -n "$hits" ]; then
+          echo "$hits"
+          echo "::error::Use rmw_zenoh_cpp's RMW_ZENOH_LOG_* wrappers, not rcutils logging (see issue #182)."
+          exit 1
+        fi
+        echo "OK: no forbidden rcutils logging macros introduced."


### PR DESCRIPTION
## Summary

The `check_logging` guard (added for #182, which forbids rcutils logging macros because they emit over `/rosout` and can deadlock rmw_zenoh) used `JJ/github-pr-contains-action` with the bare substring `RCUTILS_LOG_`. That had three problems:

1. **False positives.** `RCUTILS_LOG_` also matches `RCUTILS_LOG_SEVERITY_*` — the severity *enum* that `rmw_zenoh_cpp`'s own console-only `RMW_ZENOH_LOG_*` wrappers are built on. Any PR touching the logging layer (`detail/logging.hpp`, `detail/logging_macros.hpp`, `detail/logging.cpp`, `rmw_zenoh.cpp`) failed on benign references to the sanctioned alternative.
2. **Self-flagging.** The action scans the whole PR diff, including the workflow file, so editing the forbidden-string list trips the check on its own definition.
3. **A coverage gap.** Direct `rcutils_log(...)` calls — the lowercase function the macros expand to, with the same `/rosout` routing — were not caught at all.

This replaces the third-party action with an inline `git diff` scan restricted to C/C++ source files.

## Key Changes

- Scan only added lines in `*.c/*.cpp/*.cc/*.h/*.hpp/*.hh`.
- Forbid: the `RCUTILS_LOG_<severity>` call macros (`DEBUG/INFO/WARN/ERROR/FATAL`, covering every `_NAMED`/`_ONCE`/`_THROTTLE` variant as a prefix), the `rcutils/logging_macros.h` include, and direct `rcutils_log(` calls.
- Allow: the `RCUTILS_LOG_SEVERITY_*` enum and `rcutils_logging_*` helper calls.
- Because the scan is path-scoped to source files, the workflow never inspects its own definition — so the forbidden patterns can live in this file without self-flagging.

Verified locally against the current tree: the scan flags the `RCUTILS_LOG_*_NAMED` call sites and the include, flags a synthetic `rcutils_log(` call, and does not flag the `RCUTILS_LOG_SEVERITY_*` enum, `rcutils_logging_set_logger_level(`, or this PR's own (source-free) diff.

## Breaking Changes

None. CI-only change; no source or runtime behavior is affected.

## Did you use Generative AI?

Yes. Claude (claude-sonnet-4-6) via Claude Code was used to assist with creating an initial prototype version of the changes contained in this PR.
