### PR TITLE
Fix deadlock between wait_set condition_mutex and entity-specific mutexes

### DIFF
--- a/rmw_zenoh_cpp/src/detail/guard_condition.cpp
+++ b/rmw_zenoh_cpp/src/detail/guard_condition.cpp
@@ -30,17 +30,21 @@ GuardCondition::GuardCondition()
 ///=============================================================================
 void GuardCondition::trigger()
 {
-  std::lock_guard<std::mutex> lock(internal_mutex_);
+  rmw_wait_set_data_t * wait_set_data_to_trigger = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(internal_mutex_);
 
-  // the change to hasTriggered_ needs to be mutually exclusive with
-  // rmw_wait() which checks hasTriggered() and decides if wait() needs to
-  // be called
-  has_triggered_ = true;
+    // the change to hasTriggered_ needs to be mutually exclusive with
+    // rmw_wait() which checks hasTriggered() and decides if wait() needs to
+    // be called
+    has_triggered_ = true;
+    wait_set_data_to_trigger = wait_set_data_;
+  }
 
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+  if (wait_set_data_to_trigger != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_to_trigger->condition_mutex);
+    wait_set_data_to_trigger->triggered = true;
+    wait_set_data_to_trigger->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_client_data.cpp
@@ -231,29 +231,34 @@ std::array<uint8_t, RMW_GID_STORAGE_SIZE> ClientData::copy_gid() const
 ///=============================================================================
 void ClientData::add_new_reply(std::unique_ptr<ZenohReply> reply)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  const rmw_qos_profile_t adapted_qos_profile =
-    entity_->topic_info().value().qos_;
-  if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
-    reply_queue_.size() >= adapted_qos_profile.depth)
+  rmw_wait_set_data_t * wait_set_data_to_trigger = nullptr;
   {
-    // Log warning if message is discarded due to hitting the queue depth
-    RMW_ZENOH_LOG_ERROR_NAMED(
-      "rmw_zenoh_cpp",
-      "Query queue depth of %ld reached, discarding oldest Query "
-      "for client for %s",
-      adapted_qos_profile.depth,
-      this->entity_->topic_info().value().topic_keyexpr_.c_str());
-    reply_queue_.pop_front();
-  }
-  reply_queue_.emplace_back(std::move(reply));
+    std::lock_guard<std::mutex> lock(mutex_);
+    const rmw_qos_profile_t adapted_qos_profile =
+      entity_->topic_info().value().qos_;
+    if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
+      reply_queue_.size() >= adapted_qos_profile.depth)
+    {
+      // Log warning if message is discarded due to hitting the queue depth
+      RMW_ZENOH_LOG_ERROR_NAMED(
+        "rmw_zenoh_cpp",
+        "Query queue depth of %ld reached, discarding oldest Query "
+        "for client for %s",
+        adapted_qos_profile.depth,
+        this->entity_->topic_info().value().topic_keyexpr_.c_str());
+      reply_queue_.pop_front();
+    }
+    reply_queue_.emplace_back(std::move(reply));
 
