### PR TITLE
Drop unnecessary mutex lock in `.event_mgr()`

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -800,7 +800,6 @@ bool PublisherData::liveliness_is_valid() const
 ///=============================================================================
 std::shared_ptr<EventsManager> PublisherData::events_mgr() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
   return events_mgr_;
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -525,7 +525,6 @@ bool SubscriptionData::liveliness_is_valid() const
 ///=============================================================================
 std::shared_ptr<EventsManager> SubscriptionData::events_mgr() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
   return events_mgr_;
 }
 

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -1186,7 +1186,6 @@ void SubscriptionData::set_on_new_message_callback(
 //==============================================================================
 std::shared_ptr<GraphCache> SubscriptionData::graph_cache() const
 {
-  std::lock_guard<std::mutex> lock(mutex_);
   return graph_cache_;
 }
 


### PR DESCRIPTION
## Description

Closes #991

### Is this user-facing behavior change?

### Did you use Generative AI?

No

### Additional Information

There are two occurrences of such pattern, where an internal `shared_ptr<EventsManager>` gets copied and returned to the caller. That smart pointer is initialized once in constructor and never re-assigned to point to a different instance. Hence, protecting its copy with the mutex is unnecessary.