### PR TITLE
return early with a zero-initialized array.

### DIFF
--- a/rmw_zenoh_cpp/src/detail/graph_cache.cpp
+++ b/rmw_zenoh_cpp/src/detail/graph_cache.cpp
@@ -1291,6 +1291,12 @@ rmw_ret_t GraphCache::get_entities_info_by_service(
     }
   }
 
+  // Exit early if there are no endpoints of the requested type,
+  // leaving the output array zero initialized.
+  if (endpoints.empty()) {
+    return RMW_RET_OK;
+  }
+
   rmw_ret_t ret = rmw_service_endpoint_info_array_init_with_size(
     endpoints_info, endpoints.size(), allocator);
   if (RMW_RET_OK != ret) {
@@ -1298,7 +1304,7 @@ rmw_ret_t GraphCache::get_entities_info_by_service(
   }
 
   memcpy(
-    endpoints_info->info_array, &endpoints[0],
+    endpoints_info->info_array, endpoints.data(),
     sizeof(rmw_service_endpoint_info_t) * endpoints.size());
 
   return RMW_RET_OK;


### PR DESCRIPTION
## Description

Part of https://github.com/ros2/ros2cli/issues/1210, but this is just a latent bug fix.
now returns early with a zero-initialized (empty) array when the service is known but has no endpoints of the requested type, instead of calling &endpoints[0] on an empty std::vector (assertion abort)

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