-  // Since we added new data, trigger user callback and guard condition if they are available
-  data_callback_mgr_.trigger_callback();
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+    // Since we added new data, trigger user callback and guard condition if they are available
+    data_callback_mgr_.trigger_callback();
+    wait_set_data_to_trigger = wait_set_data_;
+  }
+
+  if (wait_set_data_to_trigger != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_to_trigger->condition_mutex);
+    wait_set_data_to_trigger->triggered = true;
+    wait_set_data_to_trigger->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_service_data.cpp
@@ -237,36 +237,41 @@ bool ServiceData::liveliness_is_valid() const
 ///=============================================================================
 void ServiceData::add_new_query(std::unique_ptr<ZenohQuery> query)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (is_shutdown_.load(std::memory_order_acquire)) {
-    RMW_ZENOH_LOG_DEBUG_NAMED(
-      "rmw_zenoh_cpp",
-      "Request from client will be ignored since the service is shutdown."
-    );
-    return;
-  }
-  const rmw_qos_profile_t adapted_qos_profile =
-    entity_->topic_info().value().qos_;
-  if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
-    query_queue_.size() >= adapted_qos_profile.depth)
+  rmw_wait_set_data_t * wait_set_data_to_trigger = nullptr;
   {
-    // Log warning if message is discarded due to hitting the queue depth
-    RMW_ZENOH_LOG_ERROR_NAMED(
-      "rmw_zenoh_cpp",
-      "Query queue depth of %ld reached, discarding oldest Query "
-      "for service '%s'",
-      adapted_qos_profile.depth,
-      entity_->topic_info().value().name_.c_str());
-    query_queue_.pop_front();
-  }
-  query_queue_.emplace_back(std::move(query));
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (is_shutdown_.load(std::memory_order_acquire)) {
+      RMW_ZENOH_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "Request from client will be ignored since the service is shutdown."
+      );
+      return;
+    }
+    const rmw_qos_profile_t adapted_qos_profile =
+      entity_->topic_info().value().qos_;
+    if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
+      query_queue_.size() >= adapted_qos_profile.depth)
+    {
+      // Log warning if message is discarded due to hitting the queue depth
+      RMW_ZENOH_LOG_ERROR_NAMED(
+        "rmw_zenoh_cpp",
+        "Query queue depth of %ld reached, discarding oldest Query "
+        "for service '%s'",
+        adapted_qos_profile.depth,
+        entity_->topic_info().value().name_.c_str());
+      query_queue_.pop_front();
+    }
+    query_queue_.emplace_back(std::move(query));
 
