### PR TITLE
When SHM enabled, enable transport_optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ The default value of `RMW_ZENOH_BUFFER_POOL_MAX_SIZE_BYTES` is 8 MiB; this value
 
 Zenoh-backed shared memory provides implicit SHM optimization for any messages passing through (not only those created with loaned messages API).
 
+> [!WARNING]
+> In case of high CPU usage, such as at launch time in systems with a large number of Nodes, a known issue may cause some
+> service calls or TRANSIENT_LOCAL historical publications to be silently dropped.  
+> See issue [#978](https://github.com/ros2/rmw_zenoh/issues/978).
+
 ### Configuration
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -253,24 +253,28 @@ Zenoh-backed shared memory provides implicit SHM optimization for any messages p
 > [!NOTE]
 > To have Zenoh SHM working, it should be enabled on all Zenoh sessions exchanging messages. It can also be enabled on the router for lower latency between the Nodes and the router, in case a message shall be routed outside.
 
-To enable Zenoh SHM, the `transport/shared_memory/enabled` Zenoh config key should be set to `true` in the Zenoh configuration files for all the sessions and the router.
-You can also override this config with the `ZENOH_CONFIG_OVERRIDE` environment variable:
+To enable Zenoh SHM, the `transport/shared_memory/enabled` and `transport/shared_memory/transport_optimization/enabled` Zenoh config keys should be set to `true` in the Zenoh configuration files for all the sessions and the router.
+Note that if only `transport/shared_memory/enabled` is set to `true`, `rmw_zenoh_cpp` will overwrite the `transport/shared_memory/transport_optimization/enabled` configuration to force it to `true`. An INFO level log is displayed in such case.
+
+You can also enable SHM simply by setting the `ZENOH_CONFIG_OVERRIDE` environment variable as such:
 
 ```bash
 export ZENOH_CONFIG_OVERRIDE='transport/shared_memory/enabled=true'
 ```
 
-Each Node allocates at startup a SHM segment where it will write the data to send. The size of this segment can be configured via the `transport/shared_memory/transport_optimization/pool_size` Zenoh config key. The default value is 50331648 bytes (48 MiB).
+Each Node uses a SHM segment into which it writes the data to send. The size of this segment can be configured via the `transport/shared_memory/transport_optimization/pool_size` Zenoh config key. The default value is 50331648 bytes (48 MiB).
 You can also override this value with the `ZENOH_SHM_ALLOC_SIZE` environment variable. This environment variable exists for backward compatibility reason. It will be deprecated and eventually removed in a future release.
 
-Each Node will write the data that exceed a configurable threashold in this segment. Smaller data will be send via the network, as there is no benefit to use SHM for small data. This threshold can be configured via the `transport/shared_memory/transport_optimization/message_size_threshold` Zenoh config key. The default value is 512 bytes. Note that depending on your hardware characteristics (CPU, memory) it could be counter-productive for the latency of small messages to lower this threshold.
+When this segment is allocated depends on the `transport/shared_memory/mode` config key. With the default `lazy` mode, the segment is allocated the first time the Node actually sends or receives data through SHM: this minimizes startup time but adds a one-time latency on the first SHM message. With `init`, the segment is allocated when the session opens, removing that first-message latency at the cost of a slower session startup.
+
+Each Node will write the data that exceed a configurable threshold in this segment. Smaller data will be sent via the network, as there is no benefit to use SHM for small data. This threshold can be configured via the `transport/shared_memory/transport_optimization/message_size_threshold` Zenoh config key. The default value is 512 bytes. This value must be a power of two. Note that depending on your hardware characteristics (CPU, memory) it could be counter-productive for the latency of small messages to lower this threshold.
 You can also override this value with the `ZENOH_SHM_MESSAGE_SIZE_THRESHOLD` environment variable. This environment variable exists for backward compatibility reason. It will be deprecated and eventually removed in a future release.
 
 Zenoh automatically handles garbage collection of data in shared memory once all recipients have read it. It also defragments the shared memory segment to maintain space for large payloads. If writing to shared memory fails (for instance if a recipient didn't yet read the previous data) Zenoh seamlessly falls back to network transport. This ensures publishers are never blocked and data is always delivered.
 
 > [!IMPORTANT]
-> Make sure that the host's shared memory space (`/dev/shm` on Linux) is large enough for all the processes you run to allocate the configured amount of memory. As `rmw_zenoh` is pre-commiting the memory on startup, a process will fail if the shared memory is not available.
-> The default value of 48 MiB has been chosen to support out-of-the-box very large payloads such as a 4K video image (~24 MiB per image, 2 images in-flight). If this size mulitiplied by the number of ROS processes in your system exceeds the host's shared memory space, you need to reduce this size for the processes that do not need to send such large payloads. On the other hand, if a Node is sending payloads larger than 24 MiB in one or several topics, you need to consider increasing its shared memory size configuration.
+> Make sure that the host's shared memory space (`/dev/shm` on Linux) is large enough for all the processes you run to allocate the configured amount of memory. The SHM segment is allocated up to `pool_size` bytes: with the default `lazy` mode this allocation happens the first time the Node sends or receives an SHM message, so an undersized `/dev/shm` surfaces on the first large message rather than at process startup (with `mode: init` it surfaces when the session opens). If the segment cannot be allocated, Zenoh falls back to the regular network transport (as described above).
+> The default value of 48 MiB has been chosen to support out-of-the-box very large payloads such as a 4K video image (~24 MiB per image, 2 images in-flight). If this size multiplied by the number of ROS processes in your system exceeds the host's shared memory space, you need to reduce this size for the processes that do not need to send such large payloads. On the other hand, if a Node is sending payloads larger than 24 MiB in one or several topics, you need to consider increasing its shared memory size configuration.
 
 > [!TIP]
 > Shared memory can be used between Docker containers. Several solutions for this:

--- a/docs/design.md
+++ b/docs/design.md
@@ -518,6 +518,54 @@ When a new service server is created, a liveliness token of type `SS` is sent ou
 * Query::reply
 * Query::ReplyOptions
 
+## Shared memory optimization
+
+Zenoh can carry message payloads through a POSIX shared memory (SHM) segment between two processes that share the same memory domain (typically on the same host).
+This avoids serializing the payload onto a socket: the payload is written once into a shared segment and the peer reads it in place.
+SHM is only available when the underlying `zenoh-c` library is built with the `shared-memory` feature, and it is **opt-in** in configuration — it is
+disabled by default (`transport/shared_memory/enabled: false`).
+
+Zenoh exposes two mechanisms to use SHM:
+
+1. **Explicit SHM API**: the application code allocates a buffer from an SHM provider and hands it to `put()`.
+   The buffer is transported zero-copy, at any size.
+2. **Transport optimization** (`transport/shared_memory/transport_optimization`): the Zenoh runtime owns an internal SHM segment.
+   When a regular (non-SHM) payload exceeds a configurable threshold and the destination is SHM-capable, the transport transparently copies
+   it into that segment and only sends a small descriptor. This is fully implicit but costs one userspace `memcpy` on the publisher side.
+
+`rmw_zenoh_cpp` combines both: it lets `transport_optimization` create and own the SHM segment, but on the publisher path
+it drives that segment **explicitly** instead of relying on the implicit copy.
+When SHM is enabled, for each message whose estimated serialized size reaches the threshold, the publisher:
+
+1. obtains the transport's SHM provider via `session.obtain_shm_provider()`
+   (the *same* pool that `transport_optimization` created — no second segment is allocated),
+2. allocates a mutable SHM buffer (`ZShmMut`) from it,
+3. serializes the CDR message **directly into that buffer**, and
+4. publishes it zero-copy (`zenoh::Bytes(std::move(shm_buf))`).
+
+Because the message is serialized straight into shared memory, the extra `memcpy` that the implicit transport-optimization path would perform is eliminated.
+If the provider is not yet available (SHM internals are initialized lazily) or the allocation fails (pool exhausted), the publisher silently falls back
+to the regular serialization buffer and the normal network path — publishing is never blocked.
+Payloads below the threshold are also sent over the network, since SHM brings no benefit for small messages.
+
+This is why the two configuration keys are coupled in the scope of `rmw_zenoh_cpp`.
+`transport/shared_memory/enabled` announces SHM support to peers but does not by itself create any segment;
+the segment is created by `transport/shared_memory/transport_optimization/enabled`.
+Since `rmw_zenoh_cpp` reuses that very segment, it force-enables `transport_optimization` whenever SHM is enabled (logging an INFO
+message if it had to overwrite the config).
+
+Relevant Zenoh configuration keys:
+
+* `transport/shared_memory/enabled`: enable SHM support (must be `true` for any SHM usage; defaults to `false`).
+* `transport/shared_memory/transport_optimization/enabled`: create the SHM segment reused by
+  `rmw_zenoh_cpp` (force-enabled when SHM is enabled).
+* `transport/shared_memory/transport_optimization/pool_size`: size of that segment in bytes.
+* `transport/shared_memory/transport_optimization/message_size_threshold`: minimum serialized
+  payload size (bytes) that triggers SHM allocation.
+
+See the [Zenoh Shared Memory](../README.md#zenoh-shared-memory) section of the README for end-user configuration guidance
+(environment-variable overrides, `/dev/shm` sizing, and Docker setup).
+
 ## Buffer-aware pub/sub
 
 `rmw_zenoh_cpp` supports messages containing [`rosidl::Buffer<T>`](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399) fields, which describe data that may live outside of host memory (e.g. on a GPU).

--- a/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
+++ b/rmw_zenoh_cpp/src/detail/rmw_context_impl_s.cpp
@@ -46,6 +46,12 @@
 // TODO(clalancette): Make this configurable, or get it from the configuration
 #define SHM_BUFFER_SIZE_MB 10
 
+// Zenoh config key for SHM transport optimization enabled
+// When SHM is enabled, rmw_zenoh will use the same SHM segment
+// than created for transport_optimization. Hence, it must be enabled.
+static const char * CONFIG_KEY_SHM_TRANSPORT_OPTIM_ENABLED =
+  "transport/shared_memory/transport_optimization/enabled";
+
 // Zenoh config key for SHM pool size
 static const char * CONFIG_KEY_SHM_POOL_SIZE =
   "transport/shared_memory/transport_optimization/pool_size";
@@ -301,6 +307,7 @@ private:
     std::size_t shm_pool_size = 0;
     std::size_t msgsize_threshold = 512;
     {
+      // Check is transport/shared_memory/enabled == true in Zenoh config
       std::string shm_enabled_val = config.value().get(Z_CONFIG_SHARED_MEMORY_KEY, &result);
       if (result == Z_OK) {
         shm_enabled = shm_enabled_val == "true" ? true : false;
@@ -309,6 +316,31 @@ private:
           "rmw_zenoh_cpp",
           "Not able to get %s from the config file",
           Z_CONFIG_SHARED_MEMORY_KEY);
+      }
+
+      // Check if transport/shared_memory/transport_optimization/enabled == true in Zenoh config
+      // When SHM is enabled, rmw_zenoh will use the same SHM segment than created for
+      // transport_optimization. Hence, we force transport_optimization to be enabled.
+      if (shm_enabled) {
+        std::string transport_optim_enabled_val =
+          config.value().get(CONFIG_KEY_SHM_TRANSPORT_OPTIM_ENABLED, &result);
+        if (result == Z_OK) {
+          if (transport_optim_enabled_val != "true") {
+            RMW_ZENOH_LOG_INFO_NAMED(
+                "rmw_zenoh_cpp",
+                "SHM is enabled but transport_optimization is not while required "
+                "- overwritting '%s: true' in config.",
+                CONFIG_KEY_SHM_TRANSPORT_OPTIM_ENABLED);
+            config.value().insert_json5(
+              CONFIG_KEY_SHM_TRANSPORT_OPTIM_ENABLED,
+              "true");
+          }
+        } else {
+          RMW_ZENOH_LOG_ERROR_NAMED(
+            "rmw_zenoh_cpp",
+            "Not able to get %s from the config file",
+            CONFIG_KEY_SHM_TRANSPORT_OPTIM_ENABLED);
+        }
       }
 
       std::string shm_size_threshold_val = config.value().get(


### PR DESCRIPTION
## Description

Since [#857](https://github.com/ros2/rmw_zenoh/pull/857) rmw_zenoh is using the same SHM segment than created by Zenoh when `transport_optimization` is enabled. While it checks if `transport/shared_memory/enabled==true` it doesn't check nor enforce that `transport/shared_memory/transport_optimization==true`.
If SHM is enabled and `transport_optimization` is disabled, SHM is not used and rmw_zenoh fallbacks to network transport.

This PR overwrites the config with `transport/shared_memory/transport_optimization: true` if set to `false` and SHM is enabled. An INFO log is also displayed.

### Is this user-facing behavior change?

No
### Did you use Generative AI?

No
