### PR TITLE
Update CI for kilted branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: build
 on:
   pull_request:
   push:
-    branches: [ rolling ]
+    branches: [ kilted ]
   workflow_dispatch:
   schedule:
     # Run every morning to detect flakiness and broken dependencies
@@ -17,11 +17,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Rolling (source)
-          - ROS_DISTRO: rolling
-            BUILD_TYPE: source
-          # Rolling (binary)
-          - ROS_DISTRO: rolling
+          # Kilted (binary)
+          - ROS_DISTRO: kilted
             BUILD_TYPE: binary
     env:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos'

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -2,7 +2,7 @@ name: style
 on:
   pull_request:
   push:
-    branches: [ rolling ]
+    branches: [ kilted ]
 defaults:
   run:
     shell: bash
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ['rolling']
+        distro: ['kilted']
     container:
       image: ros:${{ matrix.distro }}-ros-base
     timeout-minutes: 30


### PR DESCRIPTION
## Description

When `kilted` branch was created, the Github actions were not updated to target the `kilted` branch and distro.
This is the fix.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No