-  // Since we added new data, trigger user callback and guard condition if they are available
-  data_callback_mgr_.trigger_callback();
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+    // Since we added new data, trigger user callback and guard condition if they are available
+    data_callback_mgr_.trigger_callback();
+    wait_set_data_to_trigger = wait_set_data_;
+  }
+
+  if (wait_set_data_to_trigger != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_to_trigger->condition_mutex);
+    wait_set_data_to_trigger->triggered = true;
+    wait_set_data_to_trigger->condition_variable.notify_one();
   }
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -1111,67 +1111,80 @@ void SubscriptionData::add_new_message(
   std::unique_ptr<SubscriptionData::Message> msg,
   const std::string & topic_name)
 {
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (is_shutdown_) {
-    return;
-  }
-  RMW_ZENOH_ROSIDL_BUFFER_LOG_DEBUG_NAMED(
-    "rmw_zenoh_cpp",
-    "[Subscription] add_new_message topic='%s' is_buffer_aware=%d payload_size=%zu",
-    topic_name.c_str(),
-    is_buffer_aware_,
-    msg->payload.size());
-  const rmw_qos_profile_t adapted_qos_profile = entity_->topic_info().value().qos_;
-  if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
-    message_queue_.size() >= adapted_qos_profile.depth)
+  rmw_wait_set_data_t * wait_set_data_to_trigger = nullptr;
+  bool message_lost = false;
+  int32_t num_msg_lost = 0;
+
   {
-    // Log warning if message is discarded due to hitting the queue depth
-    RMW_ZENOH_LOG_DEBUG_NAMED(
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (is_shutdown_) {
+      return;
+    }
+    RMW_ZENOH_ROSIDL_BUFFER_LOG_DEBUG_NAMED(
       "rmw_zenoh_cpp",
-      "Message queue depth of %ld reached, discarding oldest message "
-      "for subscription for %s",
-      adapted_qos_profile.depth,
-      topic_name.c_str());
+      "[Subscription] add_new_message topic='%s' is_buffer_aware=%d payload_size=%zu",
+      topic_name.c_str(),
+      is_buffer_aware_,
+      msg->payload.size());
+    const rmw_qos_profile_t adapted_qos_profile = entity_->topic_info().value().qos_;
+    if (adapted_qos_profile.history != RMW_QOS_POLICY_HISTORY_KEEP_ALL &&
+      message_queue_.size() >= adapted_qos_profile.depth)
+    {
+      // Log warning if message is discarded due to hitting the queue depth
+      RMW_ZENOH_LOG_DEBUG_NAMED(
+        "rmw_zenoh_cpp",
+        "Message queue depth of %ld reached, discarding oldest message "
+        "for subscription for %s",
+        adapted_qos_profile.depth,
+        topic_name.c_str());
 
-    // If the adapted_qos_profile.depth is 0, the std::move command below will result
-    // in UB and the z_drop will segfault. We explicitly set the depth to a minimum of 1
-    // in rmw_create_subscription() but to be safe, we only attempt to discard from the
-    // queue if it is non-empty.
-    if (!message_queue_.empty()) {
-      std::unique_ptr<Message> old = std::move(message_queue_.front());
-      message_queue_.pop_front();
+      // If the adapted_qos_profile.depth is 0, the std::move command below will result
+      // in UB and the z_drop will segfault. We explicitly set the depth to a minimum of 1
+      // in rmw_create_subscription() but to be safe, we only attempt to discard from the
+      // queue if it is non-empty.
+      if (!message_queue_.empty()) {
+        std::unique_ptr<Message> old = std::move(message_queue_.front());
+        message_queue_.pop_front();
+      }
     }
+
+    // Check for messages lost if the new sequence number is not monotonically increasing.
+    const size_t gid_hash = hash_gid(msg->attachment.copy_gid());
+    auto last_known_pub_it = last_known_published_msg_.find(gid_hash);
+    if (last_known_pub_it != last_known_published_msg_.end()) {
+      const int64_t seq_increment = std::abs(
+        msg->attachment.sequence_number() -
+        last_known_pub_it->second);
+      if (seq_increment > 1) {
+        num_msg_lost =
+          static_cast<int32_t>(std::clamp(
+            seq_increment - 1,
+            static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
+            static_cast<int64_t>(std::numeric_limits<int32_t>::max())));
+        message_lost = true;
+      }
+    }
+    // Always update the last known sequence number for the publisher.
+    last_known_published_msg_[gid_hash] = msg->attachment.sequence_number();
+
+    message_queue_.emplace_back(std::move(msg));
+
+    // Since we added new data, trigger user callback and guard condition if they are available
+    data_callback_mgr_.trigger_callback();
+    wait_set_data_to_trigger = wait_set_data_;
   }
 
-  // Check for messages lost if the new sequence number is not monotonically increasing.
-  const size_t gid_hash = hash_gid(msg->attachment.copy_gid());
-  auto last_known_pub_it = last_known_published_msg_.find(gid_hash);
-  if (last_known_pub_it != last_known_published_msg_.end()) {
-    const int64_t seq_increment = std::abs(
-      msg->attachment.sequence_number() -
-      last_known_pub_it->second);
-    if (seq_increment > 1) {
-      int32_t num_msg_lost =
-        static_cast<int32_t>(std::clamp(
-          seq_increment - 1,
-          static_cast<int64_t>(std::numeric_limits<int32_t>::min()),
-          static_cast<int64_t>(std::numeric_limits<int32_t>::max())));
-      events_mgr_->update_event_status(
-        ZENOH_EVENT_MESSAGE_LOST,
-        std::move(num_msg_lost));
-    }
+  // Trigger lost message event outside the subscription mutex to avoid deadlocks.
+  if (message_lost) {
+    events_mgr_->update_event_status(
+      ZENOH_EVENT_MESSAGE_LOST,
+      std::move(num_msg_lost));
   }
-  // Always update the last known sequence number for the publisher.
-  last_known_published_msg_[gid_hash] = msg->attachment.sequence_number();
 
-  message_queue_.emplace_back(std::move(msg));
-
-  // Since we added new data, trigger user callback and guard condition if they are available
-  data_callback_mgr_.trigger_callback();
-  if (wait_set_data_ != nullptr) {
-    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_->condition_mutex);
-    wait_set_data_->triggered = true;
-    wait_set_data_->condition_variable.notify_one();
+  if (wait_set_data_to_trigger != nullptr) {
+    std::lock_guard<std::mutex> wait_set_lock(wait_set_data_to_trigger->condition_mutex);
+    wait_set_data_to_trigger->triggered = true;
+    wait_set_data_to_trigger->condition_variable.notify_one();
   }
 }
 

--- a/test_rmw_zenoh_cpp/CMakeLists.txt
+++ b/test_rmw_zenoh_cpp/CMakeLists.txt
@@ -19,6 +19,7 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   find_package(ament_lint_common REQUIRED)
   find_package(rclcpp REQUIRED)
+  find_package(std_msgs REQUIRED)
   find_package(rmw_zenoh_cpp REQUIRED)
   find_package(zenoh_cpp_vendor REQUIRED)
 
@@ -31,6 +32,15 @@ if(BUILD_TESTING)
     rclcpp::rclcpp
     rmw_zenoh_cpp::rmw_zenoh_cpp
     zenohcxx::zenohc
+  )
+
+  ament_add_ros_isolated_gtest(test_issue_921
+    test/test_issue_921.cpp
+    ENV RMW_IMPLEMENTATION=rmw_zenoh_cpp)
+  target_link_libraries(test_issue_921
+    rclcpp::rclcpp
+    std_msgs::std_msgs
+    rmw_zenoh_cpp::rmw_zenoh_cpp
   )
 endif()
 

