### PR TITLE
Update CI for lyrical branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: build
 on:
   pull_request:
   push:
-    branches: [ rolling ]
+    branches: [ lyrical ]
   workflow_dispatch:
   schedule:
     # Run every morning to detect flakiness and broken dependencies
@@ -17,17 +17,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Rolling (source)
-          - ROS_DISTRO: rolling
-            BUILD_TYPE: source
-          # Rolling (binary)
-          - ROS_DISTRO: rolling
+          # Lyrical (binary)
+          - ROS_DISTRO: lyrical
             BUILD_TYPE: binary
     env:
       ROS2_REPOS_FILE_URL: 'https://raw.githubusercontent.com/ros2/ros2/${{ matrix.ROS_DISTRO }}/ros2.repos'
     runs-on: ubuntu-latest
     container:
-      image: ${{ matrix.BUILD_TYPE == 'binary' && format('ros:{0}-ros-base', matrix.ROS_DISTRO) || 'ubuntu:noble' }}
+      image: ${{ matrix.BUILD_TYPE == 'binary' && format('ros:{0}-ros-base', matrix.ROS_DISTRO) || 'ubuntu:resolute' }}
     steps:
     - uses: ros-tooling/setup-ros@v0.7
       if: ${{ matrix.BUILD_TYPE == 'source' }}

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -2,7 +2,7 @@ name: style
 on:
   pull_request:
   push:
-    branches: [ rolling ]
+    branches: [ lyrical ]
 defaults:
   run:
     shell: bash
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: ['rolling']
+        distro: ['lyrical']
     container:
       image: ros:${{ matrix.distro }}-ros-base
     timeout-minutes: 30

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 
 | Package | Status |
 | ------- | ------ |
-| rmw_zenoh_cpp | [![Build Status](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rmw_zenoh_cpp__ubuntu_noble_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__rmw_zenoh_cpp__ubuntu_noble_amd64__binary/) |
-| zenoh_cpp_vendor | [![Build Status](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_cpp_vendor__ubuntu_noble_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_cpp_vendor__ubuntu_noble_amd64__binary/) |
-| zenoh_security_tools | [![Build Status](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_security_tools__ubuntu_noble_amd64__binary/badge/icon)](https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__zenoh_security_tools__ubuntu_noble_amd64__binary/) |
+| rmw_zenoh_cpp | [![Build Status](https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__rmw_zenoh_cpp__ubuntu_resolute_amd64__binary/badge/icon)](https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__rmw_zenoh_cpp__ubuntu_resolute_amd64__binary/) |
+| zenoh_cpp_vendor | [![Build Status](https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__zenoh_cpp_vendor__ubuntu_resolute_amd64__binary/badge/icon)](https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__zenoh_cpp_vendor__ubuntu_resolute_amd64__binary/) |
+| zenoh_security_tools | [![Build Status](https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__zenoh_security_tools__ubuntu_resolute_amd64__binary/badge/icon)](https://build.ros2.org/view/Lbin_uR64/job/Lbin_uR64__zenoh_security_tools__ubuntu_resolute_amd64__binary/) |
 
 A ROS 2 RMW implementation based on Zenoh that is written using the zenoh-cpp bindings.
 


### PR DESCRIPTION
## Description

Update Github actions to target the `lyrical` branch and distro.
Also in README.md, update the badges' URLs to the new runners for Lyrical at build.ros2.org .


### Is this user-facing behavior change?

No

### Did you use Generative AI?

No