### PR TITLE
fix(ci): migrate Ubuntu from noble to resolute

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,7 +27,7 @@ jobs:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos'
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.BUILD_TYPE == 'binary' && format('ros:{0}-ros-base', matrix.ROS_DISTRO) || 'ubuntu:noble' }}
+      image: ${{ matrix.BUILD_TYPE == 'binary' && format('ros:{0}-ros-base', matrix.ROS_DISTRO) || 'ubuntu:resolute' }}
     steps:
     - uses: ros-tooling/setup-ros@v0.7
       if: ${{ matrix.BUILD_TYPE == 'source' }}

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 | Package | Status |
 | ------- | ------ |
-| rmw_zenoh_cpp | [![Build Status](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rmw_zenoh_cpp__ubuntu_noble_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rmw_zenoh_cpp__ubuntu_noble_amd64__binary/) |
-| zenoh_cpp_vendor | [![Build Status](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_cpp_vendor__ubuntu_noble_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_cpp_vendor__ubuntu_noble_amd64__binary/) |
-| zenoh_security_tools | [![Build Status](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_security_tools__ubuntu_noble_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_security_tools__ubuntu_noble_amd64__binary/) |
+| rmw_zenoh_cpp | [![Build Status](https://build.ros2.org/view/Rbin_uR64/job/Rbin_uR64__rmw_zenoh_cpp__ubuntu_resolute_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uR64/job/Rbin_uR64__rmw_zenoh_cpp__ubuntu_resolute_amd64__binary/) |
+| zenoh_cpp_vendor | [![Build Status](https://build.ros2.org/view/Rbin_uR64/job/Rbin_uR64__zenoh_cpp_vendor__ubuntu_resolute_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uR64/job/Rbin_uR64__zenoh_cpp_vendor__ubuntu_resolute_amd64__binary/) |
+| zenoh_security_tools | [![Build Status](https://build.ros2.org/view/Rbin_uR64/job/Rbin_uR64__zenoh_security_tools__ubuntu_resolute_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uR64/job/Rbin_uR64__zenoh_security_tools__ubuntu_resolute_amd64__binary/) |
 
 A ROS 2 RMW implementation based on Zenoh that is written using the zenoh-cpp bindings.
 


### PR DESCRIPTION
## Description

Migrate the Github action from Ubuntu noble to Ubuntu Resolute.
Also in README.md, fix the badges' URLs to the new runners on Resolute at build.ros2.org .

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No