### PR TITLE
fix: keep pub_ valid for simple publishers (debug nightly crash)

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -153,53 +153,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
     return nullptr;
   }
 
-  using AdvancedPublisherOptions = zenoh::ext::SessionExt::AdvancedPublisherOptions;
-  using SampleMissDetectionOptions = AdvancedPublisherOptions::SampleMissDetectionOptions;
-  auto adv_pub_opts = AdvancedPublisherOptions::create_default();
-
-  if (adapted_qos_profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
-    // Allow this publisher to be detected through liveliness.
-    adv_pub_opts.publisher_detection = true;
-    adv_pub_opts.cache = AdvancedPublisherOptions::CacheOptions::create_default();
-    adv_pub_opts.cache->max_samples = adapted_qos_profile.depth;
-    if (adapted_qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
-      // If RELIABLE + TRANSIENT_LOCAL activate sample miss detection for subscriber
-      // to detect missed samples and retrieve those from the Publisher cache.
-      // HeartbeatSporadic is used to prevent excessive background traffic
-      adv_pub_opts.sample_miss_detection = SampleMissDetectionOptions{};
-      adv_pub_opts.sample_miss_detection->heartbeat =
-        SampleMissDetectionOptions::HeartbeatSporadic{
-        SAMPLE_MISS_DETECTION_HEARTBEAT_PERIOD};
-    }
-  }
-
-  zenoh::KeyExpr pub_ke(entity->topic_info()->topic_keyexpr_);
-  // Set congestion_control to BLOCK if appropriate.
-  auto pub_opts = zenoh::Session::PublisherOptions::create_default();
-  pub_opts.congestion_control = Z_CONGESTION_CONTROL_DROP;
-  if (adapted_qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
-    pub_opts.reliability = Z_RELIABILITY_RELIABLE;
-    if (adapted_qos_profile.history == RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
-      pub_opts.congestion_control = Z_CONGESTION_CONTROL_BLOCK;
-    }
-  } else {
-    pub_opts.reliability = Z_RELIABILITY_BEST_EFFORT;
-  }
-  adv_pub_opts.publisher_options = pub_opts;
-
   zenoh::ZResult result;
-  auto adv_pub = session->ext().declare_advanced_publisher(
-    pub_ke, std::move(adv_pub_opts), &result);
-  if (result != Z_OK) {
-    RMW_SET_ERROR_MSG("unable to create zenoh publisher cache");
-    return nullptr;
-  }
-
-  if (result != Z_OK) {
-    RMW_SET_ERROR_MSG("Unable to create Zenoh publisher.");
-    return nullptr;
-  }
-
   std::string liveliness_keyexpr = entity->liveliness_keyexpr();
   auto token = session->liveliness_declare_token(
     zenoh::KeyExpr(liveliness_keyexpr),
@@ -218,13 +172,23 @@ std::shared_ptr<PublisherData> PublisherData::make(
       node,
       std::move(entity),
       std::move(session),
-      std::move(adv_pub),
       std::move(token),
       type_support->data,
       std::move(message_type_support),
       has_buffer_fields,
       backend_metadata
     });
