### PR TITLE
publish-deny topic correctly denied

### DIFF
--- a/zenoh_security_tools/src/config_generator.cpp
+++ b/zenoh_security_tools/src/config_generator.cpp
@@ -552,7 +552,7 @@ void ConfigGenerator::parse_topics(
                 if (permission == "ALLOW") {
                   topics_pub_allow_.insert(check_name(topic_node->GetText(), node_name));
                 } else if (permission == "DENY") {
-                  topics_pub_allow_.insert(check_name(topic_node->GetText(), node_name));
+                  topics_pub_deny_.insert(check_name(topic_node->GetText(), node_name));
                 }
               } else if (topic_type == "subscribe") {
                 if (permission == "ALLOW") {


### PR DESCRIPTION
## Description

publish-deny topic are correctly denied rather than silently granted an allow rule.

By the way `topics_pub_deny_` is not used 

### Did you use Generative AI?

Opus Claude 4.7