--- a/test_rmw_zenoh_cpp/package.xml
+++ b/test_rmw_zenoh_cpp/package.xml
@@ -14,6 +14,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rclcpp</test_depend>
+  <test_depend>std_msgs</test_depend>
   <test_depend>rmw_zenoh_cpp</test_depend>
   <test_depend>zenoh_cpp_vendor</test_depend>
 

--- a/test_rmw_zenoh_cpp/test/test_issue_921.cpp
+++ b/test_rmw_zenoh_cpp/test/test_issue_921.cpp
@@ -24,8 +24,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <std_msgs/msg/string.hpp>
 
-// This test references issue ticket number 921:
-// "potential deadlock between waitset condition_mutex and SubscriptionData mutex"
+// This test references issue ticket: https://github.com/ros2/rmw_zenoh/issues/921
 // It simulates heavy traffic by publishing messages concurrently with wait execution.
 class TestIssue921 : public ::testing::Test
 {
@@ -45,7 +44,7 @@ TEST_F(TestIssue921, TestDeadlockUnderHeavyTraffic)
 {
   auto node = std::make_shared<rclcpp::Node>("test_issue_921_node");
   auto publisher = node->create_publisher<std_msgs::msg::String>("test_issue_921_topic", 10);
-  
+
   std::atomic<size_t> received_count{0};
   auto subscription = node->create_subscription<std_msgs::msg::String>(
     "test_issue_921_topic", 10,
@@ -63,24 +62,24 @@ TEST_F(TestIssue921, TestDeadlockUnderHeavyTraffic)
   // Run the test in a thread so we can monitor for deadlocks with a watchdog
   std::thread test_thread([&]() {
     // Publisher thread that publishes messages as fast as possible
-    std::thread pub_thread([&]() {
-      std_msgs::msg::String msg;
-      msg.data = "hello";
-      for (size_t i = 0; i < 500 && running; ++i) {
-        publisher->publish(msg);
-        std::this_thread::sleep_for(std::chrono::microseconds(500));
-      }
-      running = false;
+      std::thread pub_thread([&]() {
+        std_msgs::msg::String msg;
+        msg.data = "hello";
+        for (size_t i = 0; i < 500 && running; ++i) {
+          publisher->publish(msg);
+          std::this_thread::sleep_for(std::chrono::microseconds(500));
+        }
+        running = false;
     });
 
     // Executor spin loop
-    while (running) {
-      executor.spin_some(std::chrono::milliseconds(5));
-    }
+      while (running) {
+        executor.spin_some(std::chrono::milliseconds(5));
+      }
 
-    pub_thread.join();
-    test_finished_promise.set_value();
-  });
+      pub_thread.join();
+      test_finished_promise.set_value();
+    });
 
   // Watchdog timeout (5 seconds)
   if (test_finished_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {

--- a/test_rmw_zenoh_cpp/test/test_issue_921.cpp
+++ b/test_rmw_zenoh_cpp/test/test_issue_921.cpp
@@ -1,0 +1,98 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cstdlib>
+#include <future>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/string.hpp>
+
+// This test references issue ticket number 921:
+// "potential deadlock between waitset condition_mutex and SubscriptionData mutex"
+// It simulates heavy traffic by publishing messages concurrently with wait execution.
+class TestIssue921 : public ::testing::Test
+{
+public:
+  static void SetUpTestCase()
+  {
+    rclcpp::init(0, nullptr);
+  }
+
+  static void TearDownTestCase()
+  {
+    rclcpp::shutdown();
+  }
+};
+
+TEST_F(TestIssue921, TestDeadlockUnderHeavyTraffic)
+{
+  auto node = std::make_shared<rclcpp::Node>("test_issue_921_node");
+  auto publisher = node->create_publisher<std_msgs::msg::String>("test_issue_921_topic", 10);
+  
+  std::atomic<size_t> received_count{0};
+  auto subscription = node->create_subscription<std_msgs::msg::String>(
+    "test_issue_921_topic", 10,
+    [&received_count](std_msgs::msg::String::ConstSharedPtr) {
+      received_count.fetch_add(1);
+    });
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  std::atomic<bool> running{true};
+  std::promise<void> test_finished_promise;
+  auto test_finished_future = test_finished_promise.get_future();
+
+  // Run the test in a thread so we can monitor for deadlocks with a watchdog
+  std::thread test_thread([&]() {
+    // Publisher thread that publishes messages as fast as possible
+    std::thread pub_thread([&]() {
+      std_msgs::msg::String msg;
+      msg.data = "hello";
+      for (size_t i = 0; i < 500 && running; ++i) {
+        publisher->publish(msg);
+        std::this_thread::sleep_for(std::chrono::microseconds(500));
+      }
+      running = false;
+    });
+
+    // Executor spin loop
+    while (running) {
+      executor.spin_some(std::chrono::milliseconds(5));
+    }
+
+    pub_thread.join();
+    test_finished_promise.set_value();
+  });
+
+  // Watchdog timeout (5 seconds)
+  if (test_finished_future.wait_for(std::chrono::seconds(5)) == std::future_status::timeout) {
+    running = false;
+    // We timed out! Fails the test due to deadlock
+    FAIL() << "Test timed out! Possible deadlock in rmw_zenoh_cpp (Issue #921).";
+    // We terminate to avoid hanging the process if threads are locked
+    std::terminate();
+  } else {
+    test_thread.join();
+  }
+
+  // Ensure we actually received some messages
+  EXPECT_GT(received_count.load(), 0u);
+}


### PR DESCRIPTION
## Description

Fix ABBA deadlock caused between the waitset's global condition_mutex and class-level internal mutexes in the RMW data structures. The fix follows the same pattern as what we have in [EventsManger](https://github.com/ros2/rmw_zenoh/blob/e95c62df287143f78bdb41c452b6bf1e257b0c0d/rmw_zenoh_cpp/src/detail/event.cpp#L255-L257) which was added as part of https://github.com/ros2/rmw_zenoh/pull/937.

Added a test case to validate fix.

```
colcon test --packages-select test_rmw_zenoh_cpp
```


<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes https://github.com/ros2/rmw_zenoh/issues/921

### Is this user-facing behavior change?
 No
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
Yes, Gemini 3
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