+
+  // Create the base publisher through the same path as every endpoint,
+  // stored in endpoints_ under the topic key expression.
+  const std::string base_key = pub_data->entity_->topic_info()->topic_keyexpr_;
+  auto base_endpoint = pub_data->create_publisher_endpoint(base_key, /*buffer_aware=*/false);
+  if (!base_endpoint) {
+    RMW_SET_ERROR_MSG("Unable to create Zenoh publisher.");
+    return nullptr;
+  }
+  pub_data->base_endpoint_ = base_endpoint.get();
+  pub_data->endpoints_[base_key] = std::move(base_endpoint);
 
   if (has_buffer_fields) {
     pub_data->local_endpoint_info_ =
@@ -282,7 +246,6 @@ PublisherData::PublisherData(
   const rmw_node_t * rmw_node,
   std::shared_ptr<liveliness::Entity> entity,
   std::shared_ptr<zenoh::Session> sess,
-  zenoh::ext::AdvancedPublisher pub,
   zenoh::LivelinessToken token,
   const void * type_support_impl,
   std::unique_ptr<MessageTypeSupport> type_support,
@@ -292,7 +255,6 @@ PublisherData::PublisherData(
   rmw_node_(rmw_node),
   entity_(std::move(entity)),
   sess_(std::move(sess)),
-  pub_(std::move(pub)),
   token_(std::move(token)),
   type_support_impl_(type_support_impl),
   type_support_(std::move(type_support)),
@@ -302,15 +264,6 @@ PublisherData::PublisherData(
   backend_metadata_(std::move(backend_metadata))
 {
   events_mgr_ = std::make_shared<EventsManager>();
-
-  // For simple publishers, create a single base endpoint
-  if (!is_buffer_aware_) {
-    auto base_endpoint = std::make_shared<PublisherEndpoint>();
-    base_endpoint->key = entity_->topic_info()->topic_keyexpr_;
-    base_endpoint->pub = std::optional<zenoh::ext::AdvancedPublisher>(std::move(pub_));
-    endpoints_[base_endpoint->key] = base_endpoint;
-  }
-  // For buffer-aware publishers, endpoints are created dynamically on subscriber discovery
 }
 
 ///=============================================================================
@@ -666,7 +619,7 @@ rmw_ret_t PublisherData::publish(
 
   TRACETOOLS_TRACEPOINT(
     rmw_publish, static_cast<const void *>(rmw_publisher_), ros_message, source_timestamp);
-  pub_.put(std::move(payload), std::move(opts), &result);
+  base_endpoint_->pub.value().put(std::move(payload), std::move(opts), &result);
   if (result != Z_OK) {
     if (result == Z_ESESSION_CLOSED) {
       RMW_ZENOH_LOG_WARN_NAMED(
@@ -740,7 +693,7 @@ rmw_ret_t PublisherData::publish_serialized_message(
       rmw_publish, static_cast<const void *>(rmw_publisher_), serialized_message,
       source_timestamp);
 
-    pub_.put(std::move(payload), std::move(opts), &result);
+    base_endpoint_->pub.value().put(std::move(payload), std::move(opts), &result);
   } else {
     std::vector<uint8_t> raw_image(
       serialized_message->buffer,
@@ -751,7 +704,7 @@ rmw_ret_t PublisherData::publish_serialized_message(
       rmw_publish, static_cast<const void *>(rmw_publisher_), serialized_message,
         source_timestamp);
 
-    pub_.put(std::move(payload), std::move(opts), &result);
+    base_endpoint_->pub.value().put(std::move(payload), std::move(opts), &result);
   }
 
   if (result != Z_OK) {
@@ -955,7 +908,7 @@ std::shared_ptr<PublisherData::PublisherEndpoint> PublisherData::get_or_create_e
 
 ///=============================================================================
 std::shared_ptr<PublisherData::PublisherEndpoint> PublisherData::create_publisher_endpoint(
-  const std::string & full_key)
+  const std::string & full_key, bool buffer_aware)
 {
   auto endpoint = std::make_shared<PublisherEndpoint>();
   endpoint->key = full_key;
@@ -965,12 +918,25 @@ std::shared_ptr<PublisherData::PublisherEndpoint> PublisherData::create_publishe
   auto qos_profile = entity_->topic_info()->qos_;
 
   using AdvancedPublisherOptions = zenoh::ext::SessionExt::AdvancedPublisherOptions;
+  using SampleMissDetectionOptions = AdvancedPublisherOptions::SampleMissDetectionOptions;
   auto adv_pub_opts = AdvancedPublisherOptions::create_default();
 
   if (qos_profile.durability == RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) {
+    // Allow this publisher to be detected through liveliness.
     adv_pub_opts.publisher_detection = true;
     adv_pub_opts.cache = AdvancedPublisherOptions::CacheOptions::create_default();
     adv_pub_opts.cache->max_samples = qos_profile.depth;
+    // Sample miss detection (heartbeat) is only used on the base
+    // publisher. If RELIABLE + TRANSIENT_LOCAL it lets subscribers detect missed
+    // samples and retrieve them from the Publisher cache; HeartbeatSporadic keeps
+    // background traffic low. Per-subscriber buffer-aware endpoints are
+    // point-to-point and do not need it.
+    if (!buffer_aware && qos_profile.reliability == RMW_QOS_POLICY_RELIABILITY_RELIABLE) {
+      adv_pub_opts.sample_miss_detection = SampleMissDetectionOptions{};
+      adv_pub_opts.sample_miss_detection->heartbeat =
+        SampleMissDetectionOptions::HeartbeatSporadic{
+        SAMPLE_MISS_DETECTION_HEARTBEAT_PERIOD};
+    }
   }
 
   auto pub_opts = zenoh::Session::PublisherOptions::create_default();
@@ -992,7 +958,7 @@ std::shared_ptr<PublisherData::PublisherEndpoint> PublisherData::create_publishe
   if (result != Z_OK) {
     RMW_ZENOH_ROSIDL_BUFFER_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
-      "Failed to create dynamic endpoint for key: %s", full_key.c_str());
+      "Failed to create publisher endpoint for key: %s", full_key.c_str());
     return nullptr;
   }
 
@@ -1017,53 +983,36 @@ PublisherData::~PublisherData()
 rmw_ret_t PublisherData::shutdown()
 {
   std::unordered_map<std::string, std::shared_ptr<PublisherEndpoint>> endpoints_to_destroy;
-  bool was_buffer_aware = false;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     if (is_shutdown_) {
       return RMW_RET_OK;
     }
     is_shutdown_ = true;
-    was_buffer_aware = is_buffer_aware_;
-    if (was_buffer_aware) {
-      endpoints_to_destroy = std::move(endpoints_);
-      endpoints_.clear();
-    }
+    base_endpoint_ = nullptr;
+    endpoints_to_destroy = std::move(endpoints_);
+    endpoints_.clear();
   }
 
-  if (was_buffer_aware) {
-    zenoh::ZResult result;
-    for (auto & [key, endpoint] : endpoints_to_destroy) {
-      if (endpoint->pub.has_value()) {
-        std::move(endpoint->pub.value()).undeclare(&result);
-        if (result != Z_OK) {
-          RMW_ZENOH_ROSIDL_BUFFER_LOG_ERROR_NAMED(
-            "rmw_zenoh_cpp",
+  zenoh::ZResult result;
+  // Undeclare every publisher endpoint: the base publisher plus any
+  // buffer-aware endpoints.
+  for (auto & [key, endpoint] : endpoints_to_destroy) {
+    if (endpoint->pub.has_value()) {
+      std::move(endpoint->pub.value()).undeclare(&result);
+      if (result != Z_OK) {
+        RMW_ZENOH_ROSIDL_BUFFER_LOG_ERROR_NAMED(
+          "rmw_zenoh_cpp",
           "Failed to undeclare endpoint with key '%s'", key.c_str());
-        }
       }
     }
   }
 
-  zenoh::ZResult result;
   std::move(token_).value().undeclare(&result);
   if (result != Z_OK) {
     RMW_ZENOH_LOG_ERROR_NAMED(
       "rmw_zenoh_cpp",
       "Unable to undeclare the liveliness token for topic '%s'",
-      entity_->topic_info().value().name_.c_str());
-    return RMW_RET_ERROR;
-  }
-
-  // For buffer-aware publishers, pub_ is the base publisher used for
-  // fallback/standard serialization and was never moved.
-  // For non-buffer-aware publishers, pub_ was moved into the base endpoint
-  // but still needs to be undeclared.
-  std::move(pub_).undeclare(&result);
-  if (result != Z_OK) {
-    RMW_ZENOH_ROSIDL_BUFFER_LOG_ERROR_NAMED(
-      "rmw_zenoh_cpp",
-      "Unable to undeclare the publisher for topic '%s'",
       entity_->topic_info().value().name_.c_str());
     return RMW_RET_ERROR;
   }

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.hpp
@@ -121,7 +121,6 @@ private:
     const rmw_node_t * rmw_node,
     std::shared_ptr<liveliness::Entity> entity,
     std::shared_ptr<zenoh::Session> session,
-    zenoh::ext::AdvancedPublisher pub,
     zenoh::LivelinessToken token,
     const void * type_support_impl,
     std::unique_ptr<MessageTypeSupport> type_support,
@@ -135,9 +134,11 @@ private:
   std::shared_ptr<PublisherEndpoint> get_or_create_endpoint(
     const std::string & full_key);
 
-  // Create a Zenoh publisher endpoint (does not require mutex_)
+  // Create a Zenoh publisher endpoint (does not require mutex_).
+  // buffer_aware=false builds the base publisher (with sample-miss
+  // detection); buffer_aware=true builds a per-subscriber buffer-aware endpoint.
   std::shared_ptr<PublisherEndpoint> create_publisher_endpoint(
-    const std::string & full_key);
+    const std::string & full_key, bool buffer_aware = true);
 
   // Buffer-aware publish helper
   rmw_ret_t publish_buffer_aware(
@@ -154,8 +155,10 @@ private:
   std::shared_ptr<liveliness::Entity> entity_;
   // A shared session.
   std::shared_ptr<zenoh::Session> sess_;
-  // An owned AdvancedPublisher (for simple publishers, this is the only one).
-  zenoh::ext::AdvancedPublisher pub_;
+  // Non-owning cache of the base publisher, which is stored in endpoints_
+  // under the topic key expression. Lets publish() reach it without a per-message
+  // map lookup. Owned by endpoints_; cleared on shutdown.
+  PublisherEndpoint * base_endpoint_{nullptr};
   // Liveliness token for the publisher.
   std::optional<zenoh::LivelinessToken> token_;
   // Type support fields
@@ -169,8 +172,8 @@ private:
   // Buffer-aware publisher fields
   bool is_buffer_aware_;
   std::unordered_map<std::string, std::string> backend_metadata_;
-  // For simple publishers: endpoints_ contains only base endpoint
-  // For buffer-aware: multiple endpoints based on discovered subscribers
+  // All publisher endpoints keyed by full key: the base publisher under the
+  // topic key expression, plus buffer-aware endpoints added on subscriber discovery.
   std::unordered_map<std::string, std::shared_ptr<PublisherEndpoint>> endpoints_;
   std::set<std::string> pending_endpoints_;
   std::vector<SubscriberInfo> discovered_subscribers_;


### PR DESCRIPTION
Closes #989.

## Summary

Fix a null advanced-publisher dereference that makes every `rmw_zenoh_cpp` pub/sub test fail in the `nightly_linux_debug` job (e.g. [nightly_linux_debug #3865](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/3865/) — 265 failures, all the same panic).

In debug builds every publish aborts with:

```
thread '<unnamed>' panicked at zenoh_c_vendor/src/advanced_publisher.rs:297:10:
unsafe precondition(s) violated: hint::unreachable_unchecked must never be reached
thread caused non-unwinding panic. aborting.
```

In release builds the same path is undefined behaviour (the check is compiled out), which is why only the debug nightly surfaces it.

## Root cause

The per-endpoint refactor (#930) added a base endpoint for simple (non-buffer-aware) publishers. The `PublisherData` constructor initialises `pub_` from its argument and then, for simple publishers, **moves `pub_` into `base_endpoint->pub`**:

```cpp
pub_(std::move(pub)),
...
base_endpoint->pub = std::optional<zenoh::ext::AdvancedPublisher>(std::move(pub_));
```

After the move, `pub_` is in a moved-from (null) state. But `publish()`, `publish_serialized_message()` and `shutdown()` all still operate on `pub_`, so the first `pub_.put()` calls `ze_advanced_publisher_loan_mut()` on a null owned publisher, hitting `unwrap_unchecked()` on `None`.

## Approach

Rather than just remove the stray move, this unifies how a publisher is represented. The deeper problem is that ownership lived in two divergent places — `PublisherData::pub_` and `endpoints_->pub` — with parallel creation and publish/shutdown paths that can drift out of sync (which is exactly how the bug arose). Patching the move fixes this instance but leaves the same trap for the next change. Collapsing to a single representation makes the inconsistent state unrepresentable, which is the better long-term-maintenance outcome (per review discussion).

## Key Changes

- Remove the `PublisherData::pub_` member. The standard/base publisher now lives in `base_endpoint_` (a `PublisherEndpoint`), like every other endpoint.
- `create_publisher_endpoint(full_key, bool buffer_aware)` is now the single place that declares an `AdvancedPublisher`: `buffer_aware=false` builds the base publisher (keeping the sample-miss-detection heartbeat), `buffer_aware=true` builds per-subscriber buffer-aware endpoints.
- `make()` creates the base publisher through `create_publisher_endpoint()` after construction instead of declaring it inline and passing it to the constructor.
- `publish()` / `publish_serialized_message()` publish through `base_endpoint_`; `shutdown()` undeclares `base_endpoint_` and every buffer-aware endpoint uniformly.

## Verification

Built the rolling stack in Debug (so zenoh-c carries `debug_assertions`) and ran the previously-failing tests against the patched RMW:

- Minimal repro (create one publisher and publish a message): no panic, clean exit.
- `test_communication`: 0 failures (17/17 message-type pub/sub, plus the launch-based requester/replier/action tests).
- `demo_nodes_cpp` / `logging_demo` / `image_tools` / `pendulum_control`: 16/16 pass, covering all the demo/tutorial/pendulum failures from #3865.

## Breaking Changes

None.

## Did you use Generative AI?

Yes. Claude (claude-opus-4-8) via Claude Code was used to assist with creating an initial prototype version of the changes contained in this PR.
