### PR TITLE
Fix transient-local publishing for buffer-aware path

### DIFF
--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -492,7 +492,11 @@ rmw_ret_t PublisherData::publish(
   //     channels entirely and fall through to the standard base-key publish.
   //     Buffer-aware subscribers also have a base-key subscription so they
   //     will still receive the message via standard deserialization.
-  if (is_buffer_aware_) {
+  //   - Route transient-local publishers through the base publisher below as
+  //     transient-local is not supported by buffer backends.
+  if (is_buffer_aware_ &&
+    entity_->topic_info()->qos_.durability != RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
+  {
     size_t total_matched = 0;
     if (graph_cache_) {
       graph_cache_->publisher_count_matched_subscriptions(

--- a/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_publisher_data.cpp
@@ -92,17 +92,22 @@ std::shared_ptr<PublisherData> PublisherData::make(
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(type_support->data);
   auto message_type_support = std::make_unique<MessageTypeSupport>(callbacks);
 
-  bool has_buffer_fields = callbacks->has_buffer_fields;
+  const bool has_buffer_fields = callbacks->has_buffer_fields;
+  // Buffer backends do not support transient-local durability. Those publishers
+  // use only the base Zenoh publisher, which provides the required history cache.
+  const bool use_buffer_endpoints = has_buffer_fields &&
+    adapted_qos_profile.durability != RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 
   RMW_ZENOH_ROSIDL_BUFFER_LOG_DEBUG_NAMED("rmw_zenoh_cpp",
     "[PublisherData::make] Creating publisher for topic '%s', "
-    "type name '%s', has_buffer_fields: '%d'",
-    topic_name.c_str(), message_type_support->get_name(), has_buffer_fields);
+    "type name '%s', has_buffer_fields: '%d', use_buffer_endpoints: '%d'",
+    topic_name.c_str(), message_type_support->get_name(), has_buffer_fields,
+    use_buffer_endpoints);
 
-  // Get installed backends metadata if message type has Buffer fields
+  // Get installed backends metadata if buffer endpoints are enabled.
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   std::unordered_map<std::string, std::string> backend_metadata;
-  if (has_buffer_fields) {
+  if (use_buffer_endpoints) {
     auto * backend_ctx = context_impl->buffer_backend_context();
     if (backend_ctx) {
       backend_metadata = rosidl_buffer_backend_registry::get_all_backend_metadata(
@@ -143,7 +148,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
       message_type_support->get_name(),
       type_hash_c_str,
       adapted_qos_profile,
-      has_buffer_fields ? std::make_optional(backend_metadata) : std::nullopt}
+      use_buffer_endpoints ? std::make_optional(backend_metadata) : std::nullopt}
   );
   if (entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
@@ -175,7 +180,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
       std::move(token),
       type_support->data,
       std::move(message_type_support),
-      has_buffer_fields,
+      use_buffer_endpoints,
       backend_metadata
     });
 
@@ -190,7 +195,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
   pub_data->base_endpoint_ = base_endpoint.get();
   pub_data->endpoints_[base_key] = std::move(base_endpoint);
 
-  if (has_buffer_fields) {
+  if (use_buffer_endpoints) {
     pub_data->local_endpoint_info_ =
       build_endpoint_info_from_entity(*pub_data->entity_, RMW_ENDPOINT_PUBLISHER);
 
@@ -218,7 +223,7 @@ std::shared_ptr<PublisherData> PublisherData::make(
   }
 
   // Register discovery callback for Buffer-aware publishers
-  if (has_buffer_fields) {
+  if (use_buffer_endpoints) {
     pub_data->graph_cache_ = context_impl->graph_cache();
     if (pub_data->graph_cache_ != nullptr) {
       std::weak_ptr<PublisherData> weak_pub_data = pub_data;
@@ -492,11 +497,7 @@ rmw_ret_t PublisherData::publish(
   //     channels entirely and fall through to the standard base-key publish.
   //     Buffer-aware subscribers also have a base-key subscription so they
   //     will still receive the message via standard deserialization.
-  //   - Route transient-local publishers through the base publisher below as
-  //     transient-local is not supported by buffer backends.
-  if (is_buffer_aware_ &&
-    entity_->topic_info()->qos_.durability != RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL)
-  {
+  if (is_buffer_aware_) {
     size_t total_matched = 0;
     if (graph_cache_) {
       graph_cache_->publisher_count_matched_subscriptions(

--- a/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_subscription_data.cpp
@@ -96,20 +96,23 @@ std::shared_ptr<SubscriptionData> SubscriptionData::make(
   auto callbacks = static_cast<const message_type_support_callbacks_t *>(type_support->data);
   auto message_type_support = std::make_unique<MessageTypeSupport>(callbacks);
 
-  // CREATION-TIME DECISION: Check if message type has Buffer fields
-  bool has_buffer_fields = callbacks->has_buffer_fields;
-  bool is_buffer_aware = has_buffer_fields;
+  const bool has_buffer_fields = callbacks->has_buffer_fields;
+  // A transient-local subscription can only receive history through its base
+  // advanced subscriber, so its custom buffer endpoints would never provide it.
+  const bool use_buffer_endpoints = has_buffer_fields &&
+    adapted_qos_profile.durability != RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
 
   RMW_ZENOH_LOG_DEBUG_NAMED(
     "rmw_zenoh_cpp",
-    "[SubscriptionData::make] Topic: %s, has_buffer_fields: %d, is_buffer_aware: %d",
-    topic_name.c_str(), has_buffer_fields, is_buffer_aware);
+    "[SubscriptionData::make] Topic: %s, has_buffer_fields: %d, "
+    "use_buffer_endpoints: %d",
+    topic_name.c_str(), has_buffer_fields, use_buffer_endpoints);
 
   // Query and filter installed backends based on acceptable_buffer_backends option
   rmw_context_impl_t * context_impl = static_cast<rmw_context_impl_t *>(node->context->impl);
   std::optional<std::unordered_map<std::string, std::string>> backend_types = std::nullopt;
   std::vector<std::string> my_backend_types;
-  if (is_buffer_aware) {
+  if (use_buffer_endpoints) {
     auto * backend_ctx = context_impl->buffer_backend_context();
     std::vector<std::string> all_installed;
     std::unordered_map<std::string, std::string> all_backend_metadata;
@@ -245,7 +248,7 @@ std::shared_ptr<SubscriptionData> SubscriptionData::make(
       message_type_support->get_name(),
       type_hash_c_str,
       adapted_qos_profile,
-      backend_types}  // Include backends only if Buffer message type
+      backend_types}  // Include backends only when buffer endpoints are enabled.
   );
   if (entity == nullptr) {
     RMW_ZENOH_LOG_ERROR_NAMED(
@@ -264,11 +267,11 @@ std::shared_ptr<SubscriptionData> SubscriptionData::make(
       type_support->data,
       std::move(message_type_support),
       sub_options,
-      is_buffer_aware,
+      use_buffer_endpoints,
       my_backend_types
     });
 
-  if (is_buffer_aware) {
+  if (use_buffer_endpoints) {
     sub_data->local_endpoint_info_ =
       build_endpoint_info_from_entity(*sub_data->entity_, RMW_ENDPOINT_SUBSCRIPTION);
 
@@ -285,7 +288,7 @@ std::shared_ptr<SubscriptionData> SubscriptionData::make(
   }
 
   // Register discovery callback for Buffer-aware subscribers
-  if (is_buffer_aware && graph_cache != nullptr) {
+  if (use_buffer_endpoints && graph_cache != nullptr) {
     std::weak_ptr<SubscriptionData> weak_sub_data = sub_data;
     if (!is_cpu_only_backend_types(my_backend_types)) {
       graph_cache->register_publisher_discovery_callback(


### PR DESCRIPTION
## Description

  Transient-local publishers with buffer-aware message types could skip publishing when no subscribers had yet been discovered. As a result, no sample was stored in the Zenoh transient-local cache, and late-joining subscribers did not receive the message.

  This change routes transient-local buffer-aware publishers through the base Zenoh publisher. This preserves transient-local history and late-join recovery while leaving the optimized buffer-aware path
  unchanged for volatile publishers.

  Related to https://github.com/ros2/rmw_fastrtps/issues/897

  ### Is this user-facing behavior change?
Yes. Transient-local buffer-aware publishers now explicitly go through the CPU-based path even when buffer backends are enabled.

  ### Did you use Generative AI?
No.
