### PR TITLE
Expose rosidl buffer backend metadata in rmw_zenoh graph endpoint info

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -27,8 +27,11 @@
 #include "rcpputils/find_and_replace.hpp"
 #include "rcpputils/scope_exit.hpp"
 
+#include "rcutils/error_handling.h"
 #include "rcutils/strdup.h"
+#include "rcutils/types/string_map.h"
 
+#include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
 #include "rmw/sanity_checks.h"
 #include "rmw/validate_namespace.h"
@@ -1161,6 +1164,48 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
         ret = rmw_topic_endpoint_info_set_qos_profile(&ep, &topic_data->info_.qos_);
         if (RMW_RET_OK != ret) {
           return ret;
+        }
+
+        auto entity_topic_info = entity->topic_info();
+        if (entity_topic_info.has_value() &&
+          entity_topic_info->backend_metadata_.has_value() &&
+          !entity_topic_info->backend_metadata_->empty())
+        {
+          rcutils_string_map_t buffer_backend_metadata =
+            rcutils_get_zero_initialized_string_map();
+          rcutils_ret_t rc_ret = rcutils_string_map_init(
+            &buffer_backend_metadata,
+            entity_topic_info->backend_metadata_->size(),
+            *allocator);
+          if (RCUTILS_RET_OK != rc_ret) {
+            RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
+            rcutils_reset_error();
+            return rmw_convert_rcutils_ret_to_rmw_ret(rc_ret);
+          }
+
+          for (const auto & backend_pair : entity_topic_info->backend_metadata_.value()) {
+            rc_ret = rcutils_string_map_set(
+              &buffer_backend_metadata,
+              backend_pair.first.c_str(),
+              backend_pair.second.c_str());
+            if (RCUTILS_RET_OK != rc_ret) {
+              rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
+              (void)fini_ret;
+              RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
+              rcutils_reset_error();
+              return rmw_convert_rcutils_ret_to_rmw_ret(rc_ret);
+            }
+          }
+
+          ret = rmw_topic_endpoint_info_set_buffer_backend_metadata(
+            &ep,
+            &buffer_backend_metadata,
+            allocator);
+          rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
+          (void)fini_ret;
+          if (RMW_RET_OK != ret) {
+            return ret;
+          }
         }
 
         rosidl_type_hash_t type_hash;

--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -29,10 +29,9 @@
 
 #include "rcutils/error_handling.h"
 #include "rcutils/strdup.h"
-#include "rcutils/types/string_map.h"
 
-#include "rmw/convert_rcutils_ret_to_rmw_ret.h"
 #include "rmw/error_handling.h"
+#include "rmw/impl/cpp/buffer_backend_metadata.hpp"
 #include "rmw/sanity_checks.h"
 #include "rmw/validate_namespace.h"
 #include "rmw/validate_node_name.h"
@@ -1171,40 +1170,17 @@ rmw_ret_t GraphCache::get_entities_info_by_topic(
           entity_topic_info->backend_metadata_.has_value() &&
           !entity_topic_info->backend_metadata_->empty())
         {
-          rcutils_string_map_t buffer_backend_metadata =
-            rcutils_get_zero_initialized_string_map();
-          rcutils_ret_t rc_ret = rcutils_string_map_init(
-            &buffer_backend_metadata,
-            entity_topic_info->backend_metadata_->size(),
-            *allocator);
-          if (RCUTILS_RET_OK != rc_ret) {
-            RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
-            rcutils_reset_error();
-            return rmw_convert_rcutils_ret_to_rmw_ret(rc_ret);
-          }
-
-          for (const auto & backend_pair : entity_topic_info->backend_metadata_.value()) {
-            rc_ret = rcutils_string_map_set(
-              &buffer_backend_metadata,
-              backend_pair.first.c_str(),
-              backend_pair.second.c_str());
-            if (RCUTILS_RET_OK != rc_ret) {
-              rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
-              (void)fini_ret;
-              RMW_SET_ERROR_MSG(rcutils_get_error_string().str);
-              rcutils_reset_error();
-              return rmw_convert_rcutils_ret_to_rmw_ret(rc_ret);
+          const std::string buffer_backend_metadata =
+            rmw::impl::cpp::serialize_buffer_backend_metadata(
+              entity_topic_info->backend_metadata_.value());
+          if (!buffer_backend_metadata.empty()) {
+            ret = rmw_topic_endpoint_info_set_buffer_backend_metadata(
+              &ep,
+              buffer_backend_metadata.c_str(),
+              allocator);
+            if (RMW_RET_OK != ret) {
+              return ret;
             }
-          }
-
-          ret = rmw_topic_endpoint_info_set_buffer_backend_metadata(
-            &ep,
-            &buffer_backend_metadata,
-            allocator);
-          rcutils_ret_t fini_ret = rcutils_string_map_fini(&buffer_backend_metadata);
-          (void)fini_ret;
-          if (RMW_RET_OK != ret) {
-            return ret;
           }
         }
 


### PR DESCRIPTION
## Description

Expose buffer backend support metadata through `rmw_zenoh_cpp` topic endpoint graph info.

`rmw_zenoh_cpp` already advertises and parses buffer backend metadata through liveliness tokens. This change carries that parsed metadata into `rmw_topic_endpoint_info_t` when handling publisher/subscription endpoint graph queries, allowing higher-level graph APIs and `ros2 topic info -v` to report backend support for Zenoh endpoints.

### Is this user-facing behavior change?

Yes. Users can inspect Zenoh publisher/subscription endpoint backend support through graph introspection, including `ros2 topic info <topic> -v`, once the corresponding `rmw`, `rclpy`, and CLI endpoint-info support is present.

### Did you use Generative AI?

Yes. GPT-5.5 in Cursor was used to help draft changes in this pull request.

### Additional Information

Depending on:
- https://github.com/ros2/rmw/pull/419