### PR TITLE
Replace hash_gid std::stringstream with FNV-1a

### DIFF
--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.cpp
@@ -19,7 +19,6 @@
 #include <limits>
 #include <optional>
 #include <random>
-#include <sstream>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -858,13 +857,16 @@ std::string demangle_name(const std::string & input)
 }  // namespace liveliness
 
 ///=============================================================================
-size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid)
+size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> & gid)
 {
-  std::stringstream hash_str;
-  hash_str << std::hex;
-  for (const auto & g : gid) {
-    hash_str << static_cast<int>(g);
+  // FNV-1a over the raw GID bytes: allocation-free
+  // Ref: https://datatracker.ietf.org/doc/html/draft-eastlake-fnv-17.html
+  uint64_t hash = 0xcbf29ce484222325ULL;  // FNV-1a 64-bit offset basis
+  const uint64_t kFnvPrime = 0x00000100000001b3ULL;
+  for (const uint8_t byte : gid) {
+    hash ^= byte;
+    hash *= kFnvPrime;
   }
-  return std::hash<std::string>{}(hash_str.str());
+  return static_cast<std::size_t>(hash);
 }
 }  // namespace rmw_zenoh_cpp

--- a/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
+++ b/rmw_zenoh_cpp/src/detail/liveliness_utils.hpp
@@ -240,7 +240,7 @@ std::optional<rmw_qos_profile_t> keyexpr_to_qos(const std::string & keyexpr);
 }  // namespace liveliness
 
 ///=============================================================================
-size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> gid);
+size_t hash_gid(const std::array<uint8_t, RMW_GID_STORAGE_SIZE> & gid);
 }  // namespace rmw_zenoh_cpp
 
 ///=============================================================================


### PR DESCRIPTION
## Description

`hash_gid` hashes a 16-byte GID (`RMW_GID_STORAGE_SIZE`) into a `size_t` map
key. It runs on rmw_zenoh's hot paths:

- `SubscriptionData::add_new_message` — every message received
- `ServiceData::take_request` / `send_response` — every request / response

The current implementation builds a `std::stringstream` (with `std::hex`) on
every call, heap-allocating a stream buffer and a `std::string` per
invocation. This replaces it with FNV-1a over the raw GID bytes, which is
allocation-free.

The returned value is used only as an in-memory map key (`Entity::gid_hash_`
and the `gid_hash()`-keyed event/discovery maps); it is never serialized into
attachments, key expressions, or config. The algorithm is therefore not part
of any wire or persisted format, so swapping it is externally invisible.

## Related

Narrower alternative to #422 ("Replace `hash_gid` with FNV-1a"), which has
been open but not marked ready-for-review since Jan 2025. #422 additionally
rekeys the two message-path maps from `size_t` to a `Gid` alias and
specializes `std::hash<std::array<uint8_t, RMW_GID_STORAGE_SIZE>>`. This change
keeps the maps keyed on `size_t` (minimal blast radius) and avoids that
specialization, which is formally disallowed by `[namespace.std]` — a standard
template may only be specialized when it depends on a program-defined type, and
`std::array<uint8_t, N>` does not.

## Performance

Per-call heap allocations on the message/request hot paths are eliminated
(`2 -> 0`, deterministic and machine-independent). 

## How was it tested

- Builds clean on Rolling against the released Zenoh vendor
  (`ros-rolling-zenoh-cpp-vendor`).
- `colcon test --packages-select test_rmw_zenoh_cpp`: 15/15 pass, including
  cpplint and uncrustify.
- End-to-end over the patched `rmw_zenoh`: a `ros2` talker/listener (message
  received) and an `add_two_ints` service call (`sum=42`), exercising both
  changed call sites through `hash_gid`.

## Checklist

- [x] DCO sign-off
- [x] Code style (cpplint + uncrustify pass)
- [x] Self-reviewed